### PR TITLE
fix(traceloop-sdk): default value for metrics endpoint

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/__init__.py
+++ b/packages/traceloop-sdk/traceloop/sdk/__init__.py
@@ -174,7 +174,7 @@ class Traceloop:
         if metrics_exporter:
             print(Fore.GREEN + "Traceloop exporting metrics to a custom exporter")
 
-        metrics_endpoint = os.getenv("TRACELOOP_METRICS_ENDPOINT")
+        metrics_endpoint = os.getenv("TRACELOOP_METRICS_ENDPOINT") or api_endpoint
         metrics_headers = os.getenv("TRACELOOP_METRICS_HEADERS") or metrics_headers
 
         MetricsWrapper.set_static_params(

--- a/packages/traceloop-sdk/traceloop/sdk/metrics/metrics.py
+++ b/packages/traceloop-sdk/traceloop/sdk/metrics/metrics.py
@@ -49,9 +49,9 @@ class MetricsWrapper(object):
 
 def init_metrics_exporter(endpoint: str, headers: Dict[str, str]) -> MetricExporter:
     if "http" in endpoint.lower() or "https" in endpoint.lower():
-        return HTTPExporter(endpoint=endpoint)
+        return HTTPExporter(endpoint=f"{endpoint}/v1/metrics", headers=headers)
     else:
-        return GRPCExporter(endpoint=endpoint)
+        return GRPCExporter(endpoint=endpoint, headers=headers)
 
 
 def init_metrics_provider(exporter: MetricExporter,


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

Relates to #251

Current
- The metrics endpoint does not have default value, it must be set by env var for now.
- It also have to be set with otlp metrics path `/v1/metrics`, unlikely to the [traces endpoint](https://github.com/traceloop/openllmetry/tree/main/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py#L386).
    ```python
    def init_spans_exporter(api_endpoint: str, headers: Dict[str, str]) -> SpanExporter:
        if "http" in api_endpoint.lower() or "https" in api_endpoint.lower():
            return HTTPExporter(endpoint=f"{api_endpoint}/v1/traces", headers=headers)
        else:
            return GRPCExporter(endpoint=f"{api_endpoint}", headers=headers)
    ```

Proposed
- Use `api_endpoint` as default of the metrics endpoint.
- Append metrics path, just like the traces endpoint.

I didn't open new issue for this just because it's a very small and simple change. Please feel free to comment. 

- [x] I have added tests that cover my changes.
- [x] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
