### PR TITLE
[Bugfix]: Replace the hardcoded Watsonx API URL value

### DIFF
--- a/packages/opentelemetry-instrumentation-watsonx/opentelemetry/instrumentation/watsonx/__init__.py
+++ b/packages/opentelemetry-instrumentation-watsonx/opentelemetry/instrumentation/watsonx/__init__.py
@@ -104,7 +104,7 @@ def _set_api_attributes(span):
     _set_span_attribute(
         span,
         WatsonxSpanAttributes.WATSONX_API_BASE,
-        "https://us-south.ml.cloud.ibm.com",
+        os.getenv("API_BASE_URL"),
     )
     _set_span_attribute(span, WatsonxSpanAttributes.WATSONX_API_TYPE, "watsonx.ai")
     _set_span_attribute(span, WatsonxSpanAttributes.WATSONX_API_VERSION, "1.0")

--- a/packages/opentelemetry-instrumentation-watsonx/opentelemetry/instrumentation/watsonx/__init__.py
+++ b/packages/opentelemetry-instrumentation-watsonx/opentelemetry/instrumentation/watsonx/__init__.py
@@ -14,6 +14,7 @@ from opentelemetry.trace import get_tracer, SpanKind
 from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.metrics import get_meter
 from opentelemetry.metrics import Counter, Histogram
+from watsonx-langchain import watsonx_llm_init
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import (
@@ -101,10 +102,12 @@ def _set_span_attribute(span, name, value):
 
 
 def _set_api_attributes(span):
+    watsonx_llm = watsonx_llm_init()
+    api_base_url = getattr(watsonx_llm, "url", "https://us-south.ml.cloud.ibm.com")
     _set_span_attribute(
         span,
         WatsonxSpanAttributes.WATSONX_API_BASE,
-        os.getenv("API_BASE_URL"),
+        api_base_url
     )
     _set_span_attribute(span, WatsonxSpanAttributes.WATSONX_API_TYPE, "watsonx.ai")
     _set_span_attribute(span, WatsonxSpanAttributes.WATSONX_API_VERSION, "1.0")

--- a/packages/sample-app/sample_app/watsonx-langchain.py
+++ b/packages/sample-app/sample_app/watsonx-langchain.py
@@ -28,7 +28,7 @@ def watsonx_llm_init() -> ModelInference:
 
     watsonx_llm = WatsonxLLM(
         model_id="ibm/granite-13b-instruct-v2",
-        url="https://us-south.ml.cloud.ibm.com",
+        url=os.getenv("API_BASE_URL"),
         apikey=os.getenv("IAM_API_KEY"),
         project_id=os.getenv("PROJECT_ID"),
         params=watsonx_llm_parameters,


### PR DESCRIPTION
### What does this PR do?

Previously the watsonx api url was hardcoded in `_set_span_attribute`. To support the region based API URLs or on-prem, update the hardcoded API URL with a `env` variable to get the base URL by the customer.

Fixed #2163 

### Type of change
Update the hardcoded value with `env` var.
