### PR TITLE
fix(watsonx): exclude http request, adding span for model initialization

### DIFF
--- a/packages/opentelemetry-instrumentation-watsonx/opentelemetry/instrumentation/watsonx/__init__.py
+++ b/packages/opentelemetry-instrumentation-watsonx/opentelemetry/instrumentation/watsonx/__init__.py
@@ -23,26 +23,38 @@ _instruments = ("ibm_watson_machine_learning >= 1.0.347",)
 
 WRAPPED_METHODS_WATSON_ML_VERSION_1 = [
     {
-        "module": "ibm_watson_machine_learning.foundation_models",
-        "object": "Model",
+        "module": "ibm_watson_machine_learning.foundation_models.inference",
+        "object": "ModelInference",
+        "method": "__init__",
+        "span_name": "watsonx.model_init",
+    },
+    {
+        "module": "ibm_watson_machine_learning.foundation_models.inference",
+        "object": "ModelInference",
         "method": "generate",
         "span_name": "watsonx.generate",
     },
     {
-        "module": "ibm_watson_machine_learning.foundation_models",
-        "object": "Model",
+        "module": "ibm_watson_machine_learning.foundation_models.inference",
+        "object": "ModelInference",
         "method": "generate_text_stream",
         "span_name": "watsonx.generate_text_stream",
     },
     {
-        "module": "ibm_watson_machine_learning.foundation_models",
-        "object": "Model",
+        "module": "ibm_watson_machine_learning.foundation_models.inference",
+        "object": "ModelInference",
         "method": "get_details",
         "span_name": "watsonx.get_details",
     },
 ]
 
 WRAPPED_METHODS_WATSON_AI_VERSION_1 = [
+    {
+        "module": "ibm_watsonx_ai.foundation_models",
+        "object": "ModelInference",
+        "method": "__init__",
+        "span_name": "watsonx.model_init",
+    },
     {
         "module": "ibm_watsonx_ai.foundation_models",
         "object": "ModelInference",
@@ -256,11 +268,13 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
     )
 
     _set_api_attributes(span)
-    _set_input_attributes(span, instance, kwargs)
+    if "model_init" not in name:
+        _set_input_attributes(span, instance, kwargs)
 
     response = wrapped(*args, **kwargs)
 
-    _set_response_attributes(span, response)
+    if "model_init" not in name:
+        _set_response_attributes(span, response)
 
     span.end()
     return response

--- a/packages/opentelemetry-instrumentation-watsonx/tests/cassettes/test_generate/test_generate.yaml
+++ b/packages/opentelemetry-instrumentation-watsonx/tests/cassettes/test_generate/test_generate.yaml
@@ -18,11 +18,11 @@ interactions:
     uri: https://iam.cloud.ibm.com/oidc/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoibm9uZSIsInN1YiI6Im5vb25lQGlibS5jb20iLCJpYW1faWQiOiJJQk1pZC0xMDAwMDBQVzAwIiwiYWNjb3VudCI6eyJic3MiOiJhYmMxMjMifSwiaWF0IjoxNzA4NTkzNzM3LCJleHAiOjIwMjM5NTM3Mzd9.iYXuVHrO3J-InoMRvwM2ENUlUWsiLzut_9wo97McECU","refresh_token":"eyJhbGciOiJydCJ9.eyJpYW1faWQiOiJJQk1pZC0xMTAwMDBTRFMxIiwiYWNjb3VudF9pZCI6ImQ3NTY2MTc1NzVmZjYzMWYzMmFiYzkzNzI1ZDIxYjdjIn0.f8p9rFmcUEa1cBeBteWI1upnP5l4f9dysuKKFn6tO83FLZBDvIi3UubtxVdgmGh7VfB2ZgmgpIE0ZyPYVmJef3JfAGEJYkvC87xPzrCVyBSlnoRrQUW6oBfJVQYZEsFtd9lVJlN0-HCCLNR0aFnEPKBNfBM1YA2enkq5aSL6NjTp_JJR4SadpchKNmeUj9HIzoAGU8sRSHr5rHS156hUwc5W-ecZflS_KFLEmE-Zv1zNZ6jTuRF4bLmLKIPK-9pODu7wFEMi5GX3KbTMbTs1Vgg9i6bPso_8FWS2Wv29cjMrIEe2fMZBAGP4d6BYicITrExJoOblWwRyIq-ahPSYWwJ-dJI6lbYXefBtK2Om-7a8NtuQ8a1qRlL5NHmD8Ks42GxuRzRiGv8lV_OdySgBSm6cLLgPquLTU8ERreKnZeV6b9e8P-UiYEaWgz1HvvWAproZFu9e0zCWwPQU9dR2ZpecEssX9t0O9Eo1lnittvv_LpXR5yOISMKuYfT8ipawyOxNtGE7fuh05sBrzsmj0Uw1auy36uojzMKO4oSqkDI6mTFn_z0VBOIY1Zh3ly0g9VQEQlFwt-sWK2MshFD2Hjez7-AWT_ydorFL2497TGBn5JpiNcdExlZYXuRGXl4HY5c-sWbdVNb14Yhft1h6Fof0YhASnwH0k3JCQfo_ec_P6NMZeypK-fZLe5ma4H3Z1lo3Jji7J0zMwbPpWjcUheUlgLqJb2Pyr3k9GQxu9bErnHShIUdxM-4x3JNnKe-PwwyxMW9VR_cglwnYfWqflXBtttnmYGgSKc5KEZMuY6-Jj6HhwDF4RUlc6mFK_v_1KVtQUyULZbGX6ctZKBxSysgl6p7mbDbzdLwLNZisulITyCt-LQzWsLL4WWOQxRQF-UykGR63_6temZ--EJi9wRmm9fJ5qdfCHdsI9v1pA3LOuNFsPfJE63TeYCdG2kf7JF_2ElLo_IaQTDQ5TunU4GV-LLoc6b-7dhFdI8fQfGvO4ZPWLFQZ9lCfDUiGmbkEWUhgy59lWtKVuqpVB2qJWKYwUg-P41m_zFlIETj4sz0ELNtR32H6F9I5A6F5vvX2P30wAvW2PBsSnWE474fb5EUI_ejweOyEz-067Qis4JIUsguIbmI8-JDuMDobSbyFA2_ujkUBjcbRqrQs4bY86hbu-w_-Wqf1qbKYxpV8Mb3SQLM0PaCAhCjbq9o5gcfhUhP-9HWgCla04BVTPqrf7nJc270bcyKb_HDar3SiTYgxDe-WFCXP2uX_QS1EziqkP-uPvnlaz1yjC8Uxw76MzuTbmPxllcH8RuOnAz2ai-9nXKM2RiN06D62bE0mc-NB1k1Q8ZYr6YsW-rAPIJ6BC8NL","token_type":"Bearer","expires_in":3600,"expiration":1708597208,"refresh_token_expiration":1708852808,"scope":"ibm
+      string: '{"access_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoibm9uZSIsInN1YiI6Im5vb25lQGlibS5jb20iLCJpYW1faWQiOiJJQk1pZC0xMDAwMDBQVzAwIiwiYWNjb3VudCI6eyJic3MiOiJhYmMxMjMifSwiaWF0IjoxNzA4NTkzNzM3LCJleHAiOjIwMjM5NTM3Mzd9.iYXuVHrO3J-InoMRvwM2ENUlUWsiLzut_9wo97McECU","refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoibm9uZSIsInN1YiI6Im5vb25lQGlibS5jb20iLCJpYW1faWQiOiJJQk1pZC0xMDAwMDBQVzAwIiwiYWNjb3VudCI6eyJic3MiOiJhYmMxMjMifSwiaWF0IjoxNzA4NTkzNzM3LCJleHAiOjIwMjM5NTM3Mzd9.iYXuVHrO3J-InoMRvwM2ENUlUWsiLzut_9wo97McECU","token_type":"Bearer","expires_in":3600,"expiration":1709111794,"refresh_token_expiration":1709367394,"scope":"ibm
         openid"}'
     headers:
       Akamai-GRN:
-      - 0.0fd82317.1708593609.d7826af2
+      - 0.0fd82317.1709108196.b5fbccf
       Cache-Control:
       - no-cache, no-store, must-revalidate
       Connection:
@@ -32,7 +32,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 09:20:11 GMT
+      - Wed, 28 Feb 2024 08:16:37 GMT
       Expires:
       - '0'
       Pragma:
@@ -44,15 +44,15 @@ interactions:
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transaction-id:
-      - aGg2cjQ-41496baa032e4acea087cc873ff16117
+      - ZHBjZ2M-c2592ca78083479e94803cd07318ec29
       x-content-type-options:
       - nosniff
       x-correlation-id:
-      - aGg2cjQ-41496baa032e4acea087cc873ff16117
+      - ZHBjZ2M-c2592ca78083479e94803cd07318ec29
       x-proxy-upstream-service-time:
-      - '1854'
+      - '1205'
       x-request-id:
-      - b3b8c9c1-8870-4858-ae58-87eeee555126
+      - a79f9f4b-5f99-4a19-9bd1-ccc8ecb7bd60
     status:
       code: 200
       message: OK
@@ -85,7 +85,7 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 859626dbe823aaac-SJC
+      - 85c73a003963ce34-SJC
       Cache-Control:
       - no-cache, no-store, must-revalidate
       Connection:
@@ -93,14 +93,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 09:20:12 GMT
+      - Wed, 28 Feb 2024 08:16:38 GMT
       Pragma:
       - no-cache
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=L.jvKqMtMng97Pz4E5xddajxdSS9.YZlxfgEZdbpoCw-1708593612-1.0-AXnflGd9ZAAv5TOURqGcb44U9Eu0qWVI3Px/goxvuNMx5NnogX8BPuVX0StrBu6DtDvr6pKJFrS8mW0wVfxAq9U=;
-        path=/; expires=Thu, 22-Feb-24 09:50:12 GMT; domain=.dataplatform.cloud.ibm.com;
+      - __cf_bm=ioJl_IzM_YLbooD3qENB_DKDdnjSU6U9fnOBrKws4jo-1709108198-1.0-AfGVnH0oz69bNt6lEnqn+HAvLBQZvrDgeFTxEbJ7G9xgzuQjTFyrQcmISneESpukeJvGvmuaTzewN6gy8Ju6kbM=;
+        path=/; expires=Wed, 28-Feb-24 08:46:38 GMT; domain=.dataplatform.cloud.ibm.com;
         HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
@@ -116,7 +116,7 @@ interactions:
       user-agent:
       - python-requests/2.31.0
       x-global-transaction-id:
-      - NWI3NWM3YmYtYmMzYy00MWQ5LWI2NmEtMTA3MmMxYmM0NjJk
+      - NWM5YzA1NGEtNmZjOC00MmZlLTg2YTctOTU1NjVkYWE5MzMz
     status:
       code: 200
       message: OK
@@ -143,30 +143,30 @@ interactions:
     uri: https://api.dataplatform.cloud.ibm.com/v2/projects/c1234567-2222-2222-3333-444444444444
   response:
     body:
-      string: '{"metadata":{"guid":"c1234567-2222-2222-3333-444444444444","url":"/v2/projects/c1234567-2222-2222-3333-444444444444","created_at":"2023-10-31T04:35:59.982Z","updated_at":"2023-10-31T04:36:01.922Z"},"entity":{"name":"test''s
+      string: '{"metadata":{"guid":"c1234567-2222-2222-3333-444444444444","url":"/v2/projects/c1234567-2222-2222-3333-444444444444","created_at":"2023-10-31T04:35:59.982Z","updated_at":"2023-10-31T04:36:01.922Z"},"entity":{"name":"none''s
         sandbox","generator":"wx-registration-sandbox","description":"A project to
-        try things in","storage":{"type":"bmcos_object_storage","guid":"029fd735-8b39-4f63-ae3e-184cd09e2ef4","properties":{"bucket_name":"testsandbox-donotdelete-pr-fxebzqo5e7buoh","bucket_region":"us-south","credentials":{"admin":{"api_key":"BRvKLoH1Zv3rgdMKRGzicrU0e_DHTGqnHPeGcsV042Ku","service_id":"iam-ServiceId-77aa8112-1ccf-41c7-a23b-7ae9a7383d18","access_key_id":"75156d5c76b84b5aa8c52c5e30fa7b94","secret_access_key":"89972f9d00ad41d50373dc063b2abfb235304253e6d3a85a"},"editor":{"api_key":"meK4GP8qxQz8DwHsyjZ1Tfb0XFd_HPMq3tKGS2tHHov5","service_id":"iam-ServiceId-748a6634-45fa-4ac5-98c9-92ef2225589c","access_key_id":"5bdbe8241b454c5294551fa2ca81b7ed","secret_access_key":"2c9c16cf1fda09fc767abeeb3fb83916e85a9de8a0beca17","resource_key_crn":"crn:v1:bluemix:public:cloud-object-storage:global:a/d756617575ff631f32abc93725d21b7c:029fd735-8b39-4f63-ae3e-184cd09e2ef4:resource-key:5bdbe824-1b45-4c52-9455-1fa2ca81b7ed"},"viewer":{"api_key":"2l3HLVvUxDeCxIvgoujd_eBITVgonzT2fEvk7J-uDdX6","service_id":"iam-ServiceId-1d3fb404-1c75-40e6-a58c-dfaf78876a7b","access_key_id":"51e93fea39fa4b4fb9cf3aa14f98edf9","secret_access_key":"6948048c49422b36a14013ead56e6a42ff4cf77fd50263a2","resource_key_crn":"crn:v1:bluemix:public:cloud-object-storage:global:a/d756617575ff631f32abc93725d21b7c:029fd735-8b39-4f63-ae3e-184cd09e2ef4:resource-key:51e93fea-39fa-4b4f-b9cf-3aa14f98edf9"}},"endpoint_url":"https://s3.us-south.cloud-object-storage.appdomain.cloud"}},"compute":[{"type":"machine_learning","guid":"fd36e2e7-6b2b-480d-90a7-62b0e78389d3","name":"WatsonMachineLearning","crn":"crn:v1:bluemix:public:pm-20:us-south:a/d756617575ff631f32abc93725d21b7c:fd36e2e7-6b2b-480d-90a7-62b0e78389d3::","credentials":{}}],"scope":{"bss_account_id":"d756617575ff631f32abc93725d21b7c","saml_instance_name":"IBM
+        try things in","storage":{"type":"bmcos_object_storage","guid":"029fd735-8b39-4f63-ae3e-184cd09e2ef4","properties":{"bucket_name":"nonessandbox-donotdelete-pr-fxebzqo5e7buoh","bucket_region":"us-south","credentials":{"admin":{"api_key":"test_api_key","service_id":"iam-ServiceId-testid","access_key_id":"75156d5c76b84b5a","secret_access_key":"testkey"},"editor":{"api_key":"testkey","service_id":"iam-ServiceId-testid","access_key_id":"testid","secret_access_key":"testkey","resource_key_crn":"crn:v1:bluemix:public:cloud-object-storage:global:a/noned756666666ff631f32abc93725d21b7c:029fd735-8b39-4f63-ae3e-184cd09e2ef4:resource-key:5bdbe824-1b45-4c52-9455-1fa2ca81b7ed"},"viewer":{"api_key":"testkey","service_id":"iam-ServiceId-testid","access_key_id":"testid","secret_access_key":"testkey","resource_key_crn":"crn:v1:bluemix:public:cloud-object-storage:global:a/noned756666666ff631f32abc93725d21b7c:029fd735-8b39-4f63-ae3e-184cd09e2ef4:resource-key:testkey"}},"endpoint_url":"https://s3.us-south.cloud-object-storage.appdomain.cloud"}},"compute":[{"type":"machine_learning","guid":"fd36e2e7-6b2b-480d-6666-62b0e78389d3","name":"WatsonMachineLearning","crn":"crn:v1:bluemix:public:pm-20:us-south:a/noned756666666ff631f32abc93725d21b7c:fd36e2e7-6b2b-480d-6666-62b0e78389d3::","credentials":{}}],"scope":{"bss_account_id":"noned756666666ff631f32abc93725d21b7c","saml_instance_name":"IBM
         w3id","enforce_members":true},"type":"wx","public":false,"creator":"none@ibm.com","creator_iam_id":"IBMid-110000SDS1","catalog":{"public":false,"guid":"3f5851db-d08d-4d56-98e6-7fa55a2e1fb8"}}}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 859626e9ee41984e-SJC
+      - 85c73a07d9c57ac8-SJC
       Connection:
       - keep-alive
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 22 Feb 2024 09:20:14 GMT
+      - Wed, 28 Feb 2024 08:16:39 GMT
       ETag:
       - W/"8ed-Yz2q1+Gj6GwUDN+TPCQljQxzpEk"
       Server:
       - cloudflare
       Server-Timing:
-      - intid;desc=e424aa0ceb8e5c66
+      - intid;desc=ec3bf58df53507df
       Set-Cookie:
-      - __cf_bm=U58d9NWb8b1S5tc8afiPdxbo.y2PfFORjPyfFajKE9Y-1708593614-1.0-ASmGOngYWiUAqOpUtfhIQG1UolPLkh8/sZyNdMyCi8gx5K4zGDkd9AZtyH/ddcqmZ047Zyu+fft6quvVFH77wxQ=;
-        path=/; expires=Thu, 22-Feb-24 09:50:14 GMT; domain=.dataplatform.cloud.ibm.com;
+      - __cf_bm=bo2J1WjOJ9O5zJccaWKbvMJ4giGZWNV6Ivk4.JhbVyo-1709108199-1.0-AfVqXmh0qIQLFdFDGO4qXnOX4m9SqUOSc5bqsm9KVAxgWz2Dp0ceAdVb+KpNjwMeTTbRj4eMBQtaXsKd8i4KtNc=;
+        path=/; expires=Wed, 28-Feb-24 08:46:39 GMT; domain=.dataplatform.cloud.ibm.com;
         HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
@@ -197,27 +197,27 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://us-south.ml.cloud.ibm.com/ml/v4/instances/fd36e2e7-6b2b-480d-90a7-62b0e78389d3?version=2024-02-07&project_id=c1234567-2222-2222-3333-444444444444
+    uri: https://us-south.ml.cloud.ibm.com/ml/v4/instances/fd36e2e7-6b2b-480d-6666-62b0e78389d3?version=2024-02-15&project_id=c1234567-2222-2222-3333-444444444444
   response:
     body:
-      string: "{\n  \"entity\": {\n    \"account\": {\n      \"id\": \"d756617575ff631f32abc93725d21b7c\"\n
+      string: "{\n  \"entity\": {\n    \"account\": {\n      \"id\": \"noned756666666ff631f32abc93725d21b7c\"\n
         \   },\n    \"consumption\": {\n      \"capacity_unit_hours\": {\n        \"current\":
         0.0,\n        \"limit\": 20.0\n      },\n      \"deployment_job_count\": {\n
         \       \"limit\": 100\n      },\n      \"do_job_count\": {\n        \"limit\":
         2\n      },\n      \"gpu_count\": {\n        \"limit\": 0\n      },\n      \"token_count\":
-        {\n        \"current\": 3238,\n        \"limit\": 50000\n      }\n    },\n
-        \   \"crn\": \"crn:v1:bluemix:public:pm-20:us-south:a/d756617575ff631f32abc93725d21b7c:fd36e2e7-6b2b-480d-90a7-62b0e78389d3::\",\n
+        {\n        \"current\": 3681,\n        \"limit\": 50000\n      }\n    },\n
+        \   \"crn\": \"crn:v1:bluemix:public:pm-20:us-south:a/noned756666666ff631f32abc93725d21b7c:fd36e2e7-6b2b-480d-6666-62b0e78389d3::\",\n
         \   \"plan\": {\n      \"id\": \"3f6acf43-ede8-413a-ac69-f8af3bb0cbfe\",\n
         \     \"name\": \"lite\",\n      \"version\": 2\n    },\n    \"resource_group_id\":
         \"70727d441e174dd0afad5e36a73b986e\",\n    \"service_endpoints\": \"public\",\n
         \   \"status\": \"Active\"\n  },\n  \"metadata\": {\n    \"created_at\": \"2023-08-04T05:44:54.592Z\",\n
         \   \"modified_at\": \"2023-08-04T05:44:54.592Z\",\n    \"tags\": [],\n    \"id\":
-        \"fd36e2e7-6b2b-480d-90a7-62b0e78389d3\"\n  }\n}"
+        \"fd36e2e7-6b2b-480d-6666-62b0e78389d3\"\n  }\n}"
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 859626f2a95496d5-SJC
+      - 85c73a1c5b929e64-SJC
       Cache-Control:
       - no-cache, no-store, must-revalidate
       Connection:
@@ -225,7 +225,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 09:20:16 GMT
+      - Wed, 28 Feb 2024 08:16:43 GMT
       Pragma:
       - no-cache
       Server:
@@ -242,10 +242,10 @@ interactions:
       content-length:
       - '985'
       server-timing:
-      - intid;desc=ff5f93e0947e46ca
+      - intid;desc=be494343e981de9d
       x-global-transaction-id:
-      - fda95b503eb4ad5fb712b4616f37a511
-      - fda95b503eb4ad5fb712b4616f37a511
+      - 990f470cb4b46743a962d46d5101407d
+      - 990f470cb4b46743a962d46d5101407d
     status:
       code: 200
       message: OK
@@ -312,7 +312,7 @@ interactions:
         before computation (in FP16). As a result, the GPU memory, and the data transferring
         between GPU memory and GPU compute engine, compared to the original FP16 model,
         is greatly reduced. The major quantization parameters used in the process
-        are listed below.","tier":"class_2","number_params":"7b","min_shot_size":1,"task_ids":["summarization","retrieval_augmented_generation","classification","generation","code","extraction"],"tasks":[{"id":"summarization","ratings":{"quality":4}},{"id":"retrieval_augmented_generation","ratings":{"quality":3}},{"id":"classification","ratings":{"quality":4}},{"id":"generation"},{"id":"code"},{"id":"extraction","ratings":{"quality":4}}],"model_limits":{"max_sequence_length":32768},"limits":{"lite":{"call_time":"5m0s","max_output_tokens":4096},"v2-professional":{"call_time":"5m0s","max_output_tokens":4096},"v2-standard":{"call_time":"5m0s","max_output_tokens":4096}},"lifecycle":[{"id":"available","start_date":"2024-02-15"}]},{"model_id":"ibm/granite-13b-chat-v1","label":"granite-13b-chat-v1","provider":"IBM","source":"IBM","short_description":"The
+        are listed below.","tier":"class_2","number_params":"46.7b","min_shot_size":1,"task_ids":["summarization","retrieval_augmented_generation","classification","generation","code","extraction"],"tasks":[{"id":"summarization","ratings":{"quality":4}},{"id":"retrieval_augmented_generation","ratings":{"quality":3}},{"id":"classification","ratings":{"quality":4}},{"id":"generation"},{"id":"code"},{"id":"extraction","ratings":{"quality":4}}],"model_limits":{"max_sequence_length":32768},"limits":{"lite":{"call_time":"5m0s","max_output_tokens":4096},"v2-professional":{"call_time":"5m0s","max_output_tokens":4096},"v2-standard":{"call_time":"5m0s","max_output_tokens":4096}},"lifecycle":[{"id":"available","start_date":"2024-02-15"}]},{"model_id":"ibm/granite-13b-chat-v1","label":"granite-13b-chat-v1","provider":"IBM","source":"IBM","short_description":"The
         Granite model series is a family of IBM-trained, dense decoder-only models,
         which are particularly well-suited for generative tasks.","long_description":"Granite
         models are designed to be used for a wide range of generative and non-generative
@@ -355,7 +355,7 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 859626fadc44968e-SJC
+      - 85c73a2a79461668-SJC
       Cache-Control:
       - no-cache, no-store, must-revalidate
       Connection:
@@ -366,7 +366,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 09:20:17 GMT
+      - Wed, 28 Feb 2024 08:16:45 GMT
       Pragma:
       - no-cache
       Referrer-Policy:
@@ -383,14 +383,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Global-Transaction-Id:
-      - ff2c0dd34be8bc75be0658354ea46fce
+      - bef0ac1810a98c6399406dc136c2fef0
       X-Xss-Protection:
       - 1; mode=block
       - 1; mode=block
       content-length:
-      - '20286'
+      - '20289'
       server-timing:
-      - intid;desc=6122dac9ab3d34f5
+      - intid;desc=ff57ec3fe0b540f9
     status:
       code: 200
       message: OK
@@ -457,7 +457,7 @@ interactions:
         before computation (in FP16). As a result, the GPU memory, and the data transferring
         between GPU memory and GPU compute engine, compared to the original FP16 model,
         is greatly reduced. The major quantization parameters used in the process
-        are listed below.","tier":"class_2","number_params":"7b","min_shot_size":1,"task_ids":["summarization","retrieval_augmented_generation","classification","generation","code","extraction"],"tasks":[{"id":"summarization","ratings":{"quality":4}},{"id":"retrieval_augmented_generation","ratings":{"quality":3}},{"id":"classification","ratings":{"quality":4}},{"id":"generation"},{"id":"code"},{"id":"extraction","ratings":{"quality":4}}],"model_limits":{"max_sequence_length":32768},"limits":{"lite":{"call_time":"5m0s","max_output_tokens":4096},"v2-professional":{"call_time":"5m0s","max_output_tokens":4096},"v2-standard":{"call_time":"5m0s","max_output_tokens":4096}},"lifecycle":[{"id":"available","start_date":"2024-02-15"}]},{"model_id":"ibm/granite-13b-chat-v1","label":"granite-13b-chat-v1","provider":"IBM","source":"IBM","short_description":"The
+        are listed below.","tier":"class_2","number_params":"46.7b","min_shot_size":1,"task_ids":["summarization","retrieval_augmented_generation","classification","generation","code","extraction"],"tasks":[{"id":"summarization","ratings":{"quality":4}},{"id":"retrieval_augmented_generation","ratings":{"quality":3}},{"id":"classification","ratings":{"quality":4}},{"id":"generation"},{"id":"code"},{"id":"extraction","ratings":{"quality":4}}],"model_limits":{"max_sequence_length":32768},"limits":{"lite":{"call_time":"5m0s","max_output_tokens":4096},"v2-professional":{"call_time":"5m0s","max_output_tokens":4096},"v2-standard":{"call_time":"5m0s","max_output_tokens":4096}},"lifecycle":[{"id":"available","start_date":"2024-02-15"}]},{"model_id":"ibm/granite-13b-chat-v1","label":"granite-13b-chat-v1","provider":"IBM","source":"IBM","short_description":"The
         Granite model series is a family of IBM-trained, dense decoder-only models,
         which are particularly well-suited for generative tasks.","long_description":"Granite
         models are designed to be used for a wide range of generative and non-generative
@@ -500,7 +500,7 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 8596270a8c76cf97-SJC
+      - 85c73a389e85fa56-SJC
       Cache-Control:
       - no-cache, no-store, must-revalidate
       Connection:
@@ -511,7 +511,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 09:20:19 GMT
+      - Wed, 28 Feb 2024 08:16:47 GMT
       Pragma:
       - no-cache
       Referrer-Policy:
@@ -528,14 +528,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Global-Transaction-Id:
-      - ad1b8e09c092d27d6e519e09d363000c
+      - cb98519edba603df35fd8b9921794022
       X-Xss-Protection:
       - 1; mode=block
       - 1; mode=block
       content-length:
-      - '20286'
+      - '20289'
       server-timing:
-      - intid;desc=63815d23d02236a6
+      - intid;desc=e09c0407f6aa933c
     status:
       code: 200
       message: OK
@@ -554,7 +554,7 @@ interactions:
       Content-Type:
       - application/json
       ML-Instance-ID:
-      - fd36e2e7-6b2b-480d-90a7-62b0e78389d3
+      - fd36e2e7-6b2b-480d-6666-62b0e78389d3
       User-Agent:
       - python-requests/2.31.0
       X-WML-User-Client:
@@ -562,10 +562,10 @@ interactions:
       x-wml-internal-switch-to-new-v4:
       - 'true'
     method: POST
-    uri: https://us-south.ml.cloud.ibm.com/ml/v1-beta/generation/text?version=2024-02-07
+    uri: https://us-south.ml.cloud.ibm.com/ml/v1-beta/generation/text?version=2024-02-15
   response:
     body:
-      string: '{"model_id":"google/flan-ul2","created_at":"2024-02-22T09:20:21.911Z","results":[{"generated_text":"2","generated_token_count":2,"input_token_count":7,"stop_reason":"eos_token"}],"system":{"warnings":[{"message":"This
+      string: '{"model_id":"google/flan-ul2","created_at":"2024-02-28T08:16:49.731Z","results":[{"generated_text":"2","generated_token_count":2,"input_token_count":7,"stop_reason":"eos_token"}],"system":{"warnings":[{"message":"This
         model is a Non-IBM Product governed by a third-party license that may impose
         use restrictions and other obligations. By using this model you agree to its
         terms as identified in the following URL.","id":"disclaimer_warning","more_info":"https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx"}]}}'
@@ -573,7 +573,7 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 859627153ca1d019-SJC
+      - 85c73a423fcb67d6-SJC
       Cache-Control:
       - no-cache, no-store, must-revalidate
       Connection:
@@ -584,7 +584,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 09:20:21 GMT
+      - Wed, 28 Feb 2024 08:16:49 GMT
       Pragma:
       - no-cache
       Referrer-Policy:
@@ -601,14 +601,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Global-Transaction-Id:
-      - dfffec31a2eff49c92e229ac6c87ded1
+      - 67c6a477949369a8f1ce45c32d41a20c
       X-Xss-Protection:
       - 1; mode=block
       - 1; mode=block
       content-length:
       - '549'
       server-timing:
-      - intid;desc=82b56e387558591a
+      - intid;desc=ff6e1dc964662202
     status:
       code: 200
       message: OK

--- a/packages/opentelemetry-instrumentation-watsonx/tests/conftest.py
+++ b/packages/opentelemetry-instrumentation-watsonx/tests/conftest.py
@@ -20,7 +20,14 @@ def exporter():
     provider.add_span_processor(processor)
     trace.set_tracer_provider(provider)
 
-    WatsonxInstrumentor().instrument()
+    try:
+        # Check for required package in the env, skip test if could not found
+        from ibm_watsonx_ai.foundation_models import ModelInference
+        # to avoid lint error
+        del ModelInference
+        WatsonxInstrumentor().instrument()
+    except ImportError:
+        print("no supported ibm_watsonx_ai package found, Watsonx instrumentation skipped.")
 
     return exporter
 
@@ -28,6 +35,26 @@ def exporter():
 @pytest.fixture(autouse=True)
 def clear_exporter(exporter):
     exporter.clear()
+
+
+@pytest.fixture
+def watson_ai_model():
+    try:
+        # Check for required package in the env, skip test if could not found
+        from ibm_watsonx_ai.foundation_models import ModelInference
+    except ImportError:
+        print("no supported ibm_watsonx_ai package found, model creating skipped.")
+        return None
+
+    watsonx_ai_model = ModelInference(
+        model_id="google/flan-ul2",
+        project_id="c1234567-2222-2222-3333-444444444444",
+        credentials={
+                "apikey": "test_api_key",
+                "url": "https://us-south.ml.cloud.ibm.com"
+                },
+    )
+    return watsonx_ai_model
 
 
 @pytest.fixture(scope="module")

--- a/packages/opentelemetry-instrumentation-watsonx/tests/test_generate.py
+++ b/packages/opentelemetry-instrumentation-watsonx/tests/test_generate.py
@@ -1,17 +1,17 @@
 import pytest
+import sys
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="ibm-watson-ai requires python3.10")
 @pytest.mark.vcr
-def disabled_test_generate(exporter, watson_ai_model):
+def test_generate(exporter, watson_ai_model):
+    if watson_ai_model is None:
+        print("test_generate test skipped.")
+        return
     watson_ai_model.generate(prompt="What is 1 + 1?")
     spans = exporter.get_finished_spans()
-    watsonx_ai_span = spans[0]
+    watsonx_ai_span = spans[1]
     assert watsonx_ai_span.attributes["llm.prompts.user"] == "What is 1 + 1?"
     assert watsonx_ai_span.attributes["llm.vendor"] == "Watsonx"
     assert watsonx_ai_span.attributes.get("llm.completions.content")
     assert watsonx_ai_span.attributes.get("llm.usage.total_tokens")
-
-
-# Remove once the above test is re-enabled
-def test_noop():
-    pass

--- a/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
+++ b/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
@@ -33,6 +33,9 @@ from typing import Dict, Optional, Set
 
 TRACER_NAME = "traceloop.tracer"
 EXCLUDED_URLS = """
+    iam.cloud.ibm.com,
+    dataplatform.cloud.ibm.com,
+    ml.cloud.ibm.com,
     api.openai.com,
     openai.azure.com,
     api.anthropic.com,


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [X] I have added tests that cover my changes.
- [X] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [X] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.  
  
issue related discussions in https://github.com/traceloop/openllmetry/issues/542
- exclude watsonx api URLs in `EXCLUDED_URLS` in traceloop-sdk tracing
- add a watson model_init span for model initialization response time.
- update test to enable local test, but will skip in CI for now, due to issue https://github.com/traceloop/openllmetry/issues/529 