### PR TITLE
fix(watsonx): use with statement to automatically handle exception

### DIFF
--- a/packages/opentelemetry-instrumentation-watsonx/opentelemetry/instrumentation/watsonx/__init__.py
+++ b/packages/opentelemetry-instrumentation-watsonx/opentelemetry/instrumentation/watsonx/__init__.py
@@ -445,67 +445,66 @@ def _wrap(
 
     name = to_wrap.get("span_name")
 
-    span = tracer.start_span(
+    with tracer.start_span(
         name,
         kind=SpanKind.CLIENT,
         attributes={
             SpanAttributes.LLM_SYSTEM: "Watsonx",
             SpanAttributes.LLM_REQUEST_TYPE: LLMRequestTypeValues.COMPLETION.value,
         },
-    )
+    ) as span:
 
-    _set_api_attributes(span)
-    if "generate" in name:
-        _set_input_attributes(span, instance, kwargs)
-        if to_wrap.get("method") == "generate_text_stream":
-            if (raw_flag := kwargs.get("raw_response", None)) is None:
-                kwargs = {**kwargs, "raw_response": True}
-            elif raw_flag is False:
-                kwargs["raw_response"] = True
+        _set_api_attributes(span)
+        if "generate" in name:
+            _set_input_attributes(span, instance, kwargs)
+            if to_wrap.get("method") == "generate_text_stream":
+                if (raw_flag := kwargs.get("raw_response", None)) is None:
+                    kwargs = {**kwargs, "raw_response": True}
+                elif raw_flag is False:
+                    kwargs["raw_response"] = True
 
-    try:
-        start_time = time.time()
-        response = wrapped(*args, **kwargs)
-        end_time = time.time()
-    except Exception as e:
-        end_time = time.time()
-        duration = end_time - start_time if "start_time" in locals() else 0
+        try:
+            start_time = time.time()
+            response = wrapped(*args, **kwargs)
+            end_time = time.time()
+        except Exception as e:
+            end_time = time.time()
+            duration = end_time - start_time if "start_time" in locals() else 0
 
-        attributes = {
-            "error.type": e.__class__.__name__,
-        }
+            attributes = {
+                "error.type": e.__class__.__name__,
+            }
 
-        if duration > 0 and duration_histogram:
-            duration_histogram.record(duration, attributes=attributes)
-        if exception_counter:
-            exception_counter.add(1, attributes=attributes)
+            if duration > 0 and duration_histogram:
+                duration_histogram.record(duration, attributes=attributes)
+            if exception_counter:
+                exception_counter.add(1, attributes=attributes)
 
-        raise e
+            raise e
 
-    if "generate" in name:
-        if isinstance(response, types.GeneratorType):
-            return _build_and_set_stream_response(
-                span,
-                response,
-                raw_flag,
-                token_histogram,
-                response_counter,
-                duration_histogram,
-                start_time,
-            )
-        else:
-            duration = end_time - start_time
-            _set_response_attributes(
-                span,
-                response,
-                token_histogram,
-                response_counter,
-                duration_histogram,
-                duration,
-            )
+        if "generate" in name:
+            if isinstance(response, types.GeneratorType):
+                return _build_and_set_stream_response(
+                    span,
+                    response,
+                    raw_flag,
+                    token_histogram,
+                    response_counter,
+                    duration_histogram,
+                    start_time,
+                )
+            else:
+                duration = end_time - start_time
+                _set_response_attributes(
+                    span,
+                    response,
+                    token_histogram,
+                    response_counter,
+                    duration_histogram,
+                    duration,
+                )
 
-    span.end()
-    return response
+        return response
 
 
 class WatsonxSpanAttributes:


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [ ] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

Use `with` statement to catch the exception and marks the span as being in an error state. then if an exception occurs, the span is properly ended and contains information about the exception.