### PR TITLE
fix(anthropic): token counting exception when prompt contains images

### DIFF
--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
@@ -174,12 +174,16 @@ async def _aset_token_usage(
         if request.get("prompt"):
             prompt_tokens = await anthropic.count_tokens(request.get("prompt"))
         elif request.get("messages"):
-            prompt_tokens = sum(
-                [
-                    await anthropic.count_tokens(m.get("content"))
-                    for m in request.get("messages")
-                ]
-            )
+            prompt_tokens = 0
+            for m in request.get("messages"):
+                content = m.get("content")
+                if isinstance(content, str):
+                    prompt_tokens += await anthropic.count_tokens(content)
+                elif isinstance(content, list):
+                    for item in content:
+                        # TODO: handle image tokens
+                        if isinstance(item, dict) and item.get("type") == "text":
+                            prompt_tokens += await anthropic.count_tokens(item.get("text", ""))
 
     if token_histogram and type(prompt_tokens) is int and prompt_tokens >= 0:
         token_histogram.record(
@@ -250,12 +254,16 @@ def _set_token_usage(
         if request.get("prompt"):
             prompt_tokens = anthropic.count_tokens(request.get("prompt"))
         elif request.get("messages"):
-            prompt_tokens = sum(
-                [
-                    anthropic.count_tokens(m.get("content"))
-                    for m in request.get("messages")
-                ]
-            )
+            prompt_tokens = 0
+            for m in request.get("messages"):
+                content = m.get("content")
+                if isinstance(content, str):
+                    prompt_tokens += anthropic.count_tokens(content)
+                elif isinstance(content, list):
+                    for item in content:
+                        # TODO: handle image tokens
+                        if isinstance(item, dict) and item.get("type") == "text":
+                            prompt_tokens += anthropic.count_tokens(item.get("text", ""))
 
     if token_histogram and type(prompt_tokens) is int and prompt_tokens >= 0:
         token_histogram.record(

--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
@@ -181,7 +181,9 @@ async def _aset_token_usage(
                     prompt_tokens += await anthropic.count_tokens(content)
                 elif isinstance(content, list):
                     for item in content:
-                        prompt_tokens += await anthropic.count_tokens(item)
+                        # TODO: handle image tokens
+                        if isinstance(item, dict) and item.get("type") == "text":
+                            prompt_tokens += await anthropic.count_tokens(item.get("text", ""))
 
     if token_histogram and type(prompt_tokens) is int and prompt_tokens >= 0:
         token_histogram.record(
@@ -247,8 +249,6 @@ def _set_token_usage(
     if not isinstance(response, dict):
         response = response.__dict__
 
-    print("usage", response.get("usage"))
-
     prompt_tokens = 0
     if hasattr(anthropic, "count_tokens"):
         if request.get("prompt"):
@@ -257,13 +257,13 @@ def _set_token_usage(
             prompt_tokens = 0
             for m in request.get("messages"):
                 content = m.get("content")
-                print("content", content)
                 if isinstance(content, str):
-                    print("content str", content)
                     prompt_tokens += anthropic.count_tokens(content)
                 elif isinstance(content, list):
                     for item in content:
-                        prompt_tokens += anthropic.count_tokens(item)
+                        # TODO: handle image tokens
+                        if isinstance(item, dict) and item.get("type") == "text":
+                            prompt_tokens += anthropic.count_tokens(item.get("text", ""))
 
     if token_histogram and type(prompt_tokens) is int and prompt_tokens >= 0:
         token_histogram.record(

--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
@@ -181,9 +181,7 @@ async def _aset_token_usage(
                     prompt_tokens += await anthropic.count_tokens(content)
                 elif isinstance(content, list):
                     for item in content:
-                        # TODO: handle image tokens
-                        if isinstance(item, dict) and item.get("type") == "text":
-                            prompt_tokens += await anthropic.count_tokens(item.get("text", ""))
+                        prompt_tokens += await anthropic.count_tokens(item)
 
     if token_histogram and type(prompt_tokens) is int and prompt_tokens >= 0:
         token_histogram.record(
@@ -249,6 +247,8 @@ def _set_token_usage(
     if not isinstance(response, dict):
         response = response.__dict__
 
+    print("usage", response.get("usage"))
+
     prompt_tokens = 0
     if hasattr(anthropic, "count_tokens"):
         if request.get("prompt"):
@@ -257,13 +257,13 @@ def _set_token_usage(
             prompt_tokens = 0
             for m in request.get("messages"):
                 content = m.get("content")
+                print("content", content)
                 if isinstance(content, str):
+                    print("content str", content)
                     prompt_tokens += anthropic.count_tokens(content)
                 elif isinstance(content, list):
                     for item in content:
-                        # TODO: handle image tokens
-                        if isinstance(item, dict) and item.get("type") == "text":
-                            prompt_tokens += anthropic.count_tokens(item.get("text", ""))
+                        prompt_tokens += anthropic.count_tokens(item)
 
     if token_histogram and type(prompt_tokens) is int and prompt_tokens >= 0:
         token_histogram.record(

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_completion.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_completion.py
@@ -256,7 +256,7 @@ def test_anthropic_multi_modal(exporter):
         anthropic_span.attributes.get(f"{SpanAttributes.LLM_COMPLETIONS}.0.content")
         == response.content[0].text
     )
-    assert anthropic_span.attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 1381
+    assert anthropic_span.attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 5
     assert (
         anthropic_span.attributes[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS]
         + anthropic_span.attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS]


### PR DESCRIPTION
Solves #1944 


This fix ignores token counting for images. Therefore, price calculated based on this one will be missing the vision part.