### PR TITLE
fix(sdk): special handling for metrics with custom traces exporter

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/__init__.py
+++ b/packages/traceloop-sdk/traceloop/sdk/__init__.py
@@ -165,21 +165,22 @@ class Traceloop:
             instruments=instruments,
         )
 
-        if metrics_exporter:
-            print(
-                Fore.GREEN
-                + "Traceloop exporting metrics to a custom exporter"
-                + Fore.RESET
-            )
+        if not metrics_exporter and exporter:
+            return
 
         metrics_endpoint = os.getenv("TRACELOOP_METRICS_ENDPOINT") or api_endpoint
         metrics_headers = (
             os.getenv("TRACELOOP_METRICS_HEADERS") or metrics_headers or headers
         )
 
+        if not is_metrics_enabled() or not metrics_exporter and exporter:
+            print(Fore.YELLOW + "Metrics are disabled" + Fore.RESET)
+            return
+
         MetricsWrapper.set_static_params(
             resource_attributes, metrics_endpoint, metrics_headers
         )
+
         Traceloop.__metrics_wrapper = MetricsWrapper(exporter=metrics_exporter)
 
     def set_association_properties(properties: dict) -> None:


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

If a user sets `exporter`, but not `metrics_exporter` than the metrics will try to default to Traceloop which doesn't make sense. So disabling metrics sending for this case.

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
