### PR TITLE
Feature: Support Prompt Caching

### DIFF
--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
@@ -170,6 +170,8 @@ async def _aset_token_usage(
         response = response.__dict__
 
     prompt_tokens = 0
+    cache_creation_tokens = response.get("cache_creation_input_tokens", 0)
+    cache_read_tokens = response.get("cache_read_input_tokens", 0)
     if hasattr(anthropic, "count_tokens"):
         if request.get("prompt"):
             prompt_tokens = await anthropic.count_tokens(request.get("prompt"))
@@ -230,6 +232,12 @@ async def _aset_token_usage(
         span, SpanAttributes.LLM_USAGE_COMPLETION_TOKENS, completion_tokens
     )
     set_span_attribute(span, SpanAttributes.LLM_USAGE_TOTAL_TOKENS, total_tokens)
+    set_span_attribute(
+        span, "llm.cache_creation_input_tokens", cache_creation_tokens
+    )
+    set_span_attribute(
+        span, "llm.cache_read_input_tokens", cache_read_tokens
+    )
 
 
 @dont_throw
@@ -246,6 +254,9 @@ def _set_token_usage(
         response = response.__dict__
 
     prompt_tokens = 0
+    cache_creation_tokens = response.get("cache_creation_input_tokens", 0)
+    cache_read_tokens = response.get("cache_read_input_tokens", 0)
+
     if hasattr(anthropic, "count_tokens"):
         if request.get("prompt"):
             prompt_tokens = anthropic.count_tokens(request.get("prompt"))
@@ -304,6 +315,12 @@ def _set_token_usage(
         span, SpanAttributes.LLM_USAGE_COMPLETION_TOKENS, completion_tokens
     )
     set_span_attribute(span, SpanAttributes.LLM_USAGE_TOTAL_TOKENS, total_tokens)
+    set_span_attribute(
+        span, "llm.cache_creation_input_tokens", cache_creation_tokens
+    )
+    set_span_attribute(
+        span, "llm.cache_read_input_tokens", cache_read_tokens
+    )
 
 
 @dont_throw

--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
@@ -43,6 +43,9 @@ def _set_token_usage(
     choice_counter: Counter = None,
 ):
     total_tokens = prompt_tokens + completion_tokens
+    cache_creation_tokens = complete_response.get("cache_creation_input_tokens", 0)
+    cache_read_tokens = complete_response.get("cache_read_input_tokens", 0)
+
     set_span_attribute(span, SpanAttributes.LLM_USAGE_PROMPT_TOKENS, prompt_tokens)
     set_span_attribute(
         span, SpanAttributes.LLM_USAGE_COMPLETION_TOKENS, completion_tokens
@@ -51,6 +54,13 @@ def _set_token_usage(
 
     set_span_attribute(
         span, SpanAttributes.LLM_RESPONSE_MODEL, complete_response.get("model")
+    )
+    
+    set_span_attribute(
+        span, "llm.cache_creation_input_tokens", cache_creation_tokens
+    )
+    set_span_attribute(
+        span, "llm.cache_read_input_tokens", cache_read_tokens
     )
 
     if token_histogram and type(prompt_tokens) is int and prompt_tokens >= 0:


### PR DESCRIPTION
This PR  supports tracking and logging prompt caching(#1838) metrics in the OpenTelemetry Anthropic instrumentation. 

Specifically, it captures and logs the `cache_creation_input_tokens` and `cache_read_input_tokens` fields from the API response. This enhancement allows users to monitor the effectiveness of their prompt caching strategy, providing insights into cache utilization and efficiency.

Changes include:

* Updated `_set_token_usage` and `_aset_token_usage` functions to log caching metrics.
* Added new span attributes for `cache_creation_input_tokens` and `cache_read_input_tokens`.
* Updated `streaming.py` to support prompt caching metrics in streaming responses.
