### PR TITLE
fix(openai-agents): ensure all content types are serialized consistently

### DIFF
--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
@@ -244,7 +244,7 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
                             if 'role' in message and 'content' in message:
                                 otel_span.set_attribute(f"{SpanAttributes.LLM_PROMPTS}.{i}.role", message['role'])
                                 content = message['content']
-                                if isinstance(content, dict):
+                                if not isinstance(content, str):
                                     content = json.dumps(content)
                                 otel_span.set_attribute(f"{SpanAttributes.LLM_PROMPTS}.{i}.content", content)
 
@@ -372,14 +372,14 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
                         if hasattr(message, 'role') and hasattr(message, 'content'):
                             otel_span.set_attribute(f"gen_ai.prompt.{i}.role", message.role)
                             content = message.content
-                            if isinstance(content, dict):
+                            if not isinstance(content, str):
                                 content = json.dumps(content)
                             otel_span.set_attribute(f"gen_ai.prompt.{i}.content", content)
                         elif isinstance(message, dict):
                             if 'role' in message and 'content' in message:
                                 otel_span.set_attribute(f"gen_ai.prompt.{i}.role", message['role'])
                                 content = message['content']
-                                if isinstance(content, dict):
+                                if not isinstance(content, str):
                                     content = json.dumps(content)
                                 otel_span.set_attribute(f"gen_ai.prompt.{i}.content", content)
 


### PR DESCRIPTION
## Summary
• Fixes inconsistent content serialization in OpenTelemetry attributes that was causing type warnings
• Previously only dict types were serialized to JSON, but lists and other non-string types could still cause "Invalid type dict in attribute" warnings
• Now all non-string content is consistently serialized using json.dumps() before being set as span attributes

## Test plan
- [x] Existing test `test_dict_content_serialization` passes
- [x] All openai-agents package tests pass
- [x] No more OpenTelemetry attribute type warnings for complex content structures

🤖 Generated with [Claude Code](https://claude.ai/code)