### PR TITLE
fix(sdk): dual bearer send via httpx

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/client/client.py
+++ b/packages/traceloop-sdk/traceloop/sdk/client/client.py
@@ -54,7 +54,7 @@ class Client:
         self._async_http = httpx.AsyncClient(
             base_url=self.api_endpoint,
             headers={
-                "Authorization": self.api_key,
+                "Authorization": f"Bearer {self.api_key}",
                 "Content-Type": "application/json",
                 "User-Agent": f"traceloop-sdk/{__version__}",
             },

--- a/packages/traceloop-sdk/traceloop/sdk/client/client.py
+++ b/packages/traceloop-sdk/traceloop/sdk/client/client.py
@@ -54,7 +54,7 @@ class Client:
         self._async_http = httpx.AsyncClient(
             base_url=self.api_endpoint,
             headers={
-                "Authorization": f"Bearer {self.api_key}",
+                "Authorization": self.api_key,
                 "Content-Type": "application/json",
                 "User-Agent": f"traceloop-sdk/{__version__}",
             },

--- a/packages/traceloop-sdk/traceloop/sdk/evaluator/stream_client.py
+++ b/packages/traceloop-sdk/traceloop/sdk/evaluator/stream_client.py
@@ -21,7 +21,7 @@ class SSEClient:
         """
         try:
             headers = {
-                "Authorization": f"Bearer {self.client.headers.get('Authorization')}",
+                "Authorization": self.client.headers.get('Authorization'),
                 "Accept": "text/event-stream",
                 "Cache-Control": "no-cache",
             }


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [ ] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes Authorization header in `wait_for_result` of `stream_client.py` to resolve unauthorized errors due to dual bearer tokens.
> 
>   - **Bug Fix**:
>     - Fixes Authorization header in `wait_for_result` function of `stream_client.py` to prevent dual bearer token issue causing unauthorized errors.
>   - **Behavior**:
>     - Ensures correct header format for server expectations, improving connection reliability.
>     - No changes to function signatures or other headers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for df20bcad5db87ad25b8c42db397c8c0bcc7097a3. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

at the current state the api service receiving duel bearer
so the request been failed due unauthorized
<img width="401" height="78" alt="image" src="https://github.com/user-attachments/assets/8dd88bc1-eda7-4a4f-9948-d1f99077b52d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Authorization header handling in evaluator streaming requests to use the configured value as-is, improving compatibility with non-Bearer schemes and preventing duplicate prefixes. No API changes.
  * Action required: If you previously relied on automatic “Bearer ” prefixing, ensure your Authorization header includes the appropriate scheme (e.g., “Bearer <token>”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->