### PR TITLE
fix(ci-cd): add mcp to commitizen

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -6,6 +6,8 @@ major_version_zero = true
 update_changelog_on_bump = true
 version = "0.40.0"
 version_files = [
+    "packages/opentelemetry-instrumentation-mcp/pyproject.toml:^version",
+    "packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/version.py",
     "packages/opentelemetry-instrumentation-groq/pyproject.toml:^version",
     "packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/version.py",
     "packages/opentelemetry-instrumentation-alephalpha/pyproject.toml:^version",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add MCP package to version tracking in `.cz.toml`.
> 
>   - **Configuration**:
>     - Add `packages/opentelemetry-instrumentation-mcp/pyproject.toml:^version` and `packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/version.py` to `version_files` in `.cz.toml` for version tracking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 308ce647da669003787af08400b1331ead8b4fa4. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->