### PR TITLE
feat(langchain): allow configuration of metadata key prefix

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
@@ -37,10 +37,24 @@ class LangchainInstrumentor(BaseInstrumentor):
         exception_logger=None,
         disable_trace_context_propagation=False,
         use_legacy_attributes: bool = True,
+        metadata_key_prefix: Optional[str] = None
     ):
+        """Create a Langchain instrumentor instance.
+        
+        Args:
+            exception_logger: A callable that takes an Exception as input. This will be
+                used to log exceptions that occur during instrumentation. If None, exceptions will not be logged.
+            disable_trace_context_propagation: If True, disables trace context propagation to LLM providers.
+            use_legacy_attributes: If True, uses span attributes for Inputs/Outputs instead of events.
+            metadata_key_prefix: Prefix for metadata keys added to spans. If None, defaults to
+                `SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES`.
+                Useful for using with other backends.
+        """
         super().__init__()
         Config.exception_logger = exception_logger
         Config.use_legacy_attributes = use_legacy_attributes
+        if metadata_key_prefix:
+            Config.metadata_key_prefix = metadata_key_prefix
         self.disable_trace_context_propagation = disable_trace_context_propagation
 
     def instrumentation_dependencies(self) -> Collection[str]:

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
@@ -290,7 +290,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
             for key, value in sanitized_metadata.items():
                 _set_span_attribute(
                     span,
-                    f"{SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES}.{key}",
+                    f"{Config.metadata_key_prefix}.{key}",
                     value,
                 )
 

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/config.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/config.py
@@ -1,9 +1,10 @@
 from typing import Optional
 
 from opentelemetry._events import EventLogger
-
+from opentelemetry.semconv_ai import SpanAttributes
 
 class Config:
     exception_logger = None
     use_legacy_attributes = True
     event_logger: Optional[EventLogger] = None
+    metadata_key_prefix: str = SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

Allowing to configure the key prefix for metadata enables use on other backends.
As an example for Langfuse v3 otel backend, you can use prefix `langfuse.metadata` to make user.id and session.id available.

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [ ] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
