### PR TITLE
fix(milvus): Set default values when metrics are disabled

### DIFF
--- a/packages/opentelemetry-instrumentation-milvus/opentelemetry/instrumentation/milvus/__init__.py
+++ b/packages/opentelemetry-instrumentation-milvus/opentelemetry/instrumentation/milvus/__init__.py
@@ -85,6 +85,13 @@ class MilvusInstrumentor(BaseInstrumentor):
         return _instruments
 
     def _instrument(self, **kwargs):
+        # Set default values in case metrics are disabled
+        query_duration_metric = None
+        distance_metric = None
+        insert_units_metric = None
+        upsert_units_metric = None
+        delete_units_metric = None
+
         if is_metrics_enabled():
             meter_provider = kwargs.get("meter_provider")
             meter = get_meter(__name__, __version__, meter_provider)


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [X] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.


This PR fixes an initialization error in the Milvus instrumentor that occurs when metrics are disabled:
```
Error initializing Milvus instrumentor: cannot access local variable 'query_duration_metric' where it is not associated with a value
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes initialization error in `MilvusInstrumentor` by setting default metric values when metrics are disabled.
> 
>   - **Behavior**:
>     - Fixes initialization error in `MilvusInstrumentor` when metrics are disabled by setting default values for `query_duration_metric`, `distance_metric`, `insert_units_metric`, `upsert_units_metric`, and `delete_units_metric` in `_instrument()`.
>     - Prevents error: "cannot access local variable 'query_duration_metric' where it is not associated with a value".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 6c6f51c855e209021770649bb395c063b74173c9. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when metrics collection is disabled by safely initializing metric-related fields, preventing rare runtime errors during Milvus instrumentation.
  * Ensures instrumentation operates reliably whether metrics are enabled or not, with no changes to public behavior or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->