### PR TITLE
fix(instrumentation): inline image upload improvements

### DIFF
--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
@@ -559,6 +559,12 @@ async def _awrap(
 def is_metrics_enabled() -> bool:
     return (os.getenv("TRACELOOP_METRICS_ENABLED") or "true").lower() == "true"
 
+def should_keep_inline_images():
+    return (os.getenv("TRACELOOP_KEEP_INLINE_IMAGES") or "false").lower() == "true"
+
+default_upload_base64_image = lambda trace_id, span_id, image_name, base64_image_url: f"data:image/{image_name.split('.')[-1]};base64,{base64_image_url}" \
+    if should_keep_inline_images() \
+    else lambda: ""
 
 class AnthropicInstrumentor(BaseInstrumentor):
     """An instrumentor for Anthropic's client library."""
@@ -577,7 +583,11 @@ class AnthropicInstrumentor(BaseInstrumentor):
         Config.exception_logger = exception_logger
         Config.enrich_token_usage = enrich_token_usage
         Config.get_common_metrics_attributes = get_common_metrics_attributes
-        Config.upload_base64_image = upload_base64_image
+        # do not override if already set
+        if not Config.upload_base64_image:
+            Config.upload_base64_image = upload_base64_image \
+                if upload_base64_image is not None \
+                else default_upload_base64_image
         Config.use_legacy_attributes = use_legacy_attributes
 
     def instrumentation_dependencies(self) -> Collection[str]:

--- a/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/__init__.py
+++ b/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/__init__.py
@@ -2,11 +2,14 @@ from typing import Callable, Collection, Optional
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.openai.shared.config import Config
-from opentelemetry.instrumentation.openai.utils import is_openai_v1
+from opentelemetry.instrumentation.openai.utils import is_openai_v1, should_keep_inline_images
 from typing_extensions import Coroutine
 
 _instruments = ("openai >= 0.27.0",)
 
+default_upload_base64_image = lambda trace_id, span_id, image_name, base64_image_url: f"data:image/{image_name.split('.')[-1]};base64,{base64_image_url}" \
+    if should_keep_inline_images() \
+    else lambda: ""
 
 class OpenAIInstrumentor(BaseInstrumentor):
     """An instrumentor for OpenAI's client library."""
@@ -19,7 +22,7 @@ class OpenAIInstrumentor(BaseInstrumentor):
         get_common_metrics_attributes: Callable[[], dict] = lambda: {},
         upload_base64_image: Optional[
             Callable[[str, str, str, str], Coroutine[None, None, str]]
-        ] = lambda *args: "",
+        ] = None,
         enable_trace_context_propagation: bool = True,
         use_legacy_attributes: bool = True,
     ):
@@ -28,7 +31,11 @@ class OpenAIInstrumentor(BaseInstrumentor):
         Config.enrich_token_usage = enrich_token_usage
         Config.exception_logger = exception_logger
         Config.get_common_metrics_attributes = get_common_metrics_attributes
-        Config.upload_base64_image = upload_base64_image
+        # do not override if already set
+        if not Config.upload_base64_image:
+            Config.upload_base64_image = upload_base64_image \
+                if upload_base64_image is not None \
+                else default_upload_base64_image
         Config.enable_trace_context_propagation = enable_trace_context_propagation
         Config.use_legacy_attributes = use_legacy_attributes
 

--- a/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/shared/config.py
+++ b/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/shared/config.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Callable, Optional, Coroutine
 
 from opentelemetry._events import EventLogger
 
@@ -8,8 +8,8 @@ class Config:
     enrich_assistant = False
     exception_logger = None
     get_common_metrics_attributes: Callable[[], dict] = lambda: {}
-    upload_base64_image: Callable[[str, str, str], str] = (
-        lambda trace_id, span_id, base64_image_url: str
+    upload_base64_image: Callable[[str, str, str, str], Coroutine[None, None, str]] = (
+        lambda trace_id, span_id, image_name, base64_image_url: str
     )
     enable_trace_context_propagation: bool = True
     use_legacy_attributes = True

--- a/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/utils.py
+++ b/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/utils.py
@@ -15,6 +15,7 @@ import openai
 _OPENAI_VERSION = version("openai")
 
 TRACELOOP_TRACE_CONTENT = "TRACELOOP_TRACE_CONTENT"
+TRACELOOP_KEEP_INLINE_IMAGES = "TRACELOOP_KEEP_INLINE_IMAGES"
 
 
 def is_openai_v1():
@@ -174,6 +175,11 @@ def should_send_prompts():
         os.getenv(TRACELOOP_TRACE_CONTENT) or "true"
     ).lower() == "true" or context_api.get_value("override_enable_content_tracing")
 
+
+def should_keep_inline_images():
+    return (
+        os.getenv(TRACELOOP_KEEP_INLINE_IMAGES) or "false"
+    ).lower() == "true"
 
 def should_emit_events() -> bool:
     """


### PR DESCRIPTION
fix: do not override Config.upload_base64_image if already set

fix: correct type of openai.shared.Config.upload_base64_image

feat: keep inline images if TRACELOOP_KEEP_INLINE_IMAGES environment variable is set
