### PR TITLE
Add Opentelemetry-Instrumentation-Redis package

### DIFF
--- a/packages/traceloop-sdk/pyproject.toml
+++ b/packages/traceloop-sdk/pyproject.toml
@@ -52,6 +52,7 @@ opentelemetry-instrumentation-llamaindex = { path = "../opentelemetry-instrument
 opentelemetry-instrumentation-milvus = { path = "../opentelemetry-instrumentation-milvus", develop = true }
 opentelemetry-instrumentation-haystack = { path = "../opentelemetry-instrumentation-haystack", develop = true }
 opentelemetry-instrumentation-bedrock = { path = "../opentelemetry-instrumentation-bedrock", develop = true }
+opentelemetry-instrumentation-redis = { path = "../opentelemetry-instrumentation-redis", develop = true }
 opentelemetry-instrumentation-sagemaker = { path = "../opentelemetry-instrumentation-sagemaker", develop = true }
 opentelemetry-instrumentation-replicate = { path = "../opentelemetry-instrumentation-replicate", develop = true }
 opentelemetry-instrumentation-vertexai = { path = "../opentelemetry-instrumentation-vertexai", develop = true }


### PR DESCRIPTION
I was getting the following error as Opentelemetry-Instrumentation-Redis was not in this file:
ERROR:root:Error initializing redis instrumentor: No module named 'opentelemetry.instrumentation.redis'