### PR TITLE
fix(traceloop-sdk): custom span processor's on_start is honored

### DIFF
--- a/packages/traceloop-sdk/tests/conftest.py
+++ b/packages/traceloop-sdk/tests/conftest.py
@@ -3,6 +3,8 @@
 import os
 import pytest
 from traceloop.sdk import Traceloop
+from traceloop.sdk.tracing.tracing import TracerWrapper
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 pytest_plugins = []
@@ -33,3 +35,27 @@ def environment():
 @pytest.fixture(scope="module")
 def vcr_config():
     return {"filter_headers": ["authorization"]}
+
+
+@pytest.fixture
+def exporter_with_custom_span_processor():
+    # Clear singleton if existed
+    if hasattr(TracerWrapper, "instance"):
+        _trace_wrapper_instance = TracerWrapper.instance
+        del TracerWrapper.instance
+
+    class CustomSpanProcessor(SimpleSpanProcessor):
+        def on_start(self, span, parent_context=None):
+            span.set_attribute("custom_span", "yes")
+
+    exporter = InMemorySpanExporter()
+    Traceloop.init(
+        exporter=exporter,
+        processor=CustomSpanProcessor(exporter),
+    )
+
+    yield exporter
+
+    # Restore singleton if any
+    if _trace_wrapper_instance:
+        TracerWrapper.instance = _trace_wrapper_instance

--- a/packages/traceloop-sdk/tests/test_sdk_initialization.py
+++ b/packages/traceloop-sdk/tests/test_sdk_initialization.py
@@ -18,3 +18,15 @@ def test_resource_attributes(exporter, openai_client):
     open_ai_span = spans[0]
     assert open_ai_span.resource.attributes["something"] == "yes"
     assert open_ai_span.resource.attributes["service.name"] == "test"
+
+
+@pytest.mark.vcr("test_resource_attributes.yaml")
+def test_custom_span_processor(exporter_with_custom_span_processor, openai_client):
+    openai_client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "Tell me a joke about opentelemetry"}],
+    )
+
+    spans = exporter_with_custom_span_processor.get_finished_spans()
+    open_ai_span = spans[0]
+    assert open_ai_span.attributes["custom_span"] == "yes"

--- a/packages/traceloop-sdk/tests/test_sdk_initialization.py
+++ b/packages/traceloop-sdk/tests/test_sdk_initialization.py
@@ -1,5 +1,6 @@
 import pytest
 from openai import OpenAI
+from traceloop.sdk.decorators import workflow
 
 
 @pytest.fixture
@@ -20,13 +21,13 @@ def test_resource_attributes(exporter, openai_client):
     assert open_ai_span.resource.attributes["service.name"] == "test"
 
 
-@pytest.mark.vcr("test_resource_attributes.yaml")
 def test_custom_span_processor(exporter_with_custom_span_processor, openai_client):
-    openai_client.chat.completions.create(
-        model="gpt-3.5-turbo",
-        messages=[{"role": "user", "content": "Tell me a joke about opentelemetry"}],
-    )
+    @workflow()
+    def run_workflow():
+        pass
+
+    run_workflow()
 
     spans = exporter_with_custom_span_processor.get_finished_spans()
-    open_ai_span = spans[0]
-    assert open_ai_span.attributes["custom_span"] == "yes"
+    workflow_span = spans[0]
+    assert workflow_span.attributes["custom_span"] == "yes"

--- a/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
+++ b/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
@@ -74,6 +74,7 @@ class TracerWrapper(object):
             if processor:
                 Telemetry().capture("tracer:init", {"processor": "custom"})
                 obj.__spans_processor: SpanProcessor = processor
+                obj.__spans_processor_original_on_start = processor.on_start
             else:
                 if exporter:
                     Telemetry().capture(
@@ -107,6 +108,7 @@ class TracerWrapper(object):
                     obj.__spans_processor: SpanProcessor = BatchSpanProcessor(
                         obj.__spans_exporter
                     )
+                obj.__spans_processor_original_on_start = None
 
             obj.__spans_processor.on_start = obj._span_processor_on_start
             obj.__tracer_provider.add_span_processor(obj.__spans_processor)
@@ -312,6 +314,10 @@ class TracerWrapper(object):
                     span.set_attribute(
                         f"traceloop.prompt.template_variables.{key}", value
                     )
+
+        # Call original on_start method if it exists in custom processor
+        if self.__spans_processor_original_on_start:
+            self.__spans_processor_original_on_start(span, parent_context)
 
     @staticmethod
     def set_static_params(


### PR DESCRIPTION
Fixes #686.

If a custom span processor is specified, its `on_start` will be called after setting LLM-specific attributes.

E.g. (https://www.traceloop.com/docs/openllmetry/integrations/sentry):
```python
Traceloop.init(processor=SentrySpanProcessor(), propagator=SentryPropagator())
```

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [x] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
