### PR TITLE
chore(claude): add initial Claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,29 @@
 ## Repository Structure
 This repository contains multiple PyPI-publishable packages organized and orchestrated using Nx workspace management.
 
+### Nx Workspace Commands
+```bash
+# Run tests across all packages
+nx run-many -t test
+
+# Run linting across all packages
+nx run-many -t lint
+
+# Update lock files across all packages
+nx run-many -t lock
+
+# Run specific targets on specific packages
+nx run <package-name>:test
+nx run <package-name>:lint
+
+# Show project graph
+nx graph
+
+# Show what's affected by changes
+nx affected:test
+nx affected:lint
+```
+
 ## Package Management
 All packages use Poetry as the package manager. Always execute commands through Poetry:
 ```bash
@@ -10,7 +33,35 @@ poetry run <command>
 ```
 
 ## Testing with VCR Cassettes
-Tests utilize recordings/cassettes for API calls. When making changes that affect API interactions, re-record VCR cassettes to ensure test accuracy. Creating new cassettes typically requires API keys (OpenAI, Anthropic, etc.) - request these from the user when needed.
+Tests utilize VCR cassettes for API calls.
+
+### Commands
+```bash
+# Run tests normally (uses existing cassettes)
+poetry run pytest tests/
+
+# Re-record all cassettes (requires API keys)
+poetry run pytest tests/ --record-mode=all
+
+# Record only new test episodes
+poetry run pytest tests/ --record-mode=new_episodes
+
+# Record cassettes once (if they don't exist)
+poetry run pytest tests/ --record-mode=once
+
+# Run tests without recording (fails if cassettes missing)
+poetry run pytest tests/ --record-mode=none
+
+# Run specific test files
+poetry run pytest tests/test_agents.py --record-mode=once
+```
+
+### Guidance
+Re-record cassettes when API interactions change to ensure test accuracy.
+Never commit secrets or PII. Scrub them using VCR filters (e.g., filter_headers, before_record) or your test framework's equivalent.
+Store API keys only in environment variables/secure vaults; never in code or cassettes.
+Typical record modes you may use: once, new_episodes, all, none (choose per test needs).
+Creating new cassettes requires valid API keys (OpenAI, Anthropic, etc.); ask the user to provide them if needed.
 
 ## Semantic Conventions
 The semantic convention package follows the OpenTelemetry GenAI specification:
@@ -20,4 +71,4 @@ https://opentelemetry.io/docs/specs/semconv/gen-ai/
 Instrumentation packages should leverage the semantic conventions package. Their purpose is to instrument AI-related libraries and generate spans and tracing data compliant with OpenTelemetry semantic conventions.
 
 ## Code Quality
-Flake8 is used for code linting and formatting.
+Flake8 is used for code linting.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# OpenLLMetry Repository Guide
+
+## Repository Structure
+This repository contains multiple PyPI-publishable packages organized and orchestrated using Nx workspace management.
+
+## Package Management
+All packages use Poetry as the package manager. Always execute commands through Poetry:
+```bash
+poetry run <command>
+```
+
+## Testing with VCR Cassettes
+Tests utilize recordings/cassettes for API calls. When making changes that affect API interactions, re-record VCR cassettes to ensure test accuracy. Creating new cassettes typically requires API keys (OpenAI, Anthropic, etc.) - request these from the user when needed.
+
+## Semantic Conventions
+The semantic convention package follows the OpenTelemetry GenAI specification:
+https://opentelemetry.io/docs/specs/semconv/gen-ai/
+
+## Instrumentation Packages
+Instrumentation packages should leverage the semantic conventions package. Their purpose is to instrument AI-related libraries and generate spans and tracing data compliant with OpenTelemetry semantic conventions.
+
+## Code Quality
+Flake8 is used for code linting and formatting.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `CLAUDE.md` documenting repository structure, package management, testing, semantic conventions, and code quality standards.
> 
>   - **Documentation**:
>     - Adds `CLAUDE.md` with OpenLLMetry Repository Guide.
>     - Details repository structure (Nx-managed, multi-package) and package management via Poetry.
>     - Explains testing with VCR cassettes, including re-recording flows and API key requirements.
>     - References OpenTelemetry GenAI semantic conventions for instrumentation compliance.
>     - Clarifies expectation to generate tracing data from instrumentation.
>     - Notes code quality standards enforced with Flake8.
>     - No changes to code or public APIs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 3dccef5b996dfac319b991384b04c59d63640eb2. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added CLAUDE.md with an OpenLLMetry repository guide.
  * Describes Nx-managed, multi-package structure and Poetry-based package management.
  * Explains testing with VCR cassettes, re-recording flows, and API key needs for new cassettes.
  * References OpenTelemetry GenAI semantic conventions for instrumentation compliance and tracing data.
  * Notes code quality standards enforced with Flake8.
  * No changes to code or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->