### PR TITLE
fix(instrumentation): Correct the module declaration to match package filepath name

### DIFF
--- a/packages/opentelemetry-instrumentation-watsonx/opentelemetry/instrumentation/watsonx/__init__.py
+++ b/packages/opentelemetry-instrumentation-watsonx/opentelemetry/instrumentation/watsonx/__init__.py
@@ -30,25 +30,25 @@ _instruments = ("ibm-watson-machine-learning >= 1.0.333",)
 
 WRAPPED_METHODS_WATSON_ML_VERSION_1 = [
     {
-        "module": "ibm-watson-machine-learning.foundation_models.inference",
+        "module": "ibm_watson_machine_learning.foundation_models.inference",
         "object": "ModelInference",
         "method": "__init__",
         "span_name": "watsonx.model_init",
     },
     {
-        "module": "ibm-watson-machine-learning.foundation_models.inference",
+        "module": "ibm_watson_machine_learning.foundation_models.inference",
         "object": "ModelInference",
         "method": "generate",
         "span_name": "watsonx.generate",
     },
     {
-        "module": "ibm-watson-machine-learning.foundation_models.inference",
+        "module": "ibm_watson_machine_learning.foundation_models.inference",
         "object": "ModelInference",
         "method": "generate_text_stream",
         "span_name": "watsonx.generate_text_stream",
     },
     {
-        "module": "ibm-watson-machine-learning.foundation_models.inference",
+        "module": "ibm_watson_machine_learning.foundation_models.inference",
         "object": "ModelInference",
         "method": "get_details",
         "span_name": "watsonx.get_details",


### PR DESCRIPTION
The name in the module declaration should be matched to the filepath name of the python package.
As you know, the package is displayed as `ibm-watson-machine-learning`, but in site-packages, the filepath name is `ibm_watson_machine_learning`.

```
$ pip list | grep machine
ibm-watson-machine-learning                1.0.347
$ pwd
/usr/local/lib/python3.10/site-packages
$ ls | grep machine
ibm_watson_machine_learning
ibm_watson_machine_learning-1.0.347.dist-info
```

Otherwise, the following error will happen by **resolve_path(module, name)** call:
```
wrap_function_wrapper(
  File "/Users/gyliu/new-trace/lib/python3.11/site-packages/wrapt/patches.py", line 114, in wrap_function_wrapper
    return wrap_object(module, name, FunctionWrapper, (wrapper,))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gyliu/new-trace/lib/python3.11/site-packages/wrapt/patches.py", line 60, in wrap_object
    (parent, attribute, original) = resolve_path(module, name)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gyliu/new-trace/lib/python3.11/site-packages/wrapt/patches.py", line 17, in resolve_path
    __import__(module)
ModuleNotFoundError: No module named 'ibm-watson-machine-learning'
```



Build and test:
```
$ nx run traceloop-sdk:build
......
Building traceloop-sdk (0.17.0)
  - Building sdist
  - Built traceloop_sdk-0.17.0.tar.gz
  - Building wheel
  - Built traceloop_sdk-0.17.0-py3-none-any.whl
  Artifacts generated at packages/traceloop-sdk/dist folder
>  NX   Successfully ran target build for project traceloop-sdk

$ nx run traceloop-sdk:install
......

$ pip3 list | grep traceloop-sdk
traceloop-sdk                              0.17.0
$ pip3 list | grep machine
ibm-watson-machine-learning  1.0.347

$ pwd
/root/github.com/jswang/openllmetry/packages/sample-app/sample_app
$ export IAM_API_KEY="***"
$ export PROJECT_ID="***"
$ export TRACELOOP_API_KEY=***
$ export TRACELOOP_BASE_URL=127.0.0.1:4317
$ export TRACELOOP_METRICS_ENABLED="true"
$ export TRACELOOP_METRICS_ENDPOINT=127.0.0.1:8000
$ export TRACELOOP_HEADERS="api-key=DUMMY_KEY"
$ python3 ./watsonx-langchain.py
Traceloop exporting traces to 127.0.0.1:4317, authenticating with custom headers
'2 '
```






<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [ ] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
