### PR TITLE
Update to Issue #389- Added ContextVars variable "association_properties_var"

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
+++ b/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
@@ -4,6 +4,7 @@ import os
 import contextvars
 import uuid
 
+
 from colorama import Fore
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
@@ -33,6 +34,7 @@ from traceloop.sdk.tracing.content_allow_list import ContentAllowList
 from traceloop.sdk.utils import is_notebook
 from traceloop.sdk.utils.package_check import is_package_installed
 from typing import Callable, Dict, Optional, Set
+
 
 TRACER_NAME = "traceloop.tracer"
 EXCLUDED_URLS = """

--- a/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
+++ b/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
@@ -64,7 +64,6 @@ class TracerWrapper(object):
     association_properties_var: ContextVar = None
     __tracer_provider: TracerProvider = None
     __image_uploader: ImageUploader = None
-    
 
     def __new__(
         cls,


### PR DESCRIPTION
<-- Thanks for submitting a PR!  -->

Added a ContextVars variable to the TracerWrapper object such that it updates every time set_association_properties is called such that it stores a copy of the properties in a variable called association_properties_var, so changes are only stored when using the set_association_properties function. This allows for the properties to be viewed at certain instances in between trace updates so other functions could be made possible using this backup of association_properties.