### PR TITLE
fix(langchain): context detach exception

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
@@ -188,9 +188,12 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         token = self.spans[run_id].token
         if token:
             try:
-                context_api.detach(token)
-            except ValueError:
+                # Use the runtime context directly to avoid logging from context_api.detach()
+                from opentelemetry.context import _RUNTIME_CONTEXT
+                _RUNTIME_CONTEXT.detach(token)
+            except (ValueError, RuntimeError, Exception):
                 # Context detach can fail in async scenarios when tokens are created in different contexts
+                # This includes ValueError, RuntimeError, and other context-related exceptions
                 # This is expected behavior and doesn't affect the correct span hierarchy
                 pass
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix context detachment issue in async scenarios by modifying `_end_span()` in `callback_handler.py` and adding a test in `test_langgraph.py`.
> 
>   - **Behavior**:
>     - Modify `_end_span()` in `callback_handler.py` to use `_RUNTIME_CONTEXT.detach()` instead of `context_api.detach()` to avoid logging errors.
>     - Extend exception handling in `_end_span()` to include `RuntimeError` and `Exception`.
>   - **Testing**:
>     - Add `test_context_detachment_error_handling()` in `test_langgraph.py` to verify context detachment errors are handled without logging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for b8b6bef38fdd68746bb54e56ff50b680271f035f. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracing context handling to prevent spurious detachment errors and reduce noisy logs during async workflows, enhancing stability and preserving correct span hierarchies.

* **Tests**
  * Added coverage to validate no detachment errors under concurrent async execution and to verify expected span counts and parent-child relationships, ensuring reliable behavior in complex workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->