### PR TITLE
fix(sdk): add header for logging exporter

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/__init__.py
+++ b/packages/traceloop-sdk/traceloop/sdk/__init__.py
@@ -52,6 +52,7 @@ class Traceloop:
         metrics_exporter: MetricExporter = None,
         metrics_headers: Dict[str, str] = None,
         logging_exporter: LogExporter = None,
+        logging_headers: Dict[str, str] = None,
         processor: SpanProcessor = None,
         propagator: TextMapPropagator = None,
         traceloop_sync_enabled: bool = False,
@@ -158,11 +159,14 @@ class Traceloop:
             print(Fore.YELLOW + "Logging are disabled" + Fore.RESET)
         else:
             logging_endpoint = os.getenv("TRACELOOP_LOGGING_ENDPOINT") or api_endpoint
+            logging_headers = (
+                os.getenv("TRACELOOP_LOGGING_HEADERS") or logging_headers or headers
+            )
             if logging_exporter or processor:
                 print(Fore.GREEN + "Traceloop exporting logs to a custom exporter")
 
             LoggerWrapper.set_static_params(
-                resource_attributes, logging_endpoint
+                resource_attributes, logging_endpoint, logging_headers
             )
             Traceloop.__logger_wrapper = LoggerWrapper(exporter=logging_exporter)
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

The headers could be needed for LogExporter to connect to some logs receivers.
If no TRACELOOP_LOGGING_HEADERS defined, the TRACELOOP_HEADERS will be used.
