### PR TITLE
fix(google-generativeai): defer google-generativeai to allow omission from runtime dependencies

### DIFF
--- a/packages/opentelemetry-instrumentation-google-generativeai/opentelemetry/instrumentation/google_generativeai/__init__.py
+++ b/packages/opentelemetry-instrumentation-google-generativeai/opentelemetry/instrumentation/google_generativeai/__init__.py
@@ -2,9 +2,8 @@
 
 import logging
 import types
-from typing import Collection
+from typing import Collection, TYPE_CHECKING
 
-from google.genai.types import GenerateContentResponse
 from opentelemetry import context as context_api
 from opentelemetry._events import get_event_logger
 from opentelemetry.instrumentation.google_generativeai.config import Config
@@ -32,6 +31,10 @@ from opentelemetry.semconv_ai import (
 )
 from opentelemetry.trace import SpanKind, get_tracer
 from wrapt import wrap_function_wrapper
+
+if TYPE_CHECKING:
+    from google.genai.types import GenerateContentResponse
+
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +64,7 @@ def is_async_streaming_response(response):
 
 def _build_from_streaming_response(
     span,
-    response: GenerateContentResponse,
+    response: "GenerateContentResponse",
     llm_model,
     event_logger,
 ):
@@ -81,7 +84,7 @@ def _build_from_streaming_response(
 
 
 async def _abuild_from_streaming_response(
-    span, response: GenerateContentResponse, llm_model, event_logger
+    span, response: "GenerateContentResponse", llm_model, event_logger
 ):
     complete_response = ""
     async for item in response:

--- a/packages/opentelemetry-instrumentation-google-generativeai/tests/test_generate_content.py
+++ b/packages/opentelemetry-instrumentation-google-generativeai/tests/test_generate_content.py
@@ -166,8 +166,9 @@ def assert_message_in_logs(log: LogData, event_name: str, expected_content: dict
         assert log.log_record.body
         assert dict(log.log_record.body) == expected_content
 
+
 def test_imports():
     # Ensure heavy dependencies are not accidentally imported
     import opentelemetry.instrumentation.google_generativeai  # noqa: F401
 
-    assert "google.generai" not in sys.modules
+    assert "google.genai" not in sys.modules

--- a/packages/opentelemetry-instrumentation-google-generativeai/tests/test_generate_content.py
+++ b/packages/opentelemetry-instrumentation-google-generativeai/tests/test_generate_content.py
@@ -1,3 +1,5 @@
+import sys
+
 from opentelemetry.sdk._logs import LogData
 from opentelemetry.semconv._incubating.attributes import (
     event_attributes as EventAttributes,
@@ -163,3 +165,9 @@ def assert_message_in_logs(log: LogData, event_name: str, expected_content: dict
     else:
         assert log.log_record.body
         assert dict(log.log_record.body) == expected_content
+
+def test_imports():
+    # Ensure heavy dependencies are not accidentally imported
+    import opentelemetry.instrumentation.google_generativeai  # noqa: F401
+
+    assert "google.generai" not in sys.modules


### PR DESCRIPTION
xref: https://github.com/conda-forge/opentelemetry-instrumentation-google-generativeai-feedstock/pull/23

https://github.com/traceloop/openllmetry/blob/645426360910ce56d00894fc9c7feb47d5230953/packages/opentelemetry-instrumentation-google-generativeai/opentelemetry/instrumentation/google_generativeai/__init__.py#L7

```raw
import: 'opentelemetry.instrumentation.google_generativeai'
Traceback (most recent call last):
  File "/home/conda/feedstock_root/build_artifacts/opentelemetry-instrumentation-google-generativeai_1752459194594/test_tmp/run_test.py", line 2, in <module>
    import opentelemetry.instrumentation.google_generativeai
  File "/home/conda/feedstock_root/build_artifacts/opentelemetry-instrumentation-google-generativeai_1752459194594/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.9/site-packages/opentelemetry/instrumentation/google_generativeai/__init__.py", line 7, in <module>
    from google.generativeai.types.generation_types import GenerateContentResponse
ModuleNotFoundError: No module named 'google'
```


- [x] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move `google-generativeai` to runtime dependencies in `pyproject.toml` to fix import error.
> 
>   - **Dependencies**:
>     - Move `google-generativeai` from `[tool.poetry.group.dev.dependencies]` to `[tool.poetry.dependencies]` in `pyproject.toml` to fix `ModuleNotFoundError`.
>   - **Error Fix**:
>     - Resolves `ModuleNotFoundError` for `google.generativeai.types.generation_types` in `__init__.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 136f51fb3c5779c41546ad5f76de627cb3e2afb4. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents eager importing of heavy Google Generative AI dependencies during initialization, reducing startup overhead and avoiding import-time errors when those packages aren’t installed.
  * Uses type-only references for external types so optional packages aren’t required at runtime.

* **Tests**
  * Added a test to verify importing the instrumentation does not load Google Generative AI modules, guarding against regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->