### PR TITLE
fix(watsonx instrumentation): Init OTEL_EXPORTER_OTLP_INSECURE before import watsonx models

### DIFF
--- a/packages/sample-app/sample_app/watsonx_generate.py
+++ b/packages/sample-app/sample_app/watsonx_generate.py
@@ -6,9 +6,9 @@ from traceloop.sdk import Traceloop
 from dotenv import load_dotenv
 load_dotenv()
 
-Traceloop.init()
-
 os.environ['OTEL_EXPORTER_OTLP_INSECURE'] = 'True'
+
+Traceloop.init(app_name="watsonx_example")
 
 
 def get_credentials(api_key):


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [X] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

We have to set OTEL_EXPORTER_OTLP_INSECURE before importing watsonx packages, otherwise, some error will be pop out like following:

```
Transient error StatusCode.DEADLINE_EXCEEDED encountered while exporting traces to c13610v1.fyre.ibm.com:4317, retrying in 1s.
```