### PR TITLE
fix: google gemini insturmentation

### DIFF
--- a/packages/opentelemetry-instrumentation-google-generativeai/opentelemetry/instrumentation/google_generativeai/__init__.py
+++ b/packages/opentelemetry-instrumentation-google-generativeai/opentelemetry/instrumentation/google_generativeai/__init__.py
@@ -287,7 +287,7 @@ async def _awrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         name,
         kind=SpanKind.CLIENT,
         attributes={
-            SpanAttributes.LLM_SYSTEM: "Gemini",
+            SpanAttributes.LLM_SYSTEM: "Google",
             SpanAttributes.LLM_REQUEST_TYPE: LLMRequestTypeValues.COMPLETION.value,
         },
     )
@@ -333,7 +333,7 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         name,
         kind=SpanKind.CLIENT,
         attributes={
-            SpanAttributes.LLM_SYSTEM: "Gemini",
+            SpanAttributes.LLM_SYSTEM: "Google",
             SpanAttributes.LLM_REQUEST_TYPE: LLMRequestTypeValues.COMPLETION.value,
         },
     )
@@ -362,17 +362,17 @@ class GoogleGenerativeAiInstrumentor(BaseInstrumentor):
         Config.exception_logger = exception_logger
 
     def instrumentation_dependencies(self) -> Collection[str]:
-        if is_package_installed("google-genai"):
+        if is_package_installed("google.genai"):
             return ("google-genai >= 0.1.0",)
-        elif is_package_installed("google-generativeai"):
+        elif is_package_installed("google.generativeai"):
             return ["google-generativeai >= 0.5.0"]
         else:
             return []
 
     def _wrapped_methods(self):
-        if is_package_installed("google-genai"):
+        if is_package_installed("google.genai"):
             return WRAPPED_METHODS
-        elif is_package_installed("google-generativeai"):
+        elif is_package_installed("google.generativeai"):
             return LEGACY_WRAPPED_METHODS
         else:
             return []

--- a/packages/opentelemetry-instrumentation-vertexai/opentelemetry/instrumentation/vertexai/__init__.py
+++ b/packages/opentelemetry-instrumentation-vertexai/opentelemetry/instrumentation/vertexai/__init__.py
@@ -283,7 +283,7 @@ async def _awrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         name,
         kind=SpanKind.CLIENT,
         attributes={
-            SpanAttributes.LLM_SYSTEM: "VertexAI",
+            SpanAttributes.LLM_SYSTEM: "Google",
             SpanAttributes.LLM_REQUEST_TYPE: LLMRequestTypeValues.COMPLETION.value,
         },
     )
@@ -323,7 +323,7 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         name,
         kind=SpanKind.CLIENT,
         attributes={
-            SpanAttributes.LLM_SYSTEM: "VertexAI",
+            SpanAttributes.LLM_SYSTEM: "Google",
             SpanAttributes.LLM_REQUEST_TYPE: LLMRequestTypeValues.COMPLETION.value,
         },
     )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix instrumentation by updating `SpanAttributes.LLM_SYSTEM` to "Google" and correcting package names in Google Generative AI and Vertex AI.
> 
>   - **Behavior**:
>     - Change `SpanAttributes.LLM_SYSTEM` from "Gemini" and "VertexAI" to "Google" in `_awrap()` and `_wrap()` in `google_generativeai/__init__.py` and `vertexai/__init__.py`.
>     - Update package checks from `"google-genai"` and `"google-generativeai"` to `"google.genai"` and `"google.generativeai"` in `GoogleGenerativeAiInstrumentor`.
>   - **Misc**:
>     - No changes to logic or functionality beyond string replacements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 03df986241dd0873f989c449fdb8c26fd305cabb. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->