### PR TITLE
feat(openai) Set default value of open-ai model-name to gpt-4

### DIFF
--- a/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/shared/chat_wrappers.py
+++ b/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/shared/chat_wrappers.py
@@ -356,7 +356,8 @@ def _set_streaming_token_metrics(
     # prompt_usage
     if request_kwargs and request_kwargs.get("messages"):
         prompt_content = ""
-        model_name = request_kwargs.get("model") or None
+        # setting the default model_name as gpt-4. As this uses the embedding "cl100k_base" that is used by most of the other model.
+        model_name = request_kwargs.get("model") or "gpt-4"
         for msg in request_kwargs.get("messages"):
             if msg.get("content"):
                 prompt_content += msg.get("content")


### PR DESCRIPTION
Set default value of open-ai model-name to gpt-4 for counting the number of tokens for streaming response.

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [ ] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
