### PR TITLE
fix(traceloop-sdk): add @staticmethod decorator to set_association_properties

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/__init__.py
+++ b/packages/traceloop-sdk/traceloop/sdk/__init__.py
@@ -205,6 +205,7 @@ class Traceloop:
             )
             return Traceloop.__client
 
+    @staticmethod
     def set_association_properties(properties: dict) -> None:
         set_association_properties(properties)
 


### PR DESCRIPTION
## Summary
- Add missing `@staticmethod` decorator to `set_association_properties` method in the `Traceloop` class
- Fixes type checking error where pyright was treating the method as an instance method instead of a static method
- Eliminates the need for users to add `# type: ignore` comments when calling this method

## Test plan
- [x] Verify the method can still be called correctly: `Traceloop.set_association_properties({"user_id": "test"})`
- [ ] Run type checker (pyright) to confirm no type errors
- [ ] Ensure existing functionality is not affected

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `@staticmethod` to `set_association_properties` in `Traceloop` class to fix type checking error.
> 
>   - **Decorator Addition**:
>     - Add `@staticmethod` to `set_association_properties` in `Traceloop` class in `__init__.py`.
>   - **Type Checking**:
>     - Fixes pyright type checking error by correctly marking `set_association_properties` as static.
>     - Removes need for `# type: ignore` comments when calling `set_association_properties`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 83d6366d39059ec6dc7b3170b40b0b81daa49742. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Converted an SDK instance method to a static method, enabling direct class-level use without creating an instance.
  - Maintains existing behavior; no functional changes to how properties are applied.
  - Backward compatible for typical usage; existing calls should continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->