### PR TITLE
Correct the package names for watsonx

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
+++ b/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
@@ -928,7 +928,7 @@ def init_vertexai_instrumentor():
 
 def init_watsonx_instrumentor():
     try:
-        if is_package_installed("ibm_watson_machine_learning"):
+        if is_package_installed("ibm-watsonx-ai") or is_package_installed("ibm-watson-machine-learning"):
             Telemetry().capture("instrumentation:watsonx:init")
             from opentelemetry.instrumentation.watsonx import WatsonxInstrumentor
 


### PR DESCRIPTION
With the traceloop-sdk since https://github.com/traceloop/openllmetry/pull/1374, the instrumentation cannot work for watsonx because of incorrect package name.

Actually the new `ibm_watsonx_ai` Python SDK is upgraded version of ibm_watson_machine_learning. They are similar in usage, anyway, it's better to check the both two SDKs.

```python
def is_package_installed(package_name: str) -> bool:
    # return importlib.util.find_spec(package_name) is not None
    print("Packages: ", installed_packages)  # Debug output for checking package name.
    return package_name in installed_packages
```
**Debug output:**
Packages: {'requests', 'packaging', 'opentelemetry-instrumentation-chromadb', 'langchain-ibm', 'jiter', 'distro', 'langsmith', 'importlib-metadata', 'ibm-watsonx-ai', 'googleapis-common-protos', 'opentelemetry-instrumentation-langchain', 'backoff', 'opentelemetry-instrumentation-alephalpha', 'opentelemetry-instrumentation-watsonx', 'pydantic', 'tokenizers', 'anthropic', 'deprecated', 'jsonpatch', 'opentelemetry-instrumentation-weaviate', 'six', 'opentelemetry-instrumentation-transformers', 'anyio', 'tzdata', 'pip', 'jsonpointer', 'ibm-cos-sdk', 'opentelemetry-instrumentation-haystack', 'langchain-core', 'sniffio', 'orjson', 'fsspec', 'ibm-cos-sdk-s3transfer', 'tenacity', 'jmespath', 'opentelemetry-instrumentation-sqlalchemy', 'opentelemetry-instrumentation-ollama', 'opentelemetry-instrumentation-replicate', 'opentelemetry-instrumentation', 'opentelemetry-sdk', 'opentelemetry-exporter-otlp-proto-grpc', 'opentelemetry-instrumentation-urllib3', 'opentelemetry-semantic-conventions-ai', 'tabulate', 'tiktoken', 'markupsafe', 'opentelemetry-instrumentation-milvus', 'httpx', 'typing-extensions', 'jinja2', 'setuptools', 'inflection', 'opentelemetry-instrumentation-requests', 'traceloop-sdk', 'charset-normalizer', 'opentelemetry-instrumentation-pinecone', 'monotonic', 'opentelemetry-semantic-conventions', 'colorama', 'numpy', 'grpcio', 'zipp', 'ibm-watson-machine-learning', 'opentelemetry-instrumentation-cohere', 'h11', 'ibm-cos-sdk-core', 'opentelemetry-exporter-otlp-proto-http', 'lomond', 'opentelemetry-instrumentation-vertexai', 'pyyaml', 'opentelemetry-instrumentation-together', 'idna', 'opentelemetry-instrumentation-bedrock', 'opentelemetry-instrumentation-anthropic', 'python-dotenv', 'opentelemetry-instrumentation-marqo', 'urllib3', 'filelock', 'pydantic-core', 'httpcore', 'opentelemetry-instrumentation-google-generativeai', 'protobuf', 'huggingface-hub', 'posthog', 'opentelemetry-instrumentation-llamaindex', 'regex', 'python-dateutil', 'opentelemetry-instrumentation-threading', 'opentelemetry-util-http', 'opentelemetry-instrumentation-lancedb', 'opentelemetry-instrumentation-qdrant', 'annotated-types', 'tqdm', 'pytz', 'opentelemetry-api', 'opentelemetry-exporter-otlp-proto-common', 'certifi', 'pandas', 'opentelemetry-instrumentation-openai', 'wrapt', 'opentelemetry-proto', 'opentelemetry-instrumentation-mistralai', 'openai'}