### PR TITLE
fix(sdk): client shouldn't be initialized if destination is not traceloop

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/__init__.py
+++ b/packages/traceloop-sdk/traceloop/sdk/__init__.py
@@ -87,19 +87,6 @@ class Traceloop:
         api_key = os.getenv("TRACELOOP_API_KEY") or api_key
         Traceloop.__app_name = app_name
 
-        if (
-            traceloop_sync_enabled
-            and api_endpoint.find("traceloop.com") != -1
-            and api_key
-            and (exporter is None)
-            and (processor is None)
-        ):
-            Traceloop.__fetcher = Fetcher(base_url=api_endpoint, api_key=api_key)
-            Traceloop.__fetcher.run()
-            print(
-                Fore.GREEN + "Traceloop syncing configuration and prompts" + Fore.RESET
-            )
-
         if not is_tracing_enabled():
             print(Fore.YELLOW + "Tracing is disabled" + Fore.RESET)
             return
@@ -190,10 +177,24 @@ class Traceloop:
             )
             Traceloop.__logger_wrapper = LoggerWrapper(exporter=logging_exporter)
 
-        if not api_key:
-            return
-        Traceloop.__client = Client(api_key=api_key, app_name=app_name, api_endpoint=api_endpoint)
-        return Traceloop.__client
+        if (
+            api_endpoint.find("traceloop.com") != -1
+            and api_key
+            and (exporter is None)
+            and (processor is None)
+        ):
+            if traceloop_sync_enabled:
+                Traceloop.__fetcher = Fetcher(base_url=api_endpoint, api_key=api_key)
+                Traceloop.__fetcher.run()
+                print(
+                    Fore.GREEN
+                    + "Traceloop syncing configuration and prompts"
+                    + Fore.RESET
+                )
+            Traceloop.__client = Client(
+                api_key=api_key, app_name=app_name, api_endpoint=api_endpoint
+            )
+            return Traceloop.__client
 
     def set_association_properties(properties: dict) -> None:
         set_association_properties(properties)


### PR DESCRIPTION
Fixes #2732 

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [ ] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Modifies `Traceloop` client initialization in `__init__.py` to occur only when the destination is Traceloop, addressing issue #2732.
> 
>   - **Behavior**:
>     - Modifies `init()` in `__init__.py` to initialize `Traceloop.__client` only if `api_endpoint` contains "traceloop.com", `api_key` is provided, and both `exporter` and `processor` are `None`.
>     - Moves `Traceloop.__fetcher` initialization inside the same condition, ensuring it only runs when `traceloop_sync_enabled` is `True`.
>   - **Misc**:
>     - Removes redundant client initialization logic from previous location in `init()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for acf0df5d9665ed7f36229945f473e059c09541fe. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->