### PR TITLE
fix(openai): add default value of stream as false in token usage metric

### DIFF
--- a/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/shared/chat_wrappers.py
+++ b/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/shared/chat_wrappers.py
@@ -242,6 +242,7 @@ def _set_chat_metrics(
     shared_attributes = {
         "gen_ai.response.model": response_dict.get("model") or None,
         "server.address": _get_openai_base_url(instance),
+        "stream": False,
     }
 
     # token metrics

--- a/packages/opentelemetry-instrumentation-openai/tests/metrics/test_openai_metrics.py
+++ b/packages/opentelemetry-instrumentation-openai/tests/metrics/test_openai_metrics.py
@@ -47,6 +47,7 @@ def test_chat_completion_metrics(metrics_test_context, openai_client):
                             "completion",
                             "prompt",
                         ]
+                        assert data_point.attributes["stream"] = False
                         assert len(data_point.attributes["server.address"]) > 0
                         assert data_point.value > 0
 
@@ -122,6 +123,7 @@ def test_chat_streaming_metrics(metrics_test_context, openai_client):
                                 "completion",
                                 "prompt",
                             ]
+                            assert data_point.attributes["stream"] = True
                             assert len(data_point.attributes["server.address"]) > 0
                             assert data_point.value > 0
 

--- a/packages/opentelemetry-instrumentation-openai/tests/metrics/test_openai_metrics.py
+++ b/packages/opentelemetry-instrumentation-openai/tests/metrics/test_openai_metrics.py
@@ -47,7 +47,7 @@ def test_chat_completion_metrics(metrics_test_context, openai_client):
                             "completion",
                             "prompt",
                         ]
-                        assert data_point.attributes["stream"] = False
+                        assert data_point.attributes["stream"] == False
                         assert len(data_point.attributes["server.address"]) > 0
                         assert data_point.value > 0
 
@@ -123,7 +123,7 @@ def test_chat_streaming_metrics(metrics_test_context, openai_client):
                                 "completion",
                                 "prompt",
                             ]
-                            assert data_point.attributes["stream"] = True
+                            assert data_point.attributes["stream"] == True
                             assert len(data_point.attributes["server.address"]) > 0
                             assert data_point.value > 0
 

--- a/packages/opentelemetry-instrumentation-openai/tests/metrics/test_openai_metrics.py
+++ b/packages/opentelemetry-instrumentation-openai/tests/metrics/test_openai_metrics.py
@@ -47,7 +47,6 @@ def test_chat_completion_metrics(metrics_test_context, openai_client):
                             "completion",
                             "prompt",
                         ]
-                        assert data_point.attributes["stream"] == False
                         assert len(data_point.attributes["server.address"]) > 0
                         assert data_point.value > 0
 
@@ -123,7 +122,6 @@ def test_chat_streaming_metrics(metrics_test_context, openai_client):
                                 "completion",
                                 "prompt",
                             ]
-                            assert data_point.attributes["stream"] == True
                             assert len(data_point.attributes["server.address"]) > 0
                             assert data_point.value > 0
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
