### PR TITLE
fix(sdk): disable traceloop sync by default

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/__init__.py
+++ b/packages/traceloop-sdk/traceloop/sdk/__init__.py
@@ -49,7 +49,7 @@ class Traceloop:
         metrics_headers: Dict[str, str] = None,
         processor: SpanProcessor = None,
         propagator: TextMapPropagator = None,
-        traceloop_sync_enabled: bool = True,
+        traceloop_sync_enabled: bool = False,
         should_enrich_metrics: bool = True,
         resource_attributes: dict = {},
         instruments: Optional[Set[Instruments]] = None,

--- a/packages/traceloop-sdk/traceloop/sdk/fetcher.py
+++ b/packages/traceloop-sdk/traceloop/sdk/fetcher.py
@@ -99,8 +99,11 @@ def fetch_url(url: str, api_key: str):
 
     if response.status_code != 200:
         if response.status_code == 401 or response.status_code == 403:
-            logging.error("Authorization error: Invalid API key.")
-        raise requests.exceptions.HTTPError(response=response)
+            logging.error("Authorization error: Invalid Traceloop API key.")
+            raise requests.exceptions.HTTPError(response=response)
+        else:
+            logging.error("Request failed: %s", response.status_code)
+            raise requests.exceptions.HTTPError(response=response)
     else:
         return response.json()
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

Fixes #1820 

In order to address #1820, I've disabled traceloop sync by default. The problem is that we have 2 types of users:
1. Users who only use Traceoop for tracing - and for them the fact that an invalid key was provided shouldn't make the app crash (since it's just the observability that's not working)
2. Users who use Traceloop for tracing + prompt mgmt - and for them the fact that an invalid API key was provided means they can't fetch prompts - so app should fail to start (cause it can't operate properly without an API key).

So I think it's best to assume users are of group 1, and need to explicitly state that they are in group 2 by enabling traceloop sync. We'll update the docs to reflect that.

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [ ] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
