### PR TITLE
chore(ci): fix setuptools issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           poetry config virtualenvs.create false
           poetry config virtualenvs.in-project false
+          poetry config installer.max-workers 1
 
       - name: Cache Poetry dependencies
         uses: actions/cache@v4
@@ -96,6 +97,7 @@ jobs:
         run: |
           poetry config virtualenvs.create false
           poetry config virtualenvs.in-project false
+          poetry config installer.max-workers 1
 
       - name: Cache Poetry dependencies
         uses: actions/cache@v4
@@ -123,7 +125,9 @@ jobs:
       - run: npm ci
 
       - name: Install
-        run: npx nx affected -t install --with dev --parallel=3
+        run: |
+          pip install --upgrade pip setuptools wheel
+          npx nx affected -t install --with dev --parallel=3
 
       - name: Build
         run: npx nx affected -t build-release --parallel=3
@@ -161,6 +165,7 @@ jobs:
         run: |
           poetry config virtualenvs.create false
           poetry config virtualenvs.in-project false
+          poetry config installer.max-workers 1
 
       - name: Cache Poetry dependencies
         uses: actions/cache@v4
@@ -196,7 +201,9 @@ jobs:
       - run: npm ci
 
       - name: Install
-        run: npx nx affected -t install --exclude='sample-app' --with dev --parallel=3
+        run: |
+          pip install --upgrade pip setuptools wheel
+          npx nx affected -t install --exclude='sample-app' --with dev --parallel=3
 
       - name: Test
         env:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix setuptools issue in CI by configuring Poetry and upgrading setuptools in `ci.yml`.
> 
>   - **CI Configuration**:
>     - Set `poetry config installer.max-workers 1` in `ci.yml` for `lint`, `build-packages`, and `test-packages` jobs to address concurrency issues.
>     - Add `pip install --upgrade pip setuptools wheel` before `npx nx affected -t install` in `build-packages` and `test-packages` jobs to ensure `setuptools` is up-to-date.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 46427da057c9095e94995c0fe8ca13ed3ebd473c. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->