### PR TITLE
fix(openai-agents): support json inputs

### DIFF
--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
@@ -237,7 +237,7 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
                         if hasattr(message, 'role') and hasattr(message, 'content'):
                             otel_span.set_attribute(f"{SpanAttributes.LLM_PROMPTS}.{i}.role", message.role)
                             content = message.content
-                            if isinstance(content, dict):
+                            if not isinstance(content, str):
                                 content = json.dumps(content)
                             otel_span.set_attribute(f"{SpanAttributes.LLM_PROMPTS}.{i}.content", content)
                         elif isinstance(message, dict):

--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
@@ -236,11 +236,17 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
                     for i, message in enumerate(input_data):
                         if hasattr(message, 'role') and hasattr(message, 'content'):
                             otel_span.set_attribute(f"{SpanAttributes.LLM_PROMPTS}.{i}.role", message.role)
-                            otel_span.set_attribute(f"{SpanAttributes.LLM_PROMPTS}.{i}.content", message.content)
+                            content = message.content
+                            if isinstance(content, dict):
+                                content = json.dumps(content)
+                            otel_span.set_attribute(f"{SpanAttributes.LLM_PROMPTS}.{i}.content", content)
                         elif isinstance(message, dict):
                             if 'role' in message and 'content' in message:
                                 otel_span.set_attribute(f"{SpanAttributes.LLM_PROMPTS}.{i}.role", message['role'])
-                                otel_span.set_attribute(f"{SpanAttributes.LLM_PROMPTS}.{i}.content", message['content'])
+                                content = message['content']
+                                if isinstance(content, dict):
+                                    content = json.dumps(content)
+                                otel_span.set_attribute(f"{SpanAttributes.LLM_PROMPTS}.{i}.content", content)
 
                 # Add function/tool specifications to the request using OpenAI semantic conventions
                 response = getattr(span_data, 'response', None)
@@ -365,11 +371,17 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
                     for i, message in enumerate(input_data):
                         if hasattr(message, 'role') and hasattr(message, 'content'):
                             otel_span.set_attribute(f"gen_ai.prompt.{i}.role", message.role)
-                            otel_span.set_attribute(f"gen_ai.prompt.{i}.content", message.content)
+                            content = message.content
+                            if isinstance(content, dict):
+                                content = json.dumps(content)
+                            otel_span.set_attribute(f"gen_ai.prompt.{i}.content", content)
                         elif isinstance(message, dict):
                             if 'role' in message and 'content' in message:
                                 otel_span.set_attribute(f"gen_ai.prompt.{i}.role", message['role'])
-                                otel_span.set_attribute(f"gen_ai.prompt.{i}.content", message['content'])
+                                content = message['content']
+                                if isinstance(content, dict):
+                                    content = json.dumps(content)
+                                otel_span.set_attribute(f"gen_ai.prompt.{i}.content", content)
 
                 response = getattr(span_data, 'response', None)
                 if response:

--- a/packages/opentelemetry-instrumentation-openai-agents/tests/cassettes/test_openai_agents/test_dict_content_serialization.yaml
+++ b/packages/opentelemetry-instrumentation-openai-agents/tests/cassettes/test_openai_agents/test_dict_content_serialization.yaml
@@ -1,0 +1,115 @@
+interactions:
+- request:
+    body: '{"include":[],"input":[{"role":"user","content":[{"type":"input_text","text":"Hello,
+      can you help me?"}]},{"role":"assistant","content":[{"type":"output_text","text":"Of
+      course! How can I help you?"}]},{"role":"user","content":[{"type":"input_text","text":"What
+      is the weather like?"}]}],"instructions":"You are a helpful assistant.","model":"gpt-4o","stream":false,"tools":[]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '377'
+      content-type:
+      - application/json
+      cookie:
+      - _cfuvid=PWHn6CD5_OXbE3jv9HT7E4FDlSvoTN5AciqTl4Chslg-1755280559217-0.0.1.1-604800000
+      host:
+      - api.openai.com
+      user-agent:
+      - Agents/Python 0.2.7
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.99.9
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.10
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3RUTW/bMAy951cIuuzSFPlwHDv/YLddh2IwaIlOtMqiIFFdg6L/fbCcOPGWXgKH
+        j3x6fKT0sRBCGi0PQgaMvimrdt1u243aaVWt601dVKqua70r1H5XAKyKUu8qVW/KYqt0qeTTQEDt
+        b1R8JSEXcYyrgMCoGxiw9X5XFvtyu60yFhk4xaFGUe8tMuqxqAX1egyU3KCqAxsxhzEECvIgXLI2
+        B4y7FjYaGYyNczRySIoNuXzIT0oCAgoQJ7S+S1ZAjCYyOH4ez+3hvaHEPnHD9IpuRjeATGQbBXZ+
+        UE8a7XDC0fOyoOVmtSmWq2q5Ki/eZEp5EC8LIYT4yL+T6X08Xj3f1tBWg+dVVdadWumy2FWbQu0e
+        ep45+Owxs2CMcMQb8JW5GVTkGN1N0r2sGe3VDXznqTongHPEcPX25dcMtHT0gdoHSCY6CPldKHDf
+        WPhAb0ajCAh2yaZH8QeBTxhE8hoY47P4YREiCnVC9SpgwiOGN6NQUBDgvegoCD6hsEMRC+M6Cn3W
+        J4wTZ0phmD08y0nN5+VrEigD2dz0tBZj8pCYk6SHANaine8BhzTupw/4ZijF5noFmjzhaU98oN5z
+        o0CdsHnF8z0WECI5447ycJmExK6jwHdJw1RT30O4Vi6E+BxvEnTI58ZodGw6g7NbcnGq4TEuNXaQ
+        7DhPGZkC3jfB2HsMwCmH18+rSzTP7aJs9Hb6f7cvOW907aL4DUNL0fB53FJtUi8n3aOPJzJqND4x
+        yQm4rY9k8s3dUq2moL/XGJJTeeS5SxOhtdcXJeXLMTVg3OyOF/un/+N3T8rUZh6dvhWuZq3++3Rs
+        ikfAI95p+l9RMzHYG7hfTxamOJ92jwwaGAb6z8XnXwAAAP//AwBykjkw3gUAAA==
+    headers:
+      CF-RAY:
+      - 976c9abcf9ddbfae-ATL
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 29 Aug 2025 14:05:40 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=h5OPTb88ihzuHT.qP.Oj0SjE_tWpmfRrWNu4mUt4S1M-1756476340-1.0.1.1-80gk3ddE8DF8Q.NmuO.XNa5K71CoOLh.zzIRZmQUTtuH9p5jeXANgE.9G0ftTm8nXAM5XP_aHRdq_w_OfFWfYb04R5SPCVAWJdr.st7L2AM;
+        path=/; expires=Fri, 29-Aug-25 14:35:40 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=TLb_ZfjHeeZ44eIV0y..9xwip611QAuocoxSqi3HLzY-1756476340100-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - traceloop
+      openai-processing-ms:
+      - '1313'
+      openai-project:
+      - proj_tzz1TbPPOXaf6j9tEkVUBIAa
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-envoy-upstream-service-time:
+      - '1318'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999934'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_79d83ab696490c185fd869f472d7deed
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [ ] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds JSON serialization for dictionary content in OpenAI agent spans and tests this functionality.
> 
>   - **Behavior**:
>     - In `_hooks.py`, `on_span_end()` now serializes dictionary content in `message.content` to JSON strings before setting attributes.
>     - Handles both `ResponseSpanData` and `GenerationSpanData` types.
>   - **Tests**:
>     - Adds `test_dict_content_serialization()` in `test_openai_agents.py` to verify dictionary content is serialized to JSON strings.
>     - Includes a new VCR cassette `test_dict_content_serialization.yaml` for testing serialized content.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 4ef8bd786576d24acb008d34d9c8c83234b8a0ff. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prompt message content is now consistently serialized to strings in telemetry spans, preventing issues when messages include structured/dict content and improving compatibility with tracing backends.

- Tests
  - Added a deterministic test and recorded cassette to verify correct serialization of structured prompt content during agent runs without network access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->