### PR TITLE
Fix dataclass serialization in workflows and tasks

### DIFF
--- a/packages/traceloop-sdk/tests/test_tasks.py
+++ b/packages/traceloop-sdk/tests/test_tasks.py
@@ -138,7 +138,7 @@ def test_dataclass_serialization_task(exporter):
         return data
 
     data = TestDataClass(field1="value1", field2=123)
-    result = dataclass_task(data)
+    dataclass_task(data)
 
     spans = exporter.get_finished_spans()
     assert [span.name for span in spans] == ["dataclass_task.task"]

--- a/packages/traceloop-sdk/tests/test_workflows.py
+++ b/packages/traceloop-sdk/tests/test_workflows.py
@@ -474,7 +474,7 @@ def test_dataclass_serialization_workflow(exporter):
         return dataclass_task(data)
 
     data = TestDataClass(field1="value1", field2=123)
-    result = dataclass_workflow(data)
+    dataclass_workflow(data)
 
     spans = exporter.get_finished_spans()
     assert [span.name for span in spans] == ["dataclass_task.task", "dataclass_workflow.workflow"]


### PR DESCRIPTION
Fixes #2320

Add test cases for dataclass serialization in workflows and tasks.

* **Test Workflows**: Add a new test case `test_dataclass_serialization_workflow` in `packages/traceloop-sdk/tests/test_workflows.py` to verify dataclass serialization in workflows.
* **Test Tasks**: Add a new test case `test_dataclass_serialization_task` in `packages/traceloop-sdk/tests/test_tasks.py` to verify dataclass serialization in tasks.
* **Dataclass Definition**: Define a `TestDataClass` dataclass used in the new test cases.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/traceloop/openllmetry/pull/2800?shareId=e6caec68-eb33-4f4d-bbdc-6e0a118b2956).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add test cases for dataclass serialization in workflows and tasks using `TestDataClass`.
> 
>   - **Test Cases**:
>     - Add `test_dataclass_serialization_workflow` in `test_workflows.py` to verify dataclass serialization in workflows.
>     - Add `test_dataclass_serialization_task` in `test_tasks.py` to verify dataclass serialization in tasks.
>   - **Dataclass**:
>     - Define `TestDataClass` with fields `field1` and `field2` for use in test cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 612c918dcee61b85ae8b59ed38800e7bb6bbd80c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->