### PR TITLE
fix(sdk): gemini instrumentation was never installed due to package name error

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
+++ b/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
@@ -584,7 +584,7 @@ def init_chroma_instrumentor():
 
 def init_google_generativeai_instrumentor():
     try:
-        if is_package_installed("google.generativeai"):
+        if is_package_installed("google-generativeai"):
             Telemetry().capture("instrumentation:gemini:init")
             from opentelemetry.instrumentation.google_generativeai import (
                 GoogleGenerativeAiInstrumentor,


### PR DESCRIPTION
Fixes #2140 

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [ ] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
