### PR TITLE
fix(replicate): defer replicate import

### DIFF
--- a/packages/opentelemetry-instrumentation-replicate/opentelemetry/instrumentation/replicate/event_emitter.py
+++ b/packages/opentelemetry-instrumentation-replicate/opentelemetry/instrumentation/replicate/event_emitter.py
@@ -1,6 +1,6 @@
 from dataclasses import asdict
 from enum import Enum
-from typing import Union
+from typing import Union, TYPE_CHECKING
 
 from opentelemetry._events import Event, EventLogger
 from opentelemetry.instrumentation.replicate.event_models import (
@@ -16,7 +16,8 @@ from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
 
-from replicate.prediction import Prediction
+if TYPE_CHECKING:
+    from replicate.prediction import Prediction
 
 
 class Roles(Enum):
@@ -35,7 +36,7 @@ EVENT_ATTRIBUTES = {GenAIAttributes.GEN_AI_SYSTEM: "replicate"}
 
 @dont_throw
 def emit_choice_events(
-    response: Union[str, list, Prediction], event_logger: Union[EventLogger, None]
+    response: Union[str, list, "Prediction"], event_logger: Union[EventLogger, None]
 ):
     # Handle replicate.run responses
     if isinstance(response, list):
@@ -47,7 +48,7 @@ def emit_choice_events(
                 event_logger,
             )
     # Handle replicate.predictions.create responses
-    elif isinstance(response, Prediction):
+    elif isinstance(response, "Prediction"):
         emit_event(
             ChoiceEvent(
                 index=0, message={"content": response.output, "role": "assistant"}

--- a/packages/opentelemetry-instrumentation-replicate/tests/test_import.py
+++ b/packages/opentelemetry-instrumentation-replicate/tests/test_import.py
@@ -1,0 +1,7 @@
+import sys
+
+
+def test_import():
+    import opentelemetry.instrumentation.replicate  # noqa: F401
+
+    assert "replicate" not in sys.modules


### PR DESCRIPTION
xref: https://github.com/conda-forge/opentelemetry-instrumentation-replicate-feedstock/pull/20

https://github.com/traceloop/openllmetry/blob/645426360910ce56d00894fc9c7feb47d5230953/packages/opentelemetry-instrumentation-replicate/opentelemetry/instrumentation/replicate/event_emitter.py#L19

```raw
import: 'opentelemetry.instrumentation.replicate'
Traceback (most recent call last):
  File "/home/conda/feedstock_root/build_artifacts/opentelemetry-instrumentation-replicate_1752448577076/test_tmp/run_test.py", line 2, in <module>
    import opentelemetry.instrumentation.replicate
  File "/home/conda/feedstock_root/build_artifacts/opentelemetry-instrumentation-replicate_1752448577076/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.9/site-packages/opentelemetry/instrumentation/replicate/__init__.py", line 11, in <module>
    from opentelemetry.instrumentation.replicate.event_emitter import (
  File "/home/conda/feedstock_root/build_artifacts/opentelemetry-instrumentation-replicate_1752448577076/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.9/site-packages/opentelemetry/instrumentation/replicate/event_emitter.py", line 19, in <module>
    from replicate.prediction import Prediction
ModuleNotFoundError: No module named 'replicate'
```

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [x] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move `replicate` to runtime dependencies in `pyproject.toml` to fix import error.
> 
>   - **Dependency Management**:
>     - Move `replicate` from `[tool.poetry.group.dev.dependencies]` to `[tool.poetry.dependencies]` in `pyproject.toml`.
>     - Ensures `replicate` is available at runtime to prevent `ModuleNotFoundError` during import in `event_emitter.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 053b35aa2d45bf6666ca3a9ef5a5321473d171b0. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoids unintended runtime imports of optional dependencies by restricting certain imports to type-checking, improving startup reliability and compatibility.
  * Ensures import behavior doesn't introduce stray top-level modules in the runtime environment.

* **Tests**
  * Added an import-safety test to verify no unintended top-level module is created during package import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->