### PR TITLE
fix(sdk): avoid initializing metrics exporter on custom tracing config

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/__init__.py
+++ b/packages/traceloop-sdk/traceloop/sdk/__init__.py
@@ -154,7 +154,11 @@ class Traceloop:
             span_postprocess_callback=span_postprocess_callback,
         )
 
-        if not is_metrics_enabled() or not metrics_exporter and exporter:
+        metrics_disabled_by_config = not is_metrics_enabled()
+        has_custom_spans_pipeline = processor or exporter
+        custom_trace_without_custom_metrics = has_custom_spans_pipeline and not metrics_exporter
+
+        if metrics_disabled_by_config or custom_trace_without_custom_metrics:
             print(Fore.YELLOW + "Metrics are disabled" + Fore.RESET)
         else:
             metrics_endpoint = os.getenv("TRACELOOP_METRICS_ENDPOINT") or api_endpoint


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refines metrics initialization in `Traceloop.init()` to avoid initializing metrics exporter when custom tracing configuration is used without a custom metrics exporter.
> 
>   - **Behavior**:
>     - Refines metrics initialization in `Traceloop.init()` to avoid initializing metrics exporter when custom tracing configuration is used without a custom metrics exporter.
>     - Adds conditions `metrics_disabled_by_config`, `has_custom_spans_pipeline`, and `custom_trace_without_custom_metrics` to determine when metrics are disabled.
>   - **Logging**:
>     - Logs a message "Metrics are disabled" when metrics are not initialized due to the new conditions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 974f54d52414d01671395f26764e09fa20e95766. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Metrics now initialize only when enabled and a compatible exporter is provided, preventing unexpected enable/disable states with custom tracing setups.
  * Clearer log messages indicate when metrics are disabled or exported via a custom exporter.

* **Refactor**
  * Streamlined metrics initialization with explicit flag-based control for improved reliability and predictability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->