### PR TITLE
 Fix ModuleNotFoundError for weaviate.schema

### DIFF
--- a/packages/opentelemetry-instrumentation-llamaindex/pyproject.toml
+++ b/packages/opentelemetry-instrumentation-llamaindex/pyproject.toml
@@ -8,7 +8,7 @@ show_missing = true
 
 [tool.poetry]
 name = "opentelemetry-instrumentation-llamaindex"
-version = "0.36.1"
+version = "0.38.0"
 description = "OpenTelemetry LlamaIndex instrumentation"
 authors = [
   "Gal Kleinman <gal@traceloop.com>",
@@ -27,18 +27,18 @@ python = ">=3.9,<4"
 opentelemetry-api = "^1.28.0"
 opentelemetry-instrumentation = ">=0.50b0"
 opentelemetry-semantic-conventions = ">=0.50b0"
-opentelemetry-semantic-conventions-ai = "0.4.2"
+opentelemetry-semantic-conventions-ai = "0.4.3"
 inflection = "^0.5.1"
 
 [tool.poetry.group.dev.dependencies]
 autopep8 = "^2.2.0"
-flake8 = "7.0.0"
+flake8 = "7.1.1"
 
 [tool.poetry.group.test.dependencies]
-vcrpy = "^6.0.1"
+vcrpy = ">=6.0.1,<8.0.0"
 pytest-recording = "^0.13.1"
-pytest-asyncio = "^0.23.7"
-chromadb = "^0.5.23"
+pytest-asyncio = ">=0.23.7,<0.26.0"
+chromadb = ">=0.5.23,<0.7.0"
 openai = "^1.52.2"
 opentelemetry-sdk = "^1.27.0"
 llama-index = "^0.12.6"
@@ -51,7 +51,7 @@ llama-index-agent-openai = "^0.4.1"
 llama-index-vector-stores-chroma = "^0.4.1"
 llama-index-llms-cohere = "^0.4.0"
 llama-index-embeddings-openai = "^0.3.1"
-onnxruntime = "<1.20.0"
+onnxruntime = "<1.21.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
**### This pull request fixes the ModuleNotFoundError for weaviate.schema by updating the import statements and adding error handling to ensure the module is correctly imported.**

_Changes:
Updated packages/opentelemetry-instrumentation-weaviate/opentelemetry/instrumentation/weaviate/__init__.py to handle import errors and log them appropriately.

Issue: Closes #2535_