### PR TITLE
fix(sdk): Update JSONEncoder to allow class instance methods to be serializable

### DIFF
--- a/packages/traceloop-sdk/tests/test_class_tasks.py
+++ b/packages/traceloop-sdk/tests/test_class_tasks.py
@@ -1,0 +1,58 @@
+import json
+
+from opentelemetry.semconv_ai import SpanAttributes
+from traceloop.sdk.decorators import task
+
+
+def test_instance_method_task(exporter):
+    class TestService:
+        @task(name="instance_method_task")
+        def test_method(self, data: str):
+            return f"Processed: {data}"
+
+    service = TestService()
+    result = service.test_method("test data")
+
+    spans = exporter.get_finished_spans()
+    assert [span.name for span in spans] == ["instance_method_task.task"]
+
+    task_span = spans[0]
+    assert json.loads(task_span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == {
+        "args": ["TestService", "test data"],
+        "kwargs": {},
+    }
+    assert (
+        json.loads(task_span.attributes.get(SpanAttributes.TRACELOOP_ENTITY_OUTPUT))
+        == result
+    )
+    assert (
+        task_span.attributes[SpanAttributes.TRACELOOP_ENTITY_NAME]
+        == "instance_method_task"
+    )
+
+
+def test_class_decorator_task(exporter):
+    @task(name="class_decorator_task", method_name="test_method")
+    class TestService:
+        def test_method(self, data: str):
+            return f"Processed: {data}"
+
+    service = TestService()
+    result = service.test_method("test data")
+
+    spans = exporter.get_finished_spans()
+    assert [span.name for span in spans] == ["class_decorator_task.task"]
+
+    task_span = spans[0]
+    assert json.loads(task_span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == {
+        "args": ["TestService", "test data"],
+        "kwargs": {},
+    }
+    assert (
+        json.loads(task_span.attributes.get(SpanAttributes.TRACELOOP_ENTITY_OUTPUT))
+        == result
+    )
+    assert (
+        task_span.attributes[SpanAttributes.TRACELOOP_ENTITY_NAME]
+        == "class_decorator_task"
+    )

--- a/packages/traceloop-sdk/traceloop/sdk/utils/json_encoder.py
+++ b/packages/traceloop-sdk/traceloop/sdk/utils/json_encoder.py
@@ -17,4 +17,7 @@ class JSONEncoder(json.JSONEncoder):
         if hasattr(o, "json"):
             return o.json()
 
+        if hasattr(o, "__class__"):
+            return o.__class__.__name__
+
         return super().default(o)


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

I noticed that when using the task decorator on class instance methods, the `traceloop.entity.input` attribute was not showing up in spans. I did some digging and saw that a TypeError was being triggered when trying to [serialize the methods args](https://github.com/traceloop/openllmetry/blob/b7d917ffbbe856e0ccb56f271860bac8e462c161/packages/traceloop-sdk/traceloop/sdk/decorators/base.py#L68) because the first arg is the instance of the class. 

To fix this issue, I've made an update to the custom `JSONEncoder` to properly handle class instances. Specifically, if the encoder encounters an object that cannot be directly serialized, it now falls back to returning the class’s name as a string. 


- [x] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
