### PR TITLE
fix(llama-index): add attribute to span for llm request type in dispatcher wrapper

### DIFF
--- a/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/dispatcher_wrapper.py
+++ b/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/dispatcher_wrapper.py
@@ -47,6 +47,7 @@ def instrument_with_dispatcher(tracer: Tracer):
 @dont_throw
 def _set_llm_chat_request(event, span) -> None:
     model_dict = event.model_dict
+    span.set_attribute(SpanAttributes.LLM_REQUEST_TYPE, LLMRequestTypeValues.CHAT.value)
     span.set_attribute(SpanAttributes.LLM_REQUEST_MODEL, model_dict.get("model"))
     span.set_attribute(
         SpanAttributes.LLM_REQUEST_TEMPERATURE, model_dict.get("temperature")

--- a/packages/opentelemetry-instrumentation-llamaindex/tests/test_agents.py
+++ b/packages/opentelemetry-instrumentation-llamaindex/tests/test_agents.py
@@ -72,6 +72,7 @@ def test_agents_and_tools(exporter):
     assert llm_span_1.parent is not None
     assert llm_span_2.parent is not None
 
+    assert llm_span_1.attributes[SpanAttributes.LLM_REQUEST_TYPE] == "chat"
     assert (
         llm_span_1.attributes[SpanAttributes.LLM_REQUEST_MODEL] == "gpt-3.5-turbo-0613"
     )
@@ -93,6 +94,7 @@ def test_agents_and_tools(exporter):
     assert llm_span_1.attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 479
     assert llm_span_1.attributes[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 522
 
+    assert llm_span_2.attributes[SpanAttributes.LLM_REQUEST_TYPE] == "chat"
     assert (
         llm_span_2.attributes[SpanAttributes.LLM_REQUEST_MODEL] == "gpt-3.5-turbo-0613"
     )


### PR DESCRIPTION
Set LLM_REQUEST_TYPE attribute to span for tracking chat requests. This change ensures proper monitoring and categorization. (#XYZ-123)

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [x] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
