### PR TITLE
fix vertexai should_send_prompts

### DIFF
--- a/packages/opentelemetry-instrumentation-vertexai/opentelemetry/instrumentation/vertexai/__init__.py
+++ b/packages/opentelemetry-instrumentation-vertexai/opentelemetry/instrumentation/vertexai/__init__.py
@@ -195,11 +195,12 @@ def _set_response_attributes(span, llm_model, generation_text, token_usage):
         )
 
     _set_span_attribute(span, f"{SpanAttributes.LLM_COMPLETIONS}.0.role", "assistant")
-    _set_span_attribute(
-        span,
-        f"{SpanAttributes.LLM_COMPLETIONS}.0.content",
-        generation_text,
-    )
+    if should_send_prompts():
+        _set_span_attribute(
+            span,
+            f"{SpanAttributes.LLM_COMPLETIONS}.0.content",
+            generation_text,
+        )
 
 
 def _build_from_streaming_response(span, response, llm_model):

--- a/packages/opentelemetry-instrumentation-vertexai/opentelemetry/instrumentation/vertexai/__init__.py
+++ b/packages/opentelemetry-instrumentation-vertexai/opentelemetry/instrumentation/vertexai/__init__.py
@@ -194,8 +194,8 @@ def _set_response_attributes(span, llm_model, generation_text, token_usage):
             token_usage.prompt_token_count,
         )
 
-    _set_span_attribute(span, f"{SpanAttributes.LLM_COMPLETIONS}.0.role", "assistant")
     if should_send_prompts():
+        _set_span_attribute(span, f"{SpanAttributes.LLM_COMPLETIONS}.0.role", "assistant")
         _set_span_attribute(
             span,
             f"{SpanAttributes.LLM_COMPLETIONS}.0.content",


### PR DESCRIPTION
I found that `TRACELOOP_TRACE_CONTENT` doesn't work on VertexAI instrument.

```json
{
  "gen_ai": {
    "completion": [
      {
        "content": "...my prompt..",
        "role": "assistant"
      }
    ],
...
```

so i added if statement before setting generation_text.

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [ ] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a conditional check in `_set_response_attributes()` to set content attribute only if `should_send_prompts()` returns true.
> 
>   - **Behavior**:
>     - Adds a conditional check in `_set_response_attributes()` in `__init__.py` to set `LLM_COMPLETIONS.0.content` only if `should_send_prompts()` returns true.
>   - **Functions**:
>     - `should_send_prompts()` checks `TRACELOOP_TRACE_CONTENT` environment variable or context value to determine if prompts should be sent.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for acc61b0407118d0d0b0c43a50f7e10eaa49146a8. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->