### PR TITLE
fix(traceloop-sdk): flushing in notebooks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,6 +15,7 @@ body:
         - "Bedrock Instrumentation"
         - "Chromadb Instrumentation"
         - "Cohere Instrumentation"
+        - "Haystack Instrumentation"
         - "OpenAI Instrumentation"
         - "Pinecone Instrumentation"
         - "VertexAI Instrumentation"
@@ -61,13 +62,13 @@ body:
       description: "What did actually happen? Add screenshots, if applicable."
       placeholder: "It actually ..."
   - type: input
-    id: node-version
+    id: python-version
     validations:
       required: false
     attributes:
-      label: "🤖 Node Version"
+      label: "🤖 Python Version"
       description: >
-        What Node version are you using?
+        What Python version are you using?
   - type: textarea
     id: additional-context
     validations:

--- a/packages/traceloop-sdk/pyproject.toml
+++ b/packages/traceloop-sdk/pyproject.toml
@@ -11,7 +11,7 @@ addopts = "--cov --cov-report html:'../../coverage/packages/traceloop-sdk/html' 
 
 [tool.poetry]
 name = "traceloop-sdk"
-version = "0.0.42"
+version = "0.0.43"
 description = "Traceloop Software Development Kit (SDK) for Python"
 authors = [
   "Gal Kleinman <gal@traceloop.com>",

--- a/packages/traceloop-sdk/traceloop/sdk/utils/__init__.py
+++ b/packages/traceloop-sdk/traceloop/sdk/utils/__init__.py
@@ -12,3 +12,15 @@ def camel_to_snake(s):
         return s.lower()
 
     return cameltosnake(s[0].lower() + s[1:])
+
+
+def is_notebook():
+    try:
+        from IPython import get_ipython
+
+        ip = get_ipython()
+        if ip is None:
+            return False
+        return True
+    except Exception:
+        return False


### PR DESCRIPTION
Fixes #65 

The solution is to switch to a non-batching processor for notebooks, which will "flush" every trace directly to the exporter. We should probably do something like this for local runs as well at some point.