### PR TITLE
fix(sdk): When tracing task with no `name` provided , use qualified name instaed of name

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/decorators/base.py
+++ b/packages/traceloop-sdk/traceloop/sdk/decorators/base.py
@@ -258,7 +258,7 @@ def entity_class(
     tlp_span_kind: Optional[TraceloopSpanKindValues] = TraceloopSpanKindValues.TASK,
 ):
     def decorator(cls):
-        task_name = name if name else camel_to_snake(cls.__name__)
+        task_name = name if name else camel_to_snake(cls.__qualname__)
         method = getattr(cls, method_name)
         setattr(
             cls,

--- a/packages/traceloop-sdk/traceloop/sdk/decorators/base.py
+++ b/packages/traceloop-sdk/traceloop/sdk/decorators/base.py
@@ -185,7 +185,7 @@ def entity_method(
 ):
     def decorate(fn):
         is_async = _is_async_method(fn)
-        entity_name = name or fn.__name__
+        entity_name = name or fn.__qualname__
         if is_async:
             if inspect.isasyncgenfunction(fn):
                 @wraps(fn)


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [X] I have added tests that cover my changes.
- [X] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [V] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [V] (If applicable) I have updated the documentation accordingly.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use `fn.__qualname__` instead of `fn.__name__` in `entity_method` for unnamed tasks in `base.py`.
> 
>   - **Behavior**:
>     - In `entity_method` in `base.py`, use `fn.__qualname__` instead of `fn.__name__` when `name` is not provided.
>     - Affects tracing by using the qualified name for unnamed tasks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 368a40f1193d18ad44ec3fc3c3007e19dce9ec43. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->