### PR TITLE
fix(sdk): Ensure instrumentors don’t report successful init if package isn’t installed

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
+++ b/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
@@ -143,19 +143,12 @@ class TracerWrapper(object):
             # this makes sure otel context is propagated so we always want it
             ThreadingInstrumentor().instrument()
 
-            instrument_set = init_instrumentations(
+            init_instrumentations(
                 should_enrich_metrics,
                 image_uploader.aupload_base64_image,
                 instruments,
                 block_instruments,
             )
-
-            if not instrument_set:
-                print(
-                    Fore.RED + "Warning: No valid instruments set. Remove 'instrument' "
-                    "argument to use all instruments, or set a valid instrument."
-                )
-                print(Fore.RESET)
 
             obj.__content_allow_list = ContentAllowList()
 

--- a/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
+++ b/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
@@ -510,12 +510,12 @@ def init_openai_instrumentor(
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
 
     except Exception as e:
         logging.error(f"Error initializing OpenAI instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_anthropic_instrumentor(
@@ -534,11 +534,11 @@ def init_anthropic_instrumentor(
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing Anthropic instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_cohere_instrumentor():
@@ -552,11 +552,11 @@ def init_cohere_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing Cohere instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_pinecone_instrumentor():
@@ -570,11 +570,11 @@ def init_pinecone_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing Pinecone instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_qdrant_instrumentor():
@@ -588,10 +588,11 @@ def init_qdrant_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
+            return True
     except Exception as e:
         logging.error(f"Error initializing Qdrant instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_chroma_instrumentor():
@@ -605,11 +606,11 @@ def init_chroma_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing Chroma instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_google_generativeai_instrumentor():
@@ -625,11 +626,11 @@ def init_google_generativeai_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing Gemini instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_haystack_instrumentor():
@@ -643,11 +644,11 @@ def init_haystack_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing Haystack instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_langchain_instrumentor():
@@ -661,11 +662,11 @@ def init_langchain_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing LangChain instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_mistralai_instrumentor():
@@ -679,11 +680,11 @@ def init_mistralai_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing MistralAI instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_ollama_instrumentor():
@@ -697,11 +698,11 @@ def init_ollama_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing Ollama instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_transformers_instrumentor():
@@ -717,11 +718,11 @@ def init_transformers_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing Transformers instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_together_instrumentor():
@@ -735,11 +736,11 @@ def init_together_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing TogetherAI instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_llama_index_instrumentor():
@@ -753,11 +754,11 @@ def init_llama_index_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing LlamaIndex instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_milvus_instrumentor():
@@ -771,11 +772,11 @@ def init_milvus_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing Milvus instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_requests_instrumentor():
@@ -786,11 +787,11 @@ def init_requests_instrumentor():
             instrumentor = RequestsInstrumentor()
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument(excluded_urls=EXCLUDED_URLS)
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing Requests instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_urllib3_instrumentor():
@@ -801,11 +802,11 @@ def init_urllib3_instrumentor():
             instrumentor = URLLib3Instrumentor()
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument(excluded_urls=EXCLUDED_URLS)
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing urllib3 instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_pymysql_instrumentor():
@@ -816,11 +817,11 @@ def init_pymysql_instrumentor():
             instrumentor = SQLAlchemyInstrumentor()
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing SQLAlchemy instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_bedrock_instrumentor(should_enrich_metrics: bool):
@@ -834,11 +835,11 @@ def init_bedrock_instrumentor(should_enrich_metrics: bool):
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing Bedrock instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_sagemaker_instrumentor(should_enrich_metrics: bool):
@@ -852,11 +853,11 @@ def init_sagemaker_instrumentor(should_enrich_metrics: bool):
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing SageMaker instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_replicate_instrumentor():
@@ -870,11 +871,11 @@ def init_replicate_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing Replicate instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_vertexai_instrumentor():
@@ -888,11 +889,11 @@ def init_vertexai_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.warning(f"Error initializing Vertex AI instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_watsonx_instrumentor():
@@ -908,11 +909,11 @@ def init_watsonx_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.warning(f"Error initializing Watsonx instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_weaviate_instrumentor():
@@ -926,11 +927,11 @@ def init_weaviate_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.warning(f"Error initializing Weaviate instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_alephalpha_instrumentor():
@@ -944,11 +945,11 @@ def init_alephalpha_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing Aleph Alpha instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_marqo_instrumentor():
@@ -962,11 +963,11 @@ def init_marqo_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing marqo instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_lancedb_instrumentor():
@@ -980,9 +981,11 @@ def init_lancedb_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing LanceDB instrumentor: {e}")
+        Telemetry().log_exception(e)
+    return False
 
 
 def init_redis_instrumentor():
@@ -993,11 +996,11 @@ def init_redis_instrumentor():
             instrumentor = RedisInstrumentor()
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument(excluded_urls=EXCLUDED_URLS)
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing redis instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_groq_instrumentor():
@@ -1011,11 +1014,11 @@ def init_groq_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing Groq instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_crewai_instrumentor():
@@ -1029,11 +1032,11 @@ def init_crewai_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing CrewAI instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def init_mcp_instrumentor():
@@ -1047,11 +1050,11 @@ def init_mcp_instrumentor():
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
-        return True
+            return True
     except Exception as e:
         logging.error(f"Error initializing MCP instrumentor: {e}")
         Telemetry().log_exception(e)
-        return False
+    return False
 
 
 def metrics_common_attributes():

--- a/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
+++ b/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
@@ -479,7 +479,8 @@ def init_instrumentations(
         print(
             Fore.RED
             + "Warning: No valid instruments set. "
-            + "Specify instruments or remove 'instruments' argument to use all instruments."
+            + "Ensure the instrumented libraries are installed, specify valid instruments, "
+            + "or remove 'instruments' argument to use all instruments."
         )
         print(Fore.RESET)
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.


Fixes #3042 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure instrumentors in `tracing.py` don't report successful initialization if the package isn't installed, updating `init_*_instrumentor()` functions accordingly.
> 
>   - **Behavior**:
>     - Ensure instrumentors in `tracing.py` don't report successful initialization if the package isn't installed.
>     - Modify `init_instrumentations()` to print a warning if no valid instruments are set.
>   - **Functions**:
>     - Update `init_openai_instrumentor()`, `init_anthropic_instrumentor()`, `init_cohere_instrumentor()`, and 20 other `init_*_instrumentor()` functions to return `True` only if the package is installed and instrumented.
>     - Remove redundant `instrument_set` check in `wrapped_on_end()` in `tracing.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 78aa8a7fa611fb06e793032d374eda420a4a9a8c. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->