### PR TITLE
fix(sdk): reset the color of messages in the custom metrics exporter

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/__init__.py
+++ b/packages/traceloop-sdk/traceloop/sdk/__init__.py
@@ -172,7 +172,11 @@ class Traceloop:
             return
 
         if metrics_exporter:
-            print(Fore.GREEN + "Traceloop exporting metrics to a custom exporter")
+            print(
+                Fore.GREEN
+                + "Traceloop exporting metrics to a custom exporter"
+                + Fore.RESET
+            )
 
         metrics_endpoint = os.getenv("TRACELOOP_METRICS_ENDPOINT") or api_endpoint
         metrics_headers = os.getenv("TRACELOOP_METRICS_HEADERS") or metrics_headers


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

This pull request adds a reset code that was missing from the messages output when using the custom metric exporter. Prior to making this change, there was no reset output after this message, so all subsequent messages were green.

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
