### PR TITLE
fix(watsonx instrumentation) fix span attribute prompt index and token usage for multiple responses.

### DIFF
--- a/packages/opentelemetry-instrumentation-watsonx/tests/test_generate.py
+++ b/packages/opentelemetry-instrumentation-watsonx/tests/test_generate.py
@@ -11,9 +11,9 @@ def test_generate(exporter, watson_ai_model):
     watson_ai_model.generate(prompt="What is 1 + 1?")
     spans = exporter.get_finished_spans()
     watsonx_ai_span = spans[1]
-    assert watsonx_ai_span.attributes["llm.prompts.user"] == "What is 1 + 1?"
+    assert watsonx_ai_span.attributes["llm.prompts.0.user"] == "What is 1 + 1?"
     assert watsonx_ai_span.attributes["llm.vendor"] == "Watsonx"
-    assert watsonx_ai_span.attributes.get("llm.completions.content")
+    assert watsonx_ai_span.attributes.get("llm.completions.0.content")
     assert watsonx_ai_span.attributes.get("llm.usage.total_tokens")
 
 
@@ -29,7 +29,7 @@ def test_generate_text_stream(exporter, watson_ai_model):
         generated_text += chunk
     spans = exporter.get_finished_spans()
     watsonx_ai_span = spans[1]
-    assert watsonx_ai_span.attributes["llm.prompts.user"] == "Write an epigram about the sun"
+    assert watsonx_ai_span.attributes["llm.prompts.0.user"] == "Write an epigram about the sun"
     assert watsonx_ai_span.attributes["llm.vendor"] == "Watsonx"
-    assert watsonx_ai_span.attributes["llm.completions.content"] == generated_text
+    assert watsonx_ai_span.attributes["llm.completions.0.content"] == generated_text
     assert watsonx_ai_span.attributes.get("llm.usage.total_tokens")


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [X] I have added tests that cover my changes.
- [X] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [X] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

Fixing the missing Watson generate span in Traceloop UI.

- fixed span attribute prompt index missing.
- fixed token usage for multiple responses.
- test script passed in local test environment.
  
Screenshot of E2E test:  
![image](https://github.com/traceloop/openllmetry/assets/58250676/2e2a8c57-1488-4a00-af71-07a6c5ceb022)


