### PR TITLE
fix: `resource_attributes` always being None

### DIFF
--- a/packages/traceloop-sdk/tests/conftest.py
+++ b/packages/traceloop-sdk/tests/conftest.py
@@ -9,7 +9,12 @@ pytest_plugins = []
 @pytest.fixture(scope="session")
 def exporter():
     exporter = InMemorySpanExporter()
-    Traceloop.init(app_name="test", disable_batch=True, exporter=exporter)
+    Traceloop.init(
+        app_name="test",
+        resource_attributes={"something": "yes"},
+        disable_batch=True,
+        exporter=exporter,
+    )
     return exporter
 
 

--- a/packages/traceloop-sdk/tests/test_sdk_initialization.py
+++ b/packages/traceloop-sdk/tests/test_sdk_initialization.py
@@ -1,0 +1,19 @@
+import pytest
+from openai import OpenAI
+
+
+@pytest.fixture
+def openai_client():
+    return OpenAI()
+
+
+def test_resource_attributes(exporter, openai_client):
+    openai_client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "Tell me a joke about opentelemetry"}],
+    )
+
+    spans = exporter.get_finished_spans()
+    open_ai_span = spans[0]
+    assert open_ai_span.resource.attributes["something"] == "yes"
+    assert open_ai_span.resource.attributes["service.name"] == "test"

--- a/packages/traceloop-sdk/traceloop/sdk/__init__.py
+++ b/packages/traceloop-sdk/traceloop/sdk/__init__.py
@@ -145,7 +145,7 @@ class Traceloop:
 
         print(Fore.RESET)
 
-        resource_attributes = resource_attributes.update({SERVICE_NAME: app_name})
+        resource_attributes.update({SERVICE_NAME: app_name})
         TracerWrapper.set_static_params(
             resource_attributes, enable_content_tracing, api_endpoint, headers
         )


### PR DESCRIPTION
This pull request fixes a problem where `app_name` and `resource_attributes` passed to the `Traceloop.init()` method were not being added to the Trace attributes because `resource_attributes` was always `None`.

The `update()` method of the `dict` is an in-place method with a return value of `None`, so there is no need to reassign the original variable.