### PR TITLE
Add support for OpenAI's batch completions API

### DIFF
--- a/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/__init__.py
+++ b/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/__init__.py
@@ -44,6 +44,14 @@ class OpenAIInstrumentor(BaseInstrumentor):
 
             OpenAIV0Instrumentor().instrument(**kwargs)
 
+        from opentelemetry.instrumentation.openai.shared.completion_wrappers import (
+            batch_completion_wrapper,
+            abatch_completion_wrapper,
+        )
+
+        wrap_function_wrapper("openai", "BatchCompletion.create", batch_completion_wrapper(tracer))
+        wrap_function_wrapper("openai", "BatchCompletion.acreate", abatch_completion_wrapper(tracer))
+
     def _uninstrument(self, **kwargs):
         if is_openai_v1():
             from opentelemetry.instrumentation.openai.v1 import OpenAIV1Instrumentor
@@ -53,3 +61,6 @@ class OpenAIInstrumentor(BaseInstrumentor):
             from opentelemetry.instrumentation.openai.v0 import OpenAIV0Instrumentor
 
             OpenAIV0Instrumentor().uninstrument(**kwargs)
+
+        unwrap_function_wrapper("openai", "BatchCompletion.create")
+        unwrap_function_wrapper("openai", "BatchCompletion.acreate")

--- a/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/shared/completion_wrappers.py
+++ b/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/shared/completion_wrappers.py
@@ -101,6 +101,58 @@ async def acompletion_wrapper(tracer, wrapped, instance, args, kwargs):
     return response
 
 
+@_with_tracer_wrapper
+def batch_completion_wrapper(tracer, wrapped, instance, args, kwargs):
+    if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY) or context_api.get_value(
+        SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY
+    ):
+        return wrapped(*args, **kwargs)
+
+    span = tracer.start_span(
+        SPAN_NAME,
+        kind=SpanKind.CLIENT,
+        attributes={SpanAttributes.LLM_REQUEST_TYPE: LLM_REQUEST_TYPE.value},
+    )
+
+    _handle_request(span, kwargs, instance)
+    try:
+        response = wrapped(*args, **kwargs)
+    except Exception as e:
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        span.end()
+        raise e
+
+    _handle_response(response, span)
+    span.end()
+    return response
+
+
+@_with_tracer_wrapper
+async def abatch_completion_wrapper(tracer, wrapped, instance, args, kwargs):
+    if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY) or context_api.get_value(
+        SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY
+    ):
+        return await wrapped(*args, **kwargs)
+
+    span = tracer.start_span(
+        name=SPAN_NAME,
+        kind=SpanKind.CLIENT,
+        attributes={SpanAttributes.LLM_REQUEST_TYPE: LLM_REQUEST_TYPE.value},
+    )
+
+    _handle_request(span, kwargs, instance)
+    try:
+        response = await wrapped(*args, **kwargs)
+    except Exception as e:
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        span.end()
+        raise e
+
+    _handle_response(response, span)
+    span.end()
+    return response
+
+
 @dont_throw
 def _handle_request(span, kwargs, instance):
     _set_request_attributes(span, kwargs)

--- a/packages/opentelemetry-instrumentation-openai/tests/traces/test_completions.py
+++ b/packages/opentelemetry-instrumentation-openai/tests/traces/test_completions.py
@@ -202,3 +202,64 @@ async def test_async_completion_context_propagation(exporter, async_vllm_openai_
 
     assert_request_contains_tracecontext(request, openai_span)
     assert openai_span.attributes.get("gen_ai.response.id") == "cmpl-4acc6171f6c34008af07ca8490da3b95"
+
+
+@pytest.mark.vcr
+def test_batch_completion(exporter, openai_client):
+    openai_client.batch_completions.create(
+        model="davinci-002",
+        prompts=["Tell me a joke about opentelemetry", "Tell me a joke about Python"],
+    )
+
+    spans = exporter.get_finished_spans()
+    assert [span.name for span in spans] == [
+        "openai.completion",
+    ]
+    open_ai_span = spans[0]
+    assert (
+        open_ai_span.attributes[f"{SpanAttributes.LLM_PROMPTS}.0.user"]
+        == "Tell me a joke about opentelemetry"
+    )
+    assert (
+        open_ai_span.attributes[f"{SpanAttributes.LLM_PROMPTS}.1.user"]
+        == "Tell me a joke about Python"
+    )
+    assert open_ai_span.attributes.get(f"{SpanAttributes.LLM_COMPLETIONS}.0.content")
+    assert open_ai_span.attributes.get(f"{SpanAttributes.LLM_COMPLETIONS}.1.content")
+    assert (
+        open_ai_span.attributes.get(SpanAttributes.LLM_OPENAI_API_BASE)
+        == "https://api.openai.com/v1/"
+    )
+    assert open_ai_span.attributes.get(SpanAttributes.LLM_IS_STREAMING) is False
+    assert open_ai_span.attributes.get("gen_ai.response.id") == "cmpl-8wq42D1Socatcl1rCmgYZOFX7dFZw"
+
+
+@pytest.mark.vcr
+@pytest.mark.asyncio
+async def test_async_batch_completion(exporter, async_openai_client):
+    await async_openai_client.batch_completions.create(
+        model="davinci-002",
+        prompts=["Tell me a joke about opentelemetry", "Tell me a joke about Python"],
+    )
+
+    spans = exporter.get_finished_spans()
+    assert [span.name for span in spans] == [
+        "openai.completion",
+    ]
+    open_ai_span = spans[0]
+    assert (
+        open_ai_span.attributes[f"{SpanAttributes.LLM_PROMPTS}.0.user"]
+        == "Tell me a joke about opentelemetry"
+    )
+    assert (
+        open_ai_span.attributes[f"{SpanAttributes.LLM_PROMPTS}.1.user"]
+        == "Tell me a joke about Python"
+    )
+    assert open_ai_span.attributes.get(f"{SpanAttributes.LLM_COMPLETIONS}.0.content")
+    assert open_ai_span.attributes.get(f"{SpanAttributes.LLM_COMPLETIONS}.1.content")
+    assert (
+        open_ai_span.attributes.get(SpanAttributes.LLM_OPENAI_API_BASE)
+        == "https://api.openai.com/v1/"
+    )
+    assert open_ai_span.attributes.get(SpanAttributes.LLM_IS_STREAMING) is False
+    assert open_ai_span.attributes.get("gen_ai.response.id") == "cmpl-8wq43c8U5ZZCQBX5lrSpsANwcd3OF"


### PR DESCRIPTION
Fixes #1689

Add support for OpenAI's batch completions API in the OpenAI Instrumentation.

* **Instrumentation Changes**
  - Add support for batch completions in `OpenAIInstrumentor` class in `__init__.py`.
  - Update `_instrument` and `_uninstrument` methods to handle batch completions.
  - Import and wrap `batch_completion_wrapper` and `abatch_completion_wrapper` functions.

* **Wrapper Functions**
  - Add `batch_completion_wrapper` function to handle batch completion requests in `completion_wrappers.py`.
  - Add `abatch_completion_wrapper` function to handle async batch completion requests.

* **Tests**
  - Add `test_batch_completion` function to test batch completions in `test_completions.py`.
  - Add `test_async_batch_completion` function to test async batch completions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/traceloop/openllmetry/pull/2802?shareId=9d76d403-7ff5-4e72-ba9a-ed4949779b16).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for OpenAI's batch completions API in the OpenAI Instrumentation, including new wrapper functions and tests.
> 
>   - **Instrumentation Changes**:
>     - Add support for batch completions in `OpenAIInstrumentor` class in `__init__.py`.
>     - Update `_instrument` and `_uninstrument` methods to handle batch completions.
>     - Import and wrap `batch_completion_wrapper` and `abatch_completion_wrapper` functions.
>   - **Wrapper Functions**:
>     - Add `batch_completion_wrapper` function to handle batch completion requests in `completion_wrappers.py`.
>     - Add `abatch_completion_wrapper` function to handle async batch completion requests.
>   - **Tests**:
>     - Add `test_batch_completion` function to test batch completions in `test_completions.py`.
>     - Add `test_async_batch_completion` function to test async batch completions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 07a3e8c54160a61ae48d416ad8971cf95e7075c7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->