### PR TITLE
chore(openai): dont actually poll in assistant tests

### DIFF
--- a/packages/opentelemetry-instrumentation-openai/tests/traces/test_assistant.py
+++ b/packages/opentelemetry-instrumentation-openai/tests/traces/test_assistant.py
@@ -285,6 +285,9 @@ def test_new_assistant_with_polling(
         thread_id=thread.id,
         assistant_id=assistant.id,
         instructions="Please address the user as Jane Doe. The user has a premium account.",
+        # Original test waited for much longer, but now that we have VCR cassetes recorded,
+        # we don't need to wait
+        poll_interval_ms=20,
     )
 
     messages = openai_client.beta.threads.messages.list(
@@ -362,6 +365,9 @@ def test_new_assistant_with_polling_with_events_with_content(
         thread_id=thread.id,
         assistant_id=assistant.id,
         instructions="Please address the user as Jane Doe. The user has a premium account.",
+        # Original test waited for much longer, but now that we have VCR cassetes recorded,
+        # we don't need to wait
+        poll_interval_ms=20,
     )
 
     messages = openai_client.beta.threads.messages.list(
@@ -435,6 +441,9 @@ def test_new_assistant_with_polling_with_events_with_no_content(
         thread_id=thread.id,
         assistant_id=assistant.id,
         instructions="Please address the user as Jane Doe. The user has a premium account.",
+        # Original test waited for much longer, but now that we have VCR cassetes recorded,
+        # we don't need to wait
+        poll_interval_ms=20,
     )
 
     openai_client.beta.threads.messages.list(thread_id=thread.id, order="asc")


### PR DESCRIPTION
It was a little annoying to have to exclude assistant tests every time I made changes, so I did this :)

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [X] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reduce polling interval in assistant tests to 20ms using VCR cassettes for faster execution.
> 
>   - **Behavior**:
>     - Reduce `poll_interval_ms` to 20ms in `test_new_assistant_with_polling`, `test_new_assistant_with_polling_with_events_with_content`, and `test_new_assistant_with_polling_with_events_with_no_content` in `test_assistant.py`.
>     - Original tests had longer wait times, now reduced due to VCR cassettes.
>   - **Misc**:
>     - Comments added to explain reduced wait times in tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 6d607e9619252e971267836156310243c4b28bf9. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->