### PR TITLE
feat(bedrock): add event-based instrumentation

### DIFF
--- a/packages/opentelemetry-instrumentation-bedrock/README.md
+++ b/packages/opentelemetry-instrumentation-bedrock/README.md
@@ -6,6 +6,14 @@
 
 This library allows tracing any of AWS Bedrock's models prompts and completions sent with [Boto3](https://github.com/boto/boto3) to Bedrock.
 
+## Features
+
+- Traces all calls to Bedrock's model endpoints
+- Supports both legacy attribute-based and new event-based semantic conventions
+- Captures prompts, completions, and token usage metrics
+- Supports streaming responses with chunk-by-chunk instrumentation
+- Handles multiple model providers (Anthropic, Cohere, AI21, Meta, Amazon)
+
 ## Installation
 
 ```bash
@@ -17,12 +25,30 @@ pip install opentelemetry-instrumentation-bedrock
 ```python
 from opentelemetry.instrumentation.bedrock import BedrockInstrumentor
 
+# Use legacy attribute-based semantic conventions (default)
+BedrockInstrumentor().instrument()
+
+# Or use new event-based semantic conventions
+from opentelemetry.instrumentation.bedrock.config import Config
+Config.use_legacy_attributes = False
 BedrockInstrumentor().instrument()
 ```
 
+## Configuration
+
+The instrumentation can be configured using the following options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `use_legacy_attributes` | bool | `True` | Controls whether to use legacy attribute-based semantic conventions or new event-based semantic conventions. When `True`, prompts and completions are stored as span attributes. When `False`, they are stored as span events following the new OpenTelemetry semantic conventions. |
+| `enrich_token_usage` | bool | `False` | When `True`, calculates token usage even when not provided by the API response. |
+| `exception_logger` | Callable | `None` | Optional callback for logging exceptions that occur during instrumentation. |
+
 ## Privacy
 
-**By default, this instrumentation logs prompts, completions, and embeddings to span attributes**. This gives you a clear visibility into how your LLM application is working, and can make it easy to debug and evaluate the quality of the outputs.
+**By default, this instrumentation logs prompts, completions, and embeddings**. This gives you clear visibility into how your LLM application is working, and can make it easy to debug and evaluate the quality of the outputs.
+
+The data can be stored either as span attributes (legacy mode) or span events (new mode), controlled by the `use_legacy_attributes` configuration option.
 
 However, you may want to disable this logging for privacy reasons, as they may contain highly sensitive data from your users. You may also simply want to reduce the size of your traces.
 
@@ -31,3 +57,33 @@ To disable logging, set the `TRACELOOP_TRACE_CONTENT` environment variable to `f
 ```bash
 TRACELOOP_TRACE_CONTENT=false
 ```
+
+## Semantic Conventions
+
+This instrumentation supports two modes of operation:
+
+### Legacy Attribute-based Mode (Default)
+
+In this mode, prompts and completions are stored as span attributes following the pattern:
+- `gen_ai.prompt.{index}.content` - The prompt text
+- `gen_ai.prompt.{index}.role` - The role (e.g., "user", "system")
+- `gen_ai.completion.{index}.content` - The completion text
+- `gen_ai.completion.{index}.role` - The role (e.g., "assistant")
+
+### Event-based Mode
+
+In this mode, prompts and completions are stored as span events following the new OpenTelemetry semantic conventions:
+- Prompt events with attributes:
+  - `llm.prompt.index` - The index of the prompt
+  - `llm.prompt.type` - The type of prompt (e.g., "chat", "completion")
+  - `llm.prompt.content` - The prompt text
+  - `llm.prompt.role` - The role (e.g., "user", "system")
+- Completion events with attributes:
+  - `llm.completion.index` - The index of the completion
+  - `llm.completion.content` - The completion text
+  - `llm.completion.role` - The role (e.g., "assistant")
+  - `llm.completion.stop_reason` - The reason the completion stopped
+
+For streaming responses in event-based mode, each chunk generates a `llm.content.completion.chunk` event with the chunk's content.
+
+Token usage metrics and other metadata are recorded in both modes using standard attributes.

--- a/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/config.py
+++ b/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/config.py
@@ -1,3 +1,6 @@
 class Config:
+    """Configuration for Bedrock instrumentation."""
+
     enrich_token_usage = False
     exception_logger = None
+    use_legacy_attributes: bool = True  # Controls whether to use legacy attributes or new event-based semantic conventions

--- a/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/events.py
+++ b/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/events.py
@@ -1,0 +1,105 @@
+"""Event emission helpers for Bedrock instrumentation."""
+
+import json
+from typing import Any, Dict, List, Optional, Union
+
+from opentelemetry.semconv_ai import SpanAttributes
+
+
+def emit_prompt_event(
+    span,
+    prompt: Optional[str] = None,
+    messages: Optional[List[Dict[str, Any]]] = None,
+    index: int = 0,
+) -> None:
+    """Emit a prompt event for a Bedrock request.
+
+    Handles both chat-style (messages) and completion-style (prompt) inputs.
+    """
+    event_attributes = {
+        SpanAttributes.LLM_PROMPT_INDEX: index,
+    }
+
+    if messages:
+        # Chat-style input (Claude, Anthropic, etc.)
+        event_attributes[SpanAttributes.LLM_PROMPT_TYPE] = "chat"
+        for i, msg in enumerate(messages):
+            if msg.get("role"):
+                event_attributes[f"messages.{i}.role"] = msg["role"]
+            if msg.get("content"):
+                content = msg["content"]
+                if isinstance(content, list):  # Handle multi-modal content
+                    content = json.dumps(content)
+                event_attributes[f"messages.{i}.content"] = content
+    else:
+        # Completion-style input (Titan, etc.)
+        event_attributes[SpanAttributes.LLM_PROMPT_TYPE] = "completion"
+        if prompt:
+            event_attributes[SpanAttributes.LLM_PROMPT_CONTENT] = prompt
+
+    span.add_event(name="prompt", attributes=event_attributes)
+
+
+def emit_completion_event(
+    span,
+    completion: Dict[str, Any],
+    index: Optional[int] = None,
+    is_streaming: bool = False,
+) -> None:
+    """Emit a completion event for a Bedrock response."""
+    event_attributes = {}
+
+    if index is not None:
+        event_attributes[SpanAttributes.LLM_COMPLETION_INDEX] = index
+
+    # Handle different model response formats
+    if "completion" in completion:
+        # Titan model format
+        event_attributes[SpanAttributes.LLM_COMPLETION_CONTENT] = completion[
+            "completion"
+        ]
+    elif "content" in completion:
+        # Claude/Anthropic format
+        content = completion["content"]
+        if isinstance(content, list):  # Handle multi-modal content
+            content = json.dumps(content)
+        event_attributes[SpanAttributes.LLM_COMPLETION_CONTENT] = content
+    elif "generation" in completion:
+        # Cohere format
+        event_attributes[SpanAttributes.LLM_COMPLETION_CONTENT] = completion[
+            "generation"
+        ]
+    elif "text" in completion:
+        # AI21 format
+        event_attributes[SpanAttributes.LLM_COMPLETION_CONTENT] = completion["text"]
+
+    if "stop_reason" in completion:
+        event_attributes[SpanAttributes.LLM_RESPONSE_FINISH_REASON] = completion[
+            "stop_reason"
+        ]
+    elif "finish_reason" in completion:
+        event_attributes[SpanAttributes.LLM_RESPONSE_FINISH_REASON] = completion[
+            "finish_reason"
+        ]
+
+    if "role" in completion:
+        event_attributes[SpanAttributes.LLM_COMPLETION_ROLE] = completion["role"]
+
+    # Handle tool calls
+    if "tool_calls" in completion:
+        tool_calls = completion["tool_calls"]
+        for i, tool_call in enumerate(tool_calls):
+            event_attributes[f"tool_calls.{i}.type"] = tool_call.get("type")
+            if tool_call.get("function"):
+                function = tool_call["function"]
+                event_attributes[f"tool_calls.{i}.function.name"] = function.get("name")
+                event_attributes[f"tool_calls.{i}.function.arguments"] = function.get(
+                    "arguments"
+                )
+
+    event_name = (
+        f"{SpanAttributes.LLM_CONTENT_COMPLETION_CHUNK}"
+        if is_streaming
+        else "completion"
+    )
+    span.add_event(name=event_name, attributes=event_attributes)

--- a/packages/opentelemetry-instrumentation-bedrock/tests/test_completion.py
+++ b/packages/opentelemetry-instrumentation-bedrock/tests/test_completion.py
@@ -1,0 +1,406 @@
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+from opentelemetry.instrumentation.bedrock.config import Config
+
+
+def find_event(span, event_name):
+    """Helper function to find an event by name in a span."""
+    return next((event for event in span.events if event.name == event_name), None)
+
+
+def mock_bedrock_response(content, model_id, token_counts=None):
+    """Helper to create a mock Bedrock response."""
+    response = {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    if "anthropic" in model_id:
+        if "messages" in content:
+            response["body"] = json.dumps(
+                {
+                    "content": content["messages"],
+                    "model": model_id,
+                    "usage": {
+                        "input_tokens": token_counts["input"] if token_counts else 10,
+                        "output_tokens": token_counts["output"] if token_counts else 20,
+                    },
+                    "stop_reason": "stop_sequence",
+                }
+            )
+        else:
+            response["body"] = json.dumps(
+                {
+                    "completion": content["completion"],
+                    "model": model_id,
+                    "usage": {
+                        "input_tokens": token_counts["input"] if token_counts else 10,
+                        "output_tokens": token_counts["output"] if token_counts else 20,
+                    },
+                    "stop_reason": "stop_sequence",
+                }
+            )
+    elif "cohere" in model_id:
+        response["body"] = json.dumps(
+            {
+                "generations": [{"text": text} for text in content["generations"]],
+                "token_count": {
+                    "prompt_tokens": token_counts["input"] if token_counts else 10,
+                    "response_tokens": token_counts["output"] if token_counts else 20,
+                },
+            }
+        )
+    elif "ai21" in model_id:
+        response["body"] = json.dumps(
+            {
+                "completions": [
+                    {"data": {"text": text}} for text in content["completions"]
+                ],
+                "prompt": {
+                    "tokens": ["t"] * (token_counts["input"] if token_counts else 10)
+                },
+                "completions": [
+                    {
+                        "data": {
+                            "tokens": ["t"]
+                            * (token_counts["output"] if token_counts else 20)
+                        }
+                    }
+                ],
+            }
+        )
+    elif "meta" in model_id:
+        if "generations" in content:
+            response["body"] = json.dumps(
+                {
+                    "generations": content["generations"],
+                    "prompt_token_count": token_counts["input"] if token_counts else 10,
+                    "generation_token_count": token_counts["output"]
+                    if token_counts
+                    else 20,
+                }
+            )
+        else:
+            response["body"] = json.dumps(
+                {
+                    "generation": content["generation"],
+                    "prompt_token_count": token_counts["input"] if token_counts else 10,
+                    "generation_token_count": token_counts["output"]
+                    if token_counts
+                    else 20,
+                }
+            )
+    elif "amazon" in model_id:
+        response["body"] = json.dumps(
+            {
+                "inputTextTokenCount": token_counts["input"] if token_counts else 10,
+                "results": [
+                    {
+                        "outputText": text,
+                        "tokenCount": token_counts["output"] if token_counts else 20,
+                    }
+                    for text in content["results"]
+                ],
+            }
+        )
+
+    return response
+
+
+@pytest.mark.parametrize("use_legacy_attributes", [True, False])
+def test_cohere_completion(exporter, use_legacy_attributes):
+    """Test Cohere completion in both legacy and event-based modes."""
+    Config.use_legacy_attributes = use_legacy_attributes
+
+    prompt = "Tell me a joke about OpenTelemetry"
+    generations = [
+        "Why did the OpenTelemetry trace cross the road?",
+        "To reach the other service!",
+    ]
+
+    with patch("botocore.client.BaseClient._make_api_call") as mock_api:
+        mock_api.return_value = mock_bedrock_response(
+            {"generations": generations},
+            "cohere.command",
+            {"input": 15, "output": 25},
+        )
+
+        client = MagicMock()
+        client.invoke_model(
+            body=json.dumps(
+                {
+                    "prompt": prompt,
+                    "max_tokens": 100,
+                    "temperature": 0.7,
+                    "p": 0.8,
+                }
+            ),
+            modelId="cohere.command",
+        )
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+
+    if use_legacy_attributes:
+        # Check legacy attribute-based instrumentation
+        assert span.attributes.get("gen_ai.prompt.0.user") == prompt
+        for i, text in enumerate(generations):
+            assert span.attributes.get(f"gen_ai.completion.{i}.content") == text
+    else:
+        # Check event-based instrumentation
+        prompt_event = find_event(span, "prompt")
+        assert prompt_event is not None
+        assert prompt_event.attributes["llm.prompt.content"] == prompt
+
+        for i, text in enumerate(generations):
+            completion_event = find_event(span, "completion")
+            assert completion_event is not None
+            assert completion_event.attributes["llm.completion.content"] == text
+            assert completion_event.attributes["llm.completion.index"] == i
+
+    # Token usage metrics should be set in both modes
+    assert span.attributes.get("gen_ai.usage.prompt_tokens") == 15
+    assert span.attributes.get("gen_ai.usage.completion_tokens") == 25
+    assert span.attributes.get("gen_ai.usage.total_tokens") == 40
+
+
+@pytest.mark.parametrize("use_legacy_attributes", [True, False])
+def test_anthropic_chat(exporter, use_legacy_attributes):
+    """Test Anthropic chat in both legacy and event-based modes."""
+    Config.use_legacy_attributes = use_legacy_attributes
+
+    messages = [
+        {"role": "user", "content": "Tell me a joke"},
+        {
+            "role": "assistant",
+            "content": "Why did the OpenTelemetry trace cross the road?",
+        },
+        {"role": "user", "content": "Why?"},
+        {"role": "assistant", "content": "To reach the other service!"},
+    ]
+
+    with patch("botocore.client.BaseClient._make_api_call") as mock_api:
+        mock_api.return_value = mock_bedrock_response(
+            {"messages": messages},
+            "anthropic.claude-3",
+            {"input": 20, "output": 30},
+        )
+
+        client = MagicMock()
+        client.invoke_model(
+            body=json.dumps(
+                {
+                    "messages": messages[:2],
+                    "max_tokens": 100,
+                    "temperature": 0.7,
+                    "top_p": 0.8,
+                }
+            ),
+            modelId="anthropic.claude-3",
+        )
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+
+    if use_legacy_attributes:
+        # Check legacy attribute-based instrumentation
+        for i, msg in enumerate(messages[:2]):
+            assert span.attributes.get(f"gen_ai.prompt.{i}.role") == msg["role"]
+            assert span.attributes.get(f"gen_ai.prompt.{i}.content") == msg["content"]
+        assert (
+            span.attributes.get("gen_ai.completion.0.content") == messages[3]["content"]
+        )
+        assert span.attributes.get("gen_ai.completion.0.role") == "assistant"
+    else:
+        # Check event-based instrumentation
+        prompt_event = find_event(span, "prompt")
+        assert prompt_event is not None
+        assert prompt_event.attributes["llm.prompt.type"] == "chat"
+
+        completion_event = find_event(span, "completion")
+        assert completion_event is not None
+        assert (
+            completion_event.attributes["llm.completion.content"]
+            == messages[3]["content"]
+        )
+        assert completion_event.attributes["llm.completion.role"] == "assistant"
+
+    # Token usage metrics should be set in both modes
+    assert span.attributes.get("gen_ai.usage.prompt_tokens") == 20
+    assert span.attributes.get("gen_ai.usage.completion_tokens") == 30
+    assert span.attributes.get("gen_ai.usage.total_tokens") == 50
+
+
+@pytest.mark.parametrize("use_legacy_attributes", [True, False])
+def test_amazon_completion(exporter, use_legacy_attributes):
+    """Test Amazon completion in both legacy and event-based modes."""
+    Config.use_legacy_attributes = use_legacy_attributes
+
+    prompt = "Tell me a joke about OpenTelemetry"
+    results = [
+        "Why did the OpenTelemetry trace cross the road?",
+        "To reach the other service!",
+    ]
+
+    with patch("botocore.client.BaseClient._make_api_call") as mock_api:
+        mock_api.return_value = mock_bedrock_response(
+            {"results": results},
+            "amazon.titan-text",
+            {"input": 12, "output": 18},
+        )
+
+        client = MagicMock()
+        client.invoke_model(
+            body=json.dumps(
+                {
+                    "inputText": prompt,
+                    "textGenerationConfig": {
+                        "maxTokenCount": 100,
+                        "temperature": 0.7,
+                        "topP": 0.8,
+                    },
+                }
+            ),
+            modelId="amazon.titan-text",
+        )
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+
+    if use_legacy_attributes:
+        # Check legacy attribute-based instrumentation
+        assert span.attributes.get("gen_ai.prompt.0.user") == prompt
+        for i, text in enumerate(results):
+            assert span.attributes.get(f"gen_ai.completion.{i}.content") == text
+    else:
+        # Check event-based instrumentation
+        prompt_event = find_event(span, "prompt")
+        assert prompt_event is not None
+        assert prompt_event.attributes["llm.prompt.content"] == prompt
+
+        for i, text in enumerate(results):
+            completion_event = find_event(span, "completion")
+            assert completion_event is not None
+            assert completion_event.attributes["llm.completion.content"] == text
+            assert completion_event.attributes["llm.completion.index"] == i
+
+    # Token usage metrics should be set in both modes
+    assert span.attributes.get("gen_ai.usage.prompt_tokens") == 12
+    assert span.attributes.get("gen_ai.usage.completion_tokens") == 18
+    assert span.attributes.get("gen_ai.usage.total_tokens") == 30
+
+
+@pytest.mark.parametrize("use_legacy_attributes", [True, False])
+def test_meta_completion(exporter, use_legacy_attributes):
+    """Test Meta completion in both legacy and event-based modes."""
+    Config.use_legacy_attributes = use_legacy_attributes
+
+    prompt = "Tell me a joke about OpenTelemetry"
+    generation = (
+        "Why did the OpenTelemetry trace cross the road? To reach the other service!"
+    )
+
+    with patch("botocore.client.BaseClient._make_api_call") as mock_api:
+        mock_api.return_value = mock_bedrock_response(
+            {"generation": generation},
+            "meta.llama2",
+            {"input": 14, "output": 22},
+        )
+
+        client = MagicMock()
+        client.invoke_model(
+            body=json.dumps(
+                {
+                    "prompt": prompt,
+                    "max_gen_len": 100,
+                    "temperature": 0.7,
+                    "top_p": 0.8,
+                }
+            ),
+            modelId="meta.llama2",
+        )
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+
+    if use_legacy_attributes:
+        # Check legacy attribute-based instrumentation
+        assert span.attributes.get("gen_ai.prompt.0.content") == prompt
+        assert span.attributes.get("gen_ai.prompt.0.role") == "user"
+        assert span.attributes.get("gen_ai.completion.0.content") == generation
+        assert span.attributes.get("gen_ai.completion.0.role") == "assistant"
+    else:
+        # Check event-based instrumentation
+        prompt_event = find_event(span, "prompt")
+        assert prompt_event is not None
+        assert prompt_event.attributes["llm.prompt.content"] == prompt
+
+        completion_event = find_event(span, "completion")
+        assert completion_event is not None
+        assert completion_event.attributes["llm.completion.content"] == generation
+        assert completion_event.attributes["llm.completion.role"] == "assistant"
+
+    # Token usage metrics should be set in both modes
+    assert span.attributes.get("gen_ai.usage.prompt_tokens") == 14
+    assert span.attributes.get("gen_ai.usage.completion_tokens") == 22
+    assert span.attributes.get("gen_ai.usage.total_tokens") == 36
+
+
+@pytest.mark.parametrize("use_legacy_attributes", [True, False])
+def test_ai21_completion(exporter, use_legacy_attributes):
+    """Test AI21 completion in both legacy and event-based modes."""
+    Config.use_legacy_attributes = use_legacy_attributes
+
+    prompt = "Tell me a joke about OpenTelemetry"
+    completions = [
+        "Why did the OpenTelemetry trace cross the road?",
+        "To reach the other service!",
+    ]
+
+    with patch("botocore.client.BaseClient._make_api_call") as mock_api:
+        mock_api.return_value = mock_bedrock_response(
+            {"completions": completions},
+            "ai21.j2-ultra",
+            {"input": 16, "output": 24},
+        )
+
+        client = MagicMock()
+        client.invoke_model(
+            body=json.dumps(
+                {
+                    "prompt": prompt,
+                    "maxTokens": 100,
+                    "temperature": 0.7,
+                    "topP": 0.8,
+                }
+            ),
+            modelId="ai21.j2-ultra",
+        )
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+
+    if use_legacy_attributes:
+        # Check legacy attribute-based instrumentation
+        assert span.attributes.get("gen_ai.prompt.0.user") == prompt
+        for i, text in enumerate(completions):
+            assert span.attributes.get(f"gen_ai.completion.{i}.content") == text
+    else:
+        # Check event-based instrumentation
+        prompt_event = find_event(span, "prompt")
+        assert prompt_event is not None
+        assert prompt_event.attributes["llm.prompt.content"] == prompt
+
+        for i, text in enumerate(completions):
+            completion_event = find_event(span, "completion")
+            assert completion_event is not None
+            assert completion_event.attributes["llm.completion.content"] == text
+            assert completion_event.attributes["llm.completion.index"] == i
+
+    # Token usage metrics should be set in both modes
+    assert span.attributes.get("gen_ai.usage.prompt_tokens") == 16
+    assert span.attributes.get("gen_ai.usage.completion_tokens") == 24
+    assert span.attributes.get("gen_ai.usage.total_tokens") == 40


### PR DESCRIPTION
This PR adds support for event-based instrumentation to the Bedrock package, while maintaining backward compatibility with the existing attribute-based approach.

## Changes
- Add use_legacy_attributes config option (defaults to true)
- Add event emission helpers for prompts and completions
- Update all provider span attribute setters to support both modes
- Add tests for both legacy and event-based modes
- Update README with documentation

## Testing
Added comprehensive tests that verify both legacy and event-based modes for all providers:
- Cohere
- Anthropic
- AI21
- Meta
- Amazon

Each provider is tested with both completion and chat-style interactions where applicable, including streaming responses.

## Documentation
Updated the README to document:
- The new use_legacy_attributes configuration option
- Both legacy and event-based semantic conventions
- Examples of using both modes