### PR TITLE
fix(langchain): populate metadata as span attributes in batch operations

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
@@ -234,6 +234,11 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         _set_span_attribute(span, SpanAttributes.TRACELOOP_WORKFLOW_NAME, workflow_name)
         _set_span_attribute(span, SpanAttributes.TRACELOOP_ENTITY_PATH, entity_path)
 
+        # Set metadata as span attributes if available
+        if metadata is not None:
+            for key, value in sanitized_metadata.items():
+                _set_span_attribute(span, f"{SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES}.{key}", value)
+
         self.spans[run_id] = SpanHolder(
             span, token, None, [], workflow_name, entity_name, entity_path
         )

--- a/packages/opentelemetry-instrumentation-langchain/tests/cassettes/test_batch_metadata/test_async_batch_metadata_in_span_attributes.yaml
+++ b/packages/opentelemetry-instrumentation-langchain/tests/cassettes/test_batch_metadata/test_async_batch_metadata_in_span_attributes.yaml
@@ -1,0 +1,232 @@
+interactions:
+- request:
+    body: '{"messages": [{"content": "What is AI?", "role": "user"}], "model": "gpt-3.5-turbo",
+      "stream": false, "temperature": 0.0}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '121'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      traceparent:
+      - 00-c8f6bf81c4645a3bed423c22e499f6e1-a2abe4f4c63baba3-01
+      user-agent:
+      - AsyncOpenAI/Python 1.78.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.78.1
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.9.5
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//jFTBahsxEL37Kwad18ZO7abxLQ2lCTSlh0BpSzBjabw7iVYSGsmtCfn3
+        ol3Ha7cp9LKIeTOj92ae9mkEoNioJSjdYNJtsOOr6cW3q+vp+936YR7D5+/Xt48fvn66+HJby91H
+        VZUKv34gnV6qJtq3wVJi73pYR8JEpevsfDGfLc7O5+86oPWGbCmrQxq/mSzGKce1H09nZ4t9ZeNZ
+        k6gl/BgBADx138LRGfqlljCtXiItiWBNanlIAlDR2xJRKMKS0CVVDaD2LpHraF/eVOAjYEy8Yc1o
+        gV0ia7kmp6mCSBuKAslDagiE22yx6AO/gSa36E7yIUSvSYQE1jtoUTfsSCogCVSa2x2UEeVEEWQn
+        iVqZwF1DclzJTttsCCxhdOzqQgLF98cQ/dpSOxZvt32AoqZQKFWAzoBFV2esCbIzFIt0w66ewOUN
+        JNKN89bXTAIYCbKQAXaA8JMNQURXUxGGIVjWnU6pQLJuAAUkEOkGImlfO+5v5LZcdRJymHJEOxDZ
+        K+vYFoaYk3e+9VlgSw1rSzI53k6kTRYs7nDZ2iMAnfOpZ1V8cb9Hng9OsL4u85E/StWGHUuz6sdY
+        ti7JB9WhzyOA+85x+cREKkTfhrRK/pG662azvp0aPD6Ab+d7MPmEdoifL6pXuq0MJWQrR45VGnVD
+        Zqgc7I3ZsD8CRkea/ybzWu+Dff6n/QDo4isyqxDJsD4VPKRFKn+Af6UdZtwRVkJxy5pWiSmWPRja
+        YLb921T9g1ht2NUUQ+TugZY9jp5HvwEAAP//AwAHSY+ynwQAAA==
+    headers:
+      CF-RAY:
+      - 968f0276a9678e45-TLV
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 Aug 2025 16:39:09 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=G2aFKRo.BMpAVgGzp94qrRN6RFU7.sDRxXTLHkf8fgo-1754152749-1.0.1.1-Lx9OnarPKsAIlqV43Q12KB5FSJp3XJUvbV6VvCvuebyvq7nZ_5iNbqW0T.Vq2MT9kokKzR8l56yO.9pF3QwNd6qd0SjmE3BGbxpWtahcyDo;
+        path=/; expires=Sat, 02-Aug-25 17:09:09 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=f202526c11Dikkj5iE5UA8lghq6b_dAuQZKN7YTvkY8-1754152749387-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - traceloop
+      openai-processing-ms:
+      - '606'
+      openai-project:
+      - proj_tzz1TbPPOXaf6j9tEkVUBIAa
+      openai-version:
+      - '2020-10-01'
+      x-envoy-decorator-operation:
+      - router.openai.svc.cluster.local:5004/*
+      x-envoy-upstream-service-time:
+      - '631'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '50000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '49999995'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_3d597d8be1044e54a572d6c5077562cd
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"content": "Explain machine learning", "role": "user"}],
+      "model": "gpt-3.5-turbo", "stream": false, "temperature": 0.0}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '134'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      traceparent:
+      - 00-4e3b9efa7eda214b5b3d2f13af79d3f0-66d461c13277fb39-01
+      user-agent:
+      - AsyncOpenAI/Python 1.78.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.78.1
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.9.5
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//jFXBbiM3DL37K4g5O0acJkiT66IFcuihxV52uwtDljgzbDSiQFH2pov8
+        e0GNEzupt+hlgBFF8vGRfPq+AOgodPfQ+dGpn3K8+HB59+lDv95+uvn88fOvv++vb/+og6fbXx5o
+        i93SPHj7F3p98Vp5nnJEJU6z2Qs6RYu6vr25Xt9c3V7/3AwTB4zmNmS9+Gl1c6FVtnxxub66OXiO
+        TB5Ldw9/LgAAvrevYUwBv3X3cLl8OZmwFDdgd/96CaATjnbSuVKoqEvaLY9Gz0kxNdi/OT9SQojo
+        JFEagAo4KHVbUIF7cKLUkycXgZJijDRg8gg6OgVKO447LKAjQsAdRs4TptkxDiyk41TApQBFnVJR
+        8i5CK77MITC5bUQw4qqiFFCesUAvPDXXyT0iZMFA3pgtwAIBPZX2s3UFA3CC4NSt4CHB9K6k5Ul0
+        JwgqjhIGyyToeUj0N0J2qiipAM2RjpmPqVjewNiTjlwVtmi84bccyZPGJ8jCg7hpmnMEhsKrL+lL
+        +jiiYIMQqO9RjCl9yliMr/eoTwhcAiUfa7DTUjPKjqzmY301nT22EgQp9SweW19ebI2nsz7WydfM
+        NgwvbHGC6LYYMTR+lrBv1dh9zyLoFbhqrmpOWXhHAQP0LIDOj0ApV21pfwD2vxLXdJp6bk0tCj2l
+        cOwcCwhG15ozUm6tbINpPpyAtADvUwNxnpb3KNq5DapwHUZQsTWw7CjCsrTxQdpZW3rEsHX+8SVn
+        zzJZVwX3TsI8OphcVMLSSDEwbh6kNhvn9rAaQ5TAwZ4Cgrg0YFutbKM2F3o6GzS5Aedty4h+fBlv
+        u7iE5LSKixBdGqpdzMIeS2l1281pwhRaVChPRdEGz4K5qpx44lpghyP5iGUFDwqjmxc/s4mJUdM2
+        asexWhDbKkqhFhUr2iLRZIOBgL1JCib/NCfwvorzT233Dtt2MblHq+kAEsvqVMAE+1qcCWiqMZ4Y
+        XEqsMzMmnV8PludXsYw8ZOFteefa9ZSojBtBVziZMBbl3DXr8wLgaxPl+kZnuyw8Zd0oP2JLt17P
+        4brjM3BivLs7WJXVxaPhan2Q8rfxNgHVUSwnst5550cMR9fjG+BqID4xLE6q/jecc7HnyikN/yf8
+        0eA9ZsWwOQrjuWuC9kz+6Noryw1wV0wcPG6UUKwTAXtX4/yAdfNkbnpKA0oWaq+YdXLxvPgHAAD/
+        /wMAmz+dlMQHAAA=
+    headers:
+      CF-RAY:
+      - 968f0276c9d08e4e-TLV
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 Aug 2025 16:39:11 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=hOCUQ293QoWYMqqLmtY7.ikGh02jPfZwBmxUDtxRhA0-1754152751-1.0.1.1-tdrHlbsiwPs7qn7mPbKLg89QVwttr.A1N.bbVtnbZhFuWXRyj88YHh3jX8cJ9bU0ryfo3_BTVeABOhH93.Km8xewtWWIqotz34VO0PG6g.s;
+        path=/; expires=Sat, 02-Aug-25 17:09:11 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=3JjMgNbPVSJtY9DwH4U6N3l7v6TtZNUEeC87.qgS3bY-1754152751459-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - traceloop
+      openai-processing-ms:
+      - '2531'
+      openai-project:
+      - proj_tzz1TbPPOXaf6j9tEkVUBIAa
+      openai-version:
+      - '2020-10-01'
+      x-envoy-decorator-operation:
+      - router.openai.svc.cluster.local:5004/*
+      x-envoy-upstream-service-time:
+      - '2564'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '50000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '49999992'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_ce7184c928e1432a9dac39b70919dad7
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/packages/opentelemetry-instrumentation-langchain/tests/cassettes/test_batch_metadata/test_batch_metadata_in_span_attributes.yaml
+++ b/packages/opentelemetry-instrumentation-langchain/tests/cassettes/test_batch_metadata/test_batch_metadata_in_span_attributes.yaml
@@ -1,0 +1,221 @@
+interactions:
+- request:
+    body: '{"messages": [{"content": "Hello", "role": "user"}], "model": "gpt-3.5-turbo",
+      "stream": false, "temperature": 0.0}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '115'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      traceparent:
+      - 00-e28ab06fbd280c01c6229ee0fdee9b00-fa99e227c1628303-01
+      user-agent:
+      - OpenAI/Python 1.78.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.78.1
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.9.5
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//jFLLbtswELzrK7Y824Ht1nDtSw4BCvdSoGhqBC0CgSZXMmuKS5CrpEbg
+        fw9IOZbyAnLRYWdnNDPchwJAGC1WINROsmq8HV9Nljf7b/43rjc/fm7in+qX93y/314v42wjRolB
+        23+o+Il1oajxFtmQ62AVUDIm1eli/mU6ny1mkww0pNEmWu15/PliPuY2bGk8mc7mJ+aOjMIoVvC3
+        AAB4yN/k0Wn8L1aQdfKkwRhljWJ1XgIQgWyaCBmjiSwdi1EPKnKMLtteo7X0CdZ0D0o6+A4dAQ7U
+        ApOWh8shMWDVRpmMu9baASCdI5YpeLZ8e0KOZ5OWah9oG19QRWWcibsyoIzkkqHI5EVGjwXAbS6j
+        fZZP+ECN55Jpj/l3Xzs10bffY8sTxsTS9uPpYvSGVqmRpbFxUKVQUu1Q98y+d9lqQwOgGCR+7eUt
+        7S61cfVH5HtAKfSMuvQBtVHP8/ZrAdNpvrd2bjgbFhHDnVFYssGQXkFjJVvbHY2Ih8jYlJVxNQYf
+        TL6c9IrFsXgEAAD//wMA4x7TkDgDAAA=
+    headers:
+      CF-RAY:
+      - 968f01c30ace8e4a-TLV
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 Aug 2025 16:38:40 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=Nx_REDV1LHShRt2uWoImMNeyBicj_gDggKI02DXlhQM-1754152720-1.0.1.1-vyv4h3oX9UL1vKi0zzEWQh3xqHTnrJGMcE8du5Z6H5UmqJfQnsWMipiCiE8SvhY3WqU7WvvDvxfTnm9eRwFiB_IUCNjLeHJfRO_RhSBSLxk;
+        path=/; expires=Sat, 02-Aug-25 17:08:40 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=yPj_bYNfC5u52.lh1bqaKTbbpG4nmDdcBD7JfCfz3T0-1754152720669-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - traceloop
+      openai-processing-ms:
+      - '231'
+      openai-project:
+      - proj_tzz1TbPPOXaf6j9tEkVUBIAa
+      openai-version:
+      - '2020-10-01'
+      x-envoy-decorator-operation:
+      - router.openai.svc.cluster.local:5004/*
+      x-envoy-upstream-service-time:
+      - '385'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '50000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '49999995'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_44d23bc24ddb43c597b028befbaeb2a6
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"content": "How are you?", "role": "user"}], "model": "gpt-3.5-turbo",
+      "stream": false, "temperature": 0.0}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '122'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      traceparent:
+      - 00-11c5e82fdb8e16675b7002ecb7267cc6-87d88fd8c7aab1c1-01
+      user-agent:
+      - OpenAI/Python 1.78.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.78.1
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.9.5
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4xTy27bMBC86ysWvORiG37EcOJLgaZo4lt7a1EEAk2uJNoUlyBXSYzA/16Qdiyl
+        TYFedNjhDGdnqNcCQBgt1iBUI1m13o7vprc/9i97E+/Ml8Xi57fv97fVZ39/M9/tHr6KUWLQdoeK
+        31gTRa23yIbcCVYBJWNSna2W17PlfDWfZqAljTbRas/jxWQ55i5saTydzZdnZkNGYRRr+FUAALzm
+        b/LoNL6INWSdPGkxRlmjWF8OAYhANk2EjNFElo7FqAcVOUaXbW+uWth1kUFCMt8xBvCB6iDbEUSC
+        DWhyVwyNfEKoEK1xdQQKgC2lPeMIth1DkmkwIEinIaDUB2CC0+VwoA6eDTcg3YEb4+o8cYh6Ag/0
+        DEo62ECD1meAScvDp6HfgFUXZcrLddYOAOkcscw+UlKPZ+R4ycZS7QNt4x9UURlnYlMGlJFcyiEy
+        eZHRYwHwmDvo3sUqfKDWc8m0x3zdbHaSE33rPbhYnUEmlrafX9+MPlArNbI0Ng46FEqqBnXP7AuX
+        nTY0AIrBzn+b+Uj7tLdx9f/I94BS6Bl16QNqo94v3B8LmP6Jfx27ZJwNi4jhySgs2WBIPWisZGdP
+        r1XEQ2Rsy8q4GoMPJj/Z1GNxLH4DAAD//wMAsVC09rEDAAA=
+    headers:
+      CF-RAY:
+      - 968f01c30c108e48-TLV
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 Aug 2025 16:38:41 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=CDT82_b5oMQNbP6wSzJGDP0FjhTtOsTZZoLQvu08__c-1754152721-1.0.1.1-HSc90cOxnssiFiOXlSF9tKHHasngqQUJBGUHSjk.CSQBYiMNhmm0OPkiSj1kgfEAuSW1G_lv0GFuYGiK.BWnxnoT80JBRndYqLOLnub6dEY;
+        path=/; expires=Sat, 02-Aug-25 17:08:41 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=vMalCDfFDbxI5QL_IjA7yinVReK5z59yWr_6vB2nNI4-1754152721060-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - traceloop
+      openai-processing-ms:
+      - '606'
+      openai-project:
+      - proj_tzz1TbPPOXaf6j9tEkVUBIAa
+      openai-version:
+      - '2020-10-01'
+      x-envoy-decorator-operation:
+      - router.openai.svc.cluster.local:5004/*
+      x-envoy-upstream-service-time:
+      - '761'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '50000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '49999995'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_63b2299363ad478e98f84b5e9855435e
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_batch_metadata.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_batch_metadata.py
@@ -1,0 +1,84 @@
+import pytest
+from langchain_openai import ChatOpenAI
+from opentelemetry.semconv_ai import SpanAttributes
+
+
+@pytest.mark.vcr
+def test_batch_metadata_in_span_attributes(instrument_legacy, span_exporter):
+    """Test that metadata from batch calls are populated as span attributes."""
+    llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0)
+    
+    # Test batch with metadata
+    test_metadata = {"user_id": "12345", "session_id": "abc-123", "priority": "high"}
+    messages_list = [
+        [{"role": "user", "content": "Hello"}],
+        [{"role": "user", "content": "How are you?"}]
+    ]
+    
+    # Call batch with metadata
+    responses = llm.batch(messages_list, config={"metadata": test_metadata})
+    
+    spans = span_exporter.get_finished_spans()
+    
+    # Find the LLM spans
+    llm_spans = [span for span in spans if span.name.endswith(".chat")]
+    
+    # There should be 2 LLM spans (one for each message in the batch)
+    assert len(llm_spans) == 2
+    
+    # Each span should contain the metadata as attributes
+    for span in llm_spans:
+        # Check if metadata is present as span attributes
+        assert "user_id" in span.attributes or f"{SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES}.user_id" in span.attributes
+        assert "session_id" in span.attributes or f"{SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES}.session_id" in span.attributes
+        assert "priority" in span.attributes or f"{SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES}.priority" in span.attributes
+        
+        # Check the values
+        user_id_attr = span.attributes.get("user_id") or span.attributes.get(f"{SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES}.user_id")
+        session_id_attr = span.attributes.get("session_id") or span.attributes.get(f"{SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES}.session_id")
+        priority_attr = span.attributes.get("priority") or span.attributes.get(f"{SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES}.priority")
+        
+        assert user_id_attr == "12345"
+        assert session_id_attr == "abc-123"
+        assert priority_attr == "high"
+
+
+@pytest.mark.vcr
+@pytest.mark.asyncio
+async def test_async_batch_metadata_in_span_attributes(instrument_legacy, span_exporter):
+    """Test that metadata from abatch calls are populated as span attributes."""
+    llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0)
+    
+    # Test abatch with metadata
+    test_metadata = {"user_id": "67890", "session_id": "def-456", "environment": "production"}
+    messages_list = [
+        [{"role": "user", "content": "What is AI?"}],
+        [{"role": "user", "content": "Explain machine learning"}]
+    ]
+    
+    # Call abatch with metadata
+    responses = await llm.abatch(messages_list, config={"metadata": test_metadata})
+    
+    spans = span_exporter.get_finished_spans()
+    
+    # Find the LLM spans
+    llm_spans = [span for span in spans if span.name.endswith(".chat")]
+    
+    # There should be 2 LLM spans (one for each message in the batch)
+    assert len(llm_spans) == 2
+    
+    # Each span should contain the metadata as attributes
+    for span in llm_spans:
+        # Check if metadata is present as span attributes
+        assert "user_id" in span.attributes or f"{SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES}.user_id" in span.attributes
+        assert "session_id" in span.attributes or f"{SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES}.session_id" in span.attributes
+        assert "environment" in span.attributes or f"{SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES}.environment" in span.attributes
+        
+        # Check the values
+        user_id_attr = span.attributes.get("user_id") or span.attributes.get(f"{SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES}.user_id")
+        session_id_attr = span.attributes.get("session_id") or span.attributes.get(f"{SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES}.session_id")
+        environment_attr = span.attributes.get("environment") or span.attributes.get(f"{SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES}.environment")
+        
+        assert user_id_attr == "67890"
+        assert session_id_attr == "def-456"
+        assert environment_attr == "production"


### PR DESCRIPTION
Fixed issue where metadata from Langchain batch() and abatch() method calls were not being populated as span attributes. The metadata was previously only stored in the OpenTelemetry context for propagation but never set as actual span attributes, making it difficult to correlate errors with specific data points.

Changes:
- Modified _create_span method to set sanitized metadata as span attributes
- Added tests for both sync batch and async abatch operations
- Metadata is now accessible as traceloop.association.properties.* attributes

Fixes: https://github.com/traceloop/openllmetry/issues/3213

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [ ] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
