### PR TITLE
fix(MCP): Added error status to traces in MCP server for tool calls

### DIFF
--- a/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
+++ b/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
@@ -251,7 +251,7 @@ class InstrumentedStreamWriter(ObjectProxy):  # type: ignore
                     SpanAttributes.MCP_RESPONSE_VALUE, f"{serialize(request.result)}"
                 )
                 if hasattr(request.result, "isError"):
-                    if request.result.isError == True:
+                    if request.result.isError is True:
                         span.set_status(
                             Status(StatusCode.ERROR, f"{serialize(request.result)}")
                         )

--- a/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
+++ b/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
@@ -251,9 +251,10 @@ class InstrumentedStreamWriter(ObjectProxy):  # type: ignore
                     SpanAttributes.MCP_RESPONSE_VALUE, f"{serialize(request.result)}"
                 )
                 if hasattr(request.result, "isError"):
-                    span.set_status(
-                        Status(StatusCode.ERROR, f"{serialize(request.result)}")
-                    )
+                    if request.result.isError == True:
+                        span.set_status(
+                            Status(StatusCode.ERROR, f"{serialize(request.result)}")
+                        )
             if hasattr(request, "id"):
                 span.set_attribute(SpanAttributes.MCP_REQUEST_ID, f"{request.id}")
 

--- a/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
+++ b/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
@@ -250,6 +250,10 @@ class InstrumentedStreamWriter(ObjectProxy):  # type: ignore
                 span.set_attribute(
                     SpanAttributes.MCP_RESPONSE_VALUE, f"{serialize(request.result)}"
                 )
+                if hasattr(request.result, "isError"):
+                    span.set_status(
+                        Status(StatusCode.ERROR, f"{serialize(request.result)}")
+                    )
             if hasattr(request, "id"):
                 span.set_attribute(SpanAttributes.MCP_REQUEST_ID, f"{request.id}")
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [x] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
This PR aims to add trace status for failed error calls. This helps in grouping error calls by nature of failures.

<img width="1726" alt="Screenshot 2025-05-09 at 1 02 14 PM" src="https://github.com/user-attachments/assets/7e586f3a-beb4-4396-bd40-aa820cd4cd55" />
