### PR TITLE
feat(bedrock): Add prompt caching support for Converse API

### DIFF
--- a/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/__init__.py
+++ b/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/__init__.py
@@ -22,7 +22,10 @@ from opentelemetry.instrumentation.bedrock.guardrail import (
     guardrail_converse,
     guardrail_handling,
 )
-from opentelemetry.instrumentation.bedrock.prompt_caching import prompt_caching_handling
+from opentelemetry.instrumentation.bedrock.prompt_caching import (
+    prompt_caching_converse_handling,
+    prompt_caching_handling,
+)
 from opentelemetry.instrumentation.bedrock.reusable_streaming_body import (
     ReusableStreamingBody,
 )
@@ -354,6 +357,7 @@ def _handle_call(span: Span, kwargs, response, metric_params, event_logger):
 def _handle_converse(span, kwargs, response, metric_params, event_logger):
     (provider, model_vendor, model) = _get_vendor_model(kwargs.get("modelId"))
     guardrail_converse(span, response, provider, model, metric_params)
+    prompt_caching_converse_handling(response, provider, model, metric_params)
 
     set_converse_model_span_attributes(span, provider, model, kwargs)
 
@@ -394,7 +398,11 @@ def _handle_converse_stream(span, kwargs, response, metric_params, event_logger)
                     role = event["messageStart"]["role"]
                 elif "metadata" in event:
                     # last message sent
+                    metadata = event.get("metadata", {})
                     guardrail_converse(span, event["metadata"], provider, model, metric_params)
+                    prompt_caching_converse_handling( 
+                        metadata, provider, model, metric_params
+                    )
                     converse_usage_record(span, event["metadata"], metric_params)
                     span.end()
                 elif "messageStop" in event:

--- a/packages/opentelemetry-instrumentation-bedrock/tests/metrics/test_bedrock_converse_prompt_caching_metrics.py
+++ b/packages/opentelemetry-instrumentation-bedrock/tests/metrics/test_bedrock_converse_prompt_caching_metrics.py
@@ -1,0 +1,69 @@
+import pytest
+from opentelemetry.instrumentation.bedrock import PromptCaching
+from opentelemetry.instrumentation.bedrock.prompt_caching import CacheSpanAttrs
+
+
+def call(brt):
+    return brt.converse(
+        modelId="anthropic.claude-3-haiku-20240307-v1:0",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "text": "What is the capital of the USA?",
+                    }
+                ],
+            }
+        ],
+        inferenceConfig={"maxTokens": 50, "temperature": 0.1},
+        additionalModelRequestFields={"cacheControl": {"type": "ephemeral"}},
+    )
+
+
+def get_metric(resource_metrics, name):
+    for rm in resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name == name:
+                    return metric
+    raise Exception(f"No metric found with name {name}")
+
+
+def assert_metric(reader, usage):
+    metrics_data = reader.get_metrics_data()
+    resource_metrics = metrics_data.resource_metrics
+    assert len(resource_metrics) > 0
+
+    m = get_metric(resource_metrics, PromptCaching.LLM_BEDROCK_PROMPT_CACHING)
+    for data_point in m.data.data_points:
+        assert data_point.attributes[CacheSpanAttrs.TYPE] in [
+            "read",
+            "write",
+        ]
+        if data_point.attributes[CacheSpanAttrs.TYPE] == "read":
+            assert data_point.value == usage["cache_read_input_tokens"]
+        else:
+            assert data_point.value == usage["cache_creation_input_tokens"]
+
+
+@pytest.mark.vcr
+def test_prompt_cache_converse(test_context, brt):
+    _, _, reader = test_context
+
+    response = call(brt)
+    # assert first prompt writes a cache
+    usage = response["usage"]
+    assert usage["cache_read_input_tokens"] == 0
+    assert usage["cache_creation_input_tokens"] > 0
+    cumulative_workaround = usage["cache_creation_input_tokens"]
+    assert_metric(reader, usage)
+
+    response = call(brt)
+    # assert second prompt reads from the cache
+    usage = response["usage"]
+    assert usage["cache_read_input_tokens"] > 0
+    assert usage["cache_creation_input_tokens"] == 0
+    # data is stored across reads of metric data due to the cumulative behavior
+    usage["cache_creation_input_tokens"] = cumulative_workaround
+    assert_metric(reader, usage)


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [x] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
---

### Description

This PR introduces prompt caching telemetry for the AWS Bedrock **Converse** and **Converse Stream** APIs, bringing feature parity with the existing `invoke_model` instrumentation.

The Converse API reports caching information in the `usage` field of the response body, rather than through HTTP headers. This implementation adds the necessary logic to parse this information and record it as metrics and span attributes.

**Changes include:**
1.  **New function `prompt_caching_converse_handling`** in `prompt_caching.py` to extract `cache_read_input_tokens` and `cache_creation_input_tokens` from the response body.
2.  **Integration into `__init__.py`**: The new function is now called from `_handle_converse` and `_handle_converse_stream` to process caching data for both standard and streaming calls.
3.  **New Test File**: Added `test_bedrock_converse_prompt_caching_metrics.py` to validate that the `gen_ai.prompt.caching` metric is correctly emitted for the Converse API.

Fixes #3337

