### PR TITLE
feat: support both new and legacy llama_index versions

### DIFF
--- a/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/custom_llm_instrumentor.py
+++ b/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/custom_llm_instrumentor.py
@@ -11,9 +11,12 @@ from opentelemetry.instrumentation.llamaindex.utils import (
     _with_tracer_wrapper, start_as_current_span_async, should_send_prompts
 )
 
-from llama_index.llms.custom import CustomLLM
-
-MODULE_NAME = "llama_index.llms"
+try:
+    from llama_index.core.llms import CustomLLM
+    MODULE_NAME = "llama_index.core.llms"
+except ModuleNotFoundError:
+    from llama_index.legacy.llms.custom import CustomLLM
+    MODULE_NAME = "llama_index.legacy.llms"
 
 
 class CustomLLMInstrumentor:


### PR DESCRIPTION
Update import logic to dynamically support both new (`llama_index.core.llms`) and legacy (`llama_index.legacy.llms.custom`) versions of the `llama_index` package. This change ensures compatibility across different versions of the package by using conditional imports and adjusting `MODULE_NAME` dynamically based on the available version. This improvement enhances the flexibility and maintainability of the codebase when working with the evolving `llama_index` library.