### PR TITLE
fix(sdk): respect truncation otel environment variable

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/decorators/base.py
+++ b/packages/traceloop-sdk/traceloop/sdk/decorators/base.py
@@ -36,7 +36,7 @@ F = TypeVar("F", bound=Callable[P, R | Awaitable[R]])
 
 
 def _truncate_json_if_needed(json_str: str) -> str:
-    """Truncate JSON string if it exceeds OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT"""
+    """Truncate JSON string if it exceeds OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT; truncation may yield an invalid JSON string, which is expected for logging purposes."""
     limit_str = os.getenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT")
     if limit_str:
         try:

--- a/packages/traceloop-sdk/traceloop/sdk/decorators/base.py
+++ b/packages/traceloop-sdk/traceloop/sdk/decorators/base.py
@@ -36,7 +36,10 @@ F = TypeVar("F", bound=Callable[P, R | Awaitable[R]])
 
 
 def _truncate_json_if_needed(json_str: str) -> str:
-    """Truncate JSON string if it exceeds OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT; truncation may yield an invalid JSON string, which is expected for logging purposes."""
+    """
+    Truncate JSON string if it exceeds OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT;
+    truncation may yield an invalid JSON string, which is expected for logging purposes.
+    """
     limit_str = os.getenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT")
     if limit_str:
         try:

--- a/packages/traceloop-sdk/traceloop/sdk/decorators/base.py
+++ b/packages/traceloop-sdk/traceloop/sdk/decorators/base.py
@@ -41,7 +41,7 @@ def _truncate_json_if_needed(json_str: str) -> str:
     if limit_str:
         try:
             limit = int(limit_str)
-            if len(json_str) > limit:
+            if limit > 0 and len(json_str) > limit:
                 return json_str[:limit]
         except ValueError:
             pass


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [ ] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces JSON truncation in task spans based on `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` and adds tests for various scenarios.
> 
>   - **Behavior**:
>     - Introduced JSON truncation in `_truncate_json_if_needed()` in `base.py` based on `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`.
>     - Updated `_handle_span_input()` and `_handle_span_output()` in `base.py` to use `_truncate_json_if_needed()` for truncating JSON data.
>   - **Tests**:
>     - Added `test_json_truncation_with_otel_limit()`, `test_json_no_truncation_without_otel_limit()`, `test_json_truncation_with_invalid_otel_limit()`, `test_async_json_truncation_with_otel_limit()`, and `test_json_truncation_preserves_short_content()` in `test_tasks.py` to verify JSON truncation behavior under various conditions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 9aa03c8a4e83adb5d8935b76912de6526b35d971. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced automatic truncation of JSON input/output in task spans based on the environment variable `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`.
  * Task span attributes now always include JSON data, truncated as needed according to the specified limit.

* **Tests**
  * Added comprehensive tests to verify JSON truncation behavior for various environment variable settings, including valid, unset, and invalid values, as well as for both synchronous and asynchronous tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->