### PR TITLE
fix(anthropic): fix with_raw_response wrapper consistency and re-enable beta API instrumentation

### DIFF
--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_bedrock_with_raw_response.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_bedrock_with_raw_response.py
@@ -25,7 +25,7 @@ def async_anthropic_bedrock_client(instrument_legacy):
     )
 
 
-@pytest.mark.skip
+# @pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.vcr
 async def test_async_anthropic_bedrock_with_raw_response(
@@ -80,7 +80,7 @@ async def test_async_anthropic_bedrock_with_raw_response(
     )
 
 
-@pytest.mark.skip
+# @pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.vcr
 async def test_async_anthropic_bedrock_regular_create(
@@ -129,7 +129,7 @@ async def test_async_anthropic_bedrock_regular_create(
     )
 
 
-@pytest.mark.skip
+# @pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.vcr
 async def test_async_anthropic_bedrock_beta_with_raw_response(


### PR DESCRIPTION
## Summary
- Fixes inconsistent response data handling that was causing issues with `with_raw_response` wrapper methods
- Re-enables beta API instrumentation that was temporarily disabled due to response object corruption
- Updates all response handling functions to use consistent safe attribute access patterns

## Background
PR #3250 introduced support for `with_raw_response` wrapper but was partially reverted due to response object corruption issues. While some functions were updated to use safe `getattr()` access, others still used the problematic `_extract_response_data` approach, creating inconsistency.

## Changes
- **Fixed metrics functions**: Updated `ashared_metrics_attributes` and `shared_metrics_attributes` to properly handle `with_raw_response` objects by calling `response.parse()` when needed
- **Fixed token usage functions**: Updated `_aset_token_usage` and `_set_token_usage` to use consistent safe attribute access with `getattr()` instead of dict-style access  
- **Re-enabled beta API**: Uncommented beta API instrumentation methods in `WRAPPED_METHODS` and `WRAPPED_AMETHODS`
- **Enabled tests**: Uncommented `@pytest.mark.skip` in bedrock with_raw_response tests

## Test plan
- [x] All 67 tests pass including previously failing bedrock `with_raw_response` tests
- [x] Flake8 linting passes
- [x] Verified metrics generation works for all response types (normal, raw, streaming, dict)

🤖 Generated with [Claude Code](https://claude.ai/code)