### PR TITLE
fix(langchain): span attrs and metrics missing of langchain third party integration

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
@@ -54,7 +54,7 @@ from opentelemetry.instrumentation.langchain.utils import (
     should_send_prompts,
 )
 from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
-from opentelemetry.metrics import Histogram
+from opentelemetry.metrics import Histogram, Counter
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
     GEN_AI_RESPONSE_ID,
 )
@@ -146,15 +146,64 @@ def _extract_tool_call_data(
 
 class TraceloopCallbackHandler(BaseCallbackHandler):
     def __init__(
-        self, tracer: Tracer, duration_histogram: Histogram, token_histogram: Histogram
+        self,
+        tracer: Tracer,
+        duration_histogram: Histogram,
+        token_histogram: Histogram,
+        ttft_histogram: Histogram,
+        streaming_time_histogram: Histogram,
+        choices_counter: Counter,
+        exception_counter: Counter
     ) -> None:
         super().__init__()
         self.tracer = tracer
         self.duration_histogram = duration_histogram
         self.token_histogram = token_histogram
+        self.ttft_histogram = ttft_histogram
+        self.streaming_time_histogram = streaming_time_histogram
+        self.choices_counter = choices_counter
+        self.exception_counter = exception_counter
         self.spans: dict[UUID, SpanHolder] = {}
         self.run_inline = True
         self._callback_manager: CallbackManager | AsyncCallbackManager = None
+
+    def _create_shared_attributes(
+        self, span, model_name: str, operation_type: str = None, is_streaming: bool = False
+    ) -> dict:
+        """Create shared attributes for metrics matching OpenAI SDK structure."""
+        vendor = span.attributes.get(SpanAttributes.LLM_SYSTEM, "Langchain")
+        attributes = {
+            SpanAttributes.LLM_SYSTEM: vendor,
+            SpanAttributes.LLM_RESPONSE_MODEL: model_name,
+        }
+        # Add operation name if available
+        if operation_type:
+            attributes["gen_ai.operation.name"] = operation_type
+        elif span.attributes.get(SpanAttributes.LLM_REQUEST_TYPE):
+            attributes["gen_ai.operation.name"] = span.attributes.get(SpanAttributes.LLM_REQUEST_TYPE)
+        server_address = None
+        try:
+            association_properties = context_api.get_value("association_properties") or {}
+            server_address = (
+                association_properties.get("api_base") or
+                association_properties.get("endpoint") or
+                association_properties.get("base_url") or
+                association_properties.get("server_address")
+            )
+        except Exception:
+            pass
+
+        if not server_address:
+            # Check if we can get it from span attributes
+            server_address = span.attributes.get("server.address")
+
+        if server_address:
+            attributes["server.address"] = server_address
+
+        if is_streaming:
+            attributes["stream"] = True
+
+        return attributes
 
     @staticmethod
     def _get_name_from_callback(
@@ -494,7 +543,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
             metadata=metadata,
             serialized=serialized,
         )
-        set_request_params(span, kwargs, self.spans[run_id])
+        set_request_params(span, kwargs, self.spans[run_id], serialized, metadata)
         if should_emit_events():
             self._emit_chat_input_events(messages)
         else:
@@ -524,12 +573,52 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
             LLMRequestTypeValues.COMPLETION,
             serialized=serialized,
         )
-        set_request_params(span, kwargs, self.spans[run_id])
+        set_request_params(span, kwargs, self.spans[run_id], serialized, metadata)
         if should_emit_events():
             for prompt in prompts:
                 emit_event(MessageEvent(content=prompt, role="user"))
         else:
             set_llm_request(span, serialized, prompts, kwargs, self.spans[run_id])
+
+    @dont_throw
+    def on_llm_new_token(
+        self,
+        token: str,
+        *,
+        chunk: Optional[Union[GenerationChunk, ChatGenerationChunk]] = None,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Run on new LLM token. Track TTFT and streaming metrics."""
+        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
+            return
+
+        if run_id not in self.spans:
+            return
+
+        span_holder = self.spans[run_id]
+        current_time = time.time()
+
+        # Track time to first token
+        if span_holder.first_token_time is None:
+            span_holder.first_token_time = current_time
+            ttft = current_time - span_holder.start_time
+
+            # Record TTFT metric
+            span = span_holder.span
+            from opentelemetry.instrumentation.langchain.span_utils import _get_unified_unknown_model
+
+            model_name = (
+                span.attributes.get(SpanAttributes.LLM_RESPONSE_MODEL) or
+                span_holder.request_model or
+                _get_unified_unknown_model(existing_model=span_holder.request_model)
+            )
+
+            self.ttft_histogram.record(
+                ttft,
+                attributes=self._create_shared_attributes(span, model_name, is_streaming=True)
+            )
 
     @dont_throw
     def on_llm_end(
@@ -552,7 +641,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
             ) or response.llm_output.get("model_id")
             if model_name is not None:
                 _set_span_attribute(
-                    span, SpanAttributes.LLM_RESPONSE_MODEL, model_name or "unknown"
+                    span, SpanAttributes.LLM_RESPONSE_MODEL, model_name
                 )
 
                 if self.spans[run_id].request_model is None:
@@ -571,6 +660,20 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
             model_name = _extract_model_name_from_association_metadata(
                 association_properties
             )
+
+        # Final fallback: use model name from request if all else fails
+        if model_name is None and run_id in self.spans and self.spans[run_id].request_model:
+            model_name = self.spans[run_id].request_model
+
+        # Ensure model_name is never None for downstream usage
+        if model_name is None:
+            from opentelemetry.instrumentation.langchain.span_utils import _get_unified_unknown_model
+            existing_model = self.spans[run_id].request_model if run_id in self.spans else None
+            model_name = _get_unified_unknown_model(existing_model=existing_model)
+
+        # Update span attribute with final resolved model name
+        _set_span_attribute(span, SpanAttributes.LLM_RESPONSE_MODEL, model_name)
+
         token_usage = (response.llm_output or {}).get("token_usage") or (
             response.llm_output or {}
         ).get("usage")
@@ -600,44 +703,47 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
             )
 
             # Record token usage metrics
-            vendor = span.attributes.get(SpanAttributes.LLM_SYSTEM, "Langchain")
+            base_attrs = self._create_shared_attributes(span, model_name)
+
             if prompt_tokens > 0:
-                self.token_histogram.record(
-                    prompt_tokens,
-                    attributes={
-                        SpanAttributes.LLM_SYSTEM: vendor,
-                        SpanAttributes.LLM_TOKEN_TYPE: "input",
-                        SpanAttributes.LLM_RESPONSE_MODEL: model_name or "unknown",
-                    },
-                )
+                input_attrs = {**base_attrs, SpanAttributes.LLM_TOKEN_TYPE: "input"}
+                self.token_histogram.record(prompt_tokens, attributes=input_attrs)
 
             if completion_tokens > 0:
-                self.token_histogram.record(
-                    completion_tokens,
-                    attributes={
-                        SpanAttributes.LLM_SYSTEM: vendor,
-                        SpanAttributes.LLM_TOKEN_TYPE: "output",
-                        SpanAttributes.LLM_RESPONSE_MODEL: model_name or "unknown",
-                    },
-                )
-        set_chat_response_usage(
-            span, response, self.token_histogram, token_usage is None, model_name
-        )
+                output_attrs = {**base_attrs, SpanAttributes.LLM_TOKEN_TYPE: "output"}
+                self.token_histogram.record(completion_tokens, attributes=output_attrs)
+        # Only call set_chat_response_usage if we didn't record token metrics above
+        # to avoid duplicate recording
+        if token_usage is None:
+            set_chat_response_usage(
+                span, response, self.token_histogram, True, model_name
+            )
         if should_emit_events():
             self._emit_llm_end_events(response)
         else:
             set_chat_response(span, response)
 
-        # Record duration before ending span
-        duration = time.time() - self.spans[run_id].start_time
-        vendor = span.attributes.get(SpanAttributes.LLM_SYSTEM, "Langchain")
-        self.duration_histogram.record(
-            duration,
-            attributes={
-                SpanAttributes.LLM_SYSTEM: vendor,
-                SpanAttributes.LLM_RESPONSE_MODEL: model_name or "unknown",
-            },
-        )
+        # Record generation choices count
+        total_choices = 0
+        for generation_list in response.generations:
+            total_choices += len(generation_list)
+
+        span_holder = self.spans[run_id]
+        current_time = time.time()
+        is_streaming_request = span_holder.first_token_time is not None
+
+        shared_attrs = self._create_shared_attributes(span, model_name, is_streaming=is_streaming_request)
+
+        if total_choices > 0:
+            self.choices_counter.add(total_choices, attributes=shared_attrs)
+
+        # Record streaming time to generate if TTFT was tracked
+        if span_holder.first_token_time is not None:
+            streaming_time = current_time - span_holder.first_token_time
+            self.streaming_time_histogram.record(streaming_time, attributes=shared_attrs)
+
+        duration = current_time - span_holder.start_time
+        self.duration_histogram.record(duration, attributes=shared_attrs)
 
         self._end_span(span, run_id)
 
@@ -752,6 +858,23 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         span = self._get_span(run_id)
         span.set_status(Status(StatusCode.ERROR))
         span.record_exception(error)
+
+        # Record exception metric for LLM errors
+        if run_id in self.spans:
+            span_holder = self.spans[run_id]
+            from opentelemetry.instrumentation.langchain.span_utils import _get_unified_unknown_model
+
+            model_name = (
+                span.attributes.get(SpanAttributes.LLM_RESPONSE_MODEL) or
+                span_holder.request_model or
+                _get_unified_unknown_model(existing_model=span_holder.request_model)
+            )
+
+            exception_attrs = self._create_shared_attributes(span, model_name)
+            exception_attrs[ERROR_TYPE] = type(error).__name__
+
+            self.exception_counter.add(1, attributes=exception_attrs)
+
         self._end_span(span, run_id)
 
     @dont_throw

--- a/packages/opentelemetry-instrumentation-langchain/tests/metrics/test_langchain_metrics.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/metrics/test_langchain_metrics.py
@@ -5,6 +5,8 @@ from langchain.chains import LLMChain
 from langchain.prompts import PromptTemplate
 from langchain_openai import ChatOpenAI
 from opentelemetry.semconv_ai import Meters, SpanAttributes
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
+from opentelemetry.semconv._incubating.metrics import gen_ai_metrics as GenAIMetrics
 from langgraph.graph import StateGraph
 from openai import OpenAI
 
@@ -90,6 +92,9 @@ def test_llm_chain_streaming_metrics(instrument_legacy, reader, llm):
 
     found_token_metric = False
     found_duration_metric = False
+    found_choices_metric = False
+    found_ttft_metric = False
+    found_streaming_time_metric = False
 
     for rm in resource_metrics:
         for sm in rm.scope_metrics:
@@ -121,8 +126,51 @@ def test_llm_chain_streaming_metrics(instrument_legacy, reader, llm):
                             == "openai"
                         )
 
+                if metric.name == Meters.LLM_GENERATION_CHOICES:
+                    found_choices_metric = True
+                    assert any(
+                        data_point.value >= 1 for data_point in metric.data.data_points
+                    )
+                    for data_point in metric.data.data_points:
+                        assert (
+                            data_point.attributes[SpanAttributes.LLM_SYSTEM]
+                            == "openai"
+                        )
+
+                if metric.name == GenAIMetrics.GEN_AI_SERVER_TIME_TO_FIRST_TOKEN:
+                    found_ttft_metric = True
+                    assert any(
+                        data_point.count > 0 for data_point in metric.data.data_points
+                    )
+                    assert any(
+                        data_point.sum > 0 for data_point in metric.data.data_points
+                    )
+                    for data_point in metric.data.data_points:
+                        assert (
+                            data_point.attributes[SpanAttributes.LLM_SYSTEM]
+                            == "openai"
+                        )
+
+                if metric.name == Meters.LLM_STREAMING_TIME_TO_GENERATE:
+                    found_streaming_time_metric = True
+                    assert any(
+                        data_point.count > 0 for data_point in metric.data.data_points
+                    )
+                    assert any(
+                        data_point.sum > 0 for data_point in metric.data.data_points
+                    )
+                    for data_point in metric.data.data_points:
+                        assert (
+                            data_point.attributes[SpanAttributes.LLM_SYSTEM]
+                            == "openai"
+                        )
+
     assert found_token_metric is True
     assert found_duration_metric is True
+    assert found_choices_metric is True
+    assert found_ttft_metric is True
+    assert found_streaming_time_metric is True
+    # Note: TTFT and streaming time metrics may only be present with streaming responses
 
 
 def verify_token_metrics(data_points):
@@ -265,3 +313,127 @@ def test_langgraph_metrics(instrument_legacy, reader, openai_client):
             == "openai"
         )
         assert data_point.value > 0
+
+
+@pytest.mark.vcr
+def test_streaming_with_ttft_and_generation_time_metrics(instrument_legacy, reader):
+    """Test streaming metrics with actual token-by-token response."""
+    from langchain_core.prompts import ChatPromptTemplate
+
+    # Use a model that supports streaming
+    llm = ChatOpenAI(
+        model="gpt-3.5-turbo",
+        temperature=0.7,
+        streaming=True
+    )
+
+    prompt = ChatPromptTemplate.from_template("Write a very short story about {topic}")
+    chain = prompt | llm
+
+    # Stream the response to trigger on_llm_new_token calls
+    response_chunks = []
+    for chunk in chain.stream({"topic": "a robot learning to paint"}):
+        response_chunks.append(chunk)
+
+    # Verify we got streaming chunks
+    assert len(response_chunks) > 1, "Should have multiple chunks for streaming"
+
+    metrics_data = reader.get_metrics_data()
+    resource_metrics = metrics_data.resource_metrics
+    assert len(resource_metrics) > 0
+
+    found_token_metric = False
+    found_duration_metric = False
+    found_choices_metric = False
+    found_ttft_metric = False
+    found_streaming_time_metric = False
+    found_exception_metric = False
+
+    for rm in resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name == Meters.LLM_TOKEN_USAGE:
+                    found_token_metric = True
+
+                elif metric.name == Meters.LLM_OPERATION_DURATION:
+                    found_duration_metric = True
+                    assert any(
+                        data_point.sum > 0 for data_point in metric.data.data_points
+                    )
+
+                elif metric.name == Meters.LLM_GENERATION_CHOICES:
+                    found_choices_metric = True
+                    assert any(
+                        data_point.value >= 1 for data_point in metric.data.data_points
+                    )
+
+                elif metric.name == GenAIMetrics.GEN_AI_SERVER_TIME_TO_FIRST_TOKEN:
+                    found_ttft_metric = True
+                    assert any(
+                        data_point.count > 0 for data_point in metric.data.data_points
+                    )
+                    assert any(
+                        data_point.sum > 0 for data_point in metric.data.data_points
+                    )
+
+                elif metric.name == Meters.LLM_STREAMING_TIME_TO_GENERATE:
+                    found_streaming_time_metric = True
+                    assert any(
+                        data_point.count > 0 for data_point in metric.data.data_points
+                    )
+
+                elif metric.name == "llm.langchain.completions.exceptions":
+                    found_exception_metric = True
+
+    # Basic metrics should always be present
+    assert found_token_metric is True
+    assert found_duration_metric is True
+    assert found_choices_metric is True
+    assert found_ttft_metric is True
+    assert found_streaming_time_metric is True
+    assert found_exception_metric is True
+
+    # Streaming-specific metrics should be present with actual streaming
+    # Note: These might not appear if the LLM doesn't actually stream tokens individually
+    # This depends on the model and provider implementation
+
+
+def test_exception_metrics(instrument_legacy, reader):
+    """Test that exception metrics are recorded when LLM calls fail."""
+    from unittest.mock import patch
+
+    llm = ChatOpenAI(model="gpt-3.5-turbo")
+    chain = LLMChain(
+        llm=llm,
+        prompt=PromptTemplate(
+            input_variables=["product"],
+            template="What is a good name for a company that makes {product}?",
+        )
+    )
+
+    # Mock the LLM to raise an exception
+    with patch.object(llm, '_generate', side_effect=Exception("API Error")):
+        try:
+            chain.run(product="test")
+        except Exception:
+            pass  # Expected to fail
+
+    metrics_data = reader.get_metrics_data()
+    resource_metrics = metrics_data.resource_metrics
+    assert len(resource_metrics) > 0
+
+    found_exception_metric = False
+
+    for rm in resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name == "llm.langchain.completions.exceptions":
+                    found_exception_metric = True
+                    assert any(
+                        data_point.value >= 1 for data_point in metric.data.data_points
+                    )
+                    # Check that error attributes are set
+                    for data_point in metric.data.data_points:
+                        assert "error.type" in data_point.attributes or ERROR_TYPE in data_point.attributes
+
+    assert found_exception_metric is True

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_model_extraction.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_model_extraction.py
@@ -1,0 +1,192 @@
+from unittest.mock import Mock
+from opentelemetry.instrumentation.langchain.span_utils import (
+    _extract_model_name_from_request,
+    _infer_model_from_class_name,
+    extract_model_name_from_response_metadata,
+    SpanHolder,
+)
+from langchain_core.outputs import LLMResult, Generation, ChatGeneration
+from langchain_core.messages import AIMessage
+
+
+class TestModelExtraction:
+    """Test enhanced model name extraction for third-party integrations."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_span = Mock()
+        self.span_holder = SpanHolder(
+            span=self.mock_span,
+            token=None,
+            context=None,
+            children=[],
+            workflow_name="test",
+            entity_name="test",
+            entity_path="test"
+        )
+
+    def test_standard_model_extraction_from_kwargs(self):
+        """Test standard model extraction from kwargs."""
+        kwargs = {"model": "gpt-4"}
+
+        result = _extract_model_name_from_request(kwargs, self.span_holder)
+        assert result == "gpt-4"
+
+    def test_model_extraction_from_invocation_params(self):
+        """Test model extraction from invocation_params."""
+        kwargs = {
+            "invocation_params": {
+                "model": "claude-3-sonnet"
+            }
+        }
+
+        result = _extract_model_name_from_request(kwargs, self.span_holder)
+        assert result == "claude-3-sonnet"
+
+    def test_deepseek_model_extraction_from_serialized(self):
+        """Test ChatDeepSeek model extraction from serialized data."""
+        kwargs = {}
+        serialized = {
+            "id": ["langchain", "chat_models", "ChatDeepSeek"],
+            "kwargs": {
+                "model": "deepseek-coder",
+                "api_base": "https://api.deepseek.com/beta"
+            }
+        }
+
+        result = _extract_model_name_from_request(kwargs, self.span_holder, serialized)
+        assert result == "deepseek-coder"
+
+    def test_deepseek_fallback_when_no_model_in_serialized(self):
+        """Test ChatDeepSeek fallback to default model."""
+        kwargs = {}
+        serialized = {
+            "id": ["langchain", "chat_models", "ChatDeepSeek"],
+            "kwargs": {
+                "api_base": "https://api.deepseek.com/beta"
+                # No model field
+            }
+        }
+
+        result = _extract_model_name_from_request(kwargs, self.span_holder, serialized)
+        assert result == "deepseek-unknown"
+
+    def test_class_name_inference_for_known_models(self):
+        """Test model inference from class names for known integrations."""
+        test_cases = [
+            ("ChatOpenAI", {}, "gpt-unknown"),
+            ("ChatAnthropic", {}, "claude-unknown"),
+            ("ChatCohere", {}, "command-unknown"),
+            ("ChatOllama", {}, "ollama-unknown"),
+        ]
+
+        for class_name, serialized, expected in test_cases:
+            result = _infer_model_from_class_name(class_name, serialized)
+            assert result == expected, f"Failed for {class_name}"
+
+    def test_unknown_class_returns_unknown(self):
+        """Test that unknown class names return unknown."""
+        result = _infer_model_from_class_name("SomeUnknownModel", {})
+        assert result == "unknown"
+
+    def test_enhanced_response_metadata_extraction(self):
+        """Test enhanced response metadata extraction."""
+
+        # Test with response_metadata
+        message = AIMessage(
+            content="Test response",
+            response_metadata={"model": "deepseek-v2"}
+        )
+        generation = ChatGeneration(message=message)
+        response = LLMResult(generations=[[generation]])
+
+        result = extract_model_name_from_response_metadata(response)
+        assert result == "deepseek-v2"
+
+    def test_response_extraction_from_llm_output(self):
+        """Test model extraction from llm_output."""
+        response = LLMResult(
+            generations=[[Generation(text="Test")]],
+            llm_output={"model": "deepseek-coder-v2"}
+        )
+
+        result = extract_model_name_from_response_metadata(response)
+        assert result == "deepseek-coder-v2"
+
+    def test_response_extraction_from_generation_info(self):
+        """Test model extraction from generation_info."""
+        generation = Generation(
+            text="Test response",
+            generation_info={"model_name": "deepseek-reasoner"}
+        )
+        response = LLMResult(generations=[[generation]])
+
+        result = extract_model_name_from_response_metadata(response)
+        assert result == "deepseek-reasoner"
+
+    def test_model_extraction_priority_order(self):
+        """Test that model extraction follows correct priority order."""
+        # kwargs should have highest priority
+        kwargs = {"model": "from-kwargs"}
+        serialized = {
+            "id": ["ChatDeepSeek"],
+            "kwargs": {"model": "from-serialized"}
+        }
+
+        result = _extract_model_name_from_request(kwargs, self.span_holder, serialized)
+        assert result == "from-kwargs"
+
+        # invocation_params should be second priority
+        kwargs = {
+            "invocation_params": {"model": "from-invocation-params"},
+            "kwargs": {"model": "from-nested-kwargs"}
+        }
+
+        result = _extract_model_name_from_request(kwargs, self.span_holder, serialized)
+        assert result == "from-invocation-params"
+
+    def test_nested_kwargs_extraction(self):
+        """Test extraction from nested kwargs structures."""
+        kwargs = {
+            "kwargs": {"model": "nested-model"}
+        }
+
+        result = _extract_model_name_from_request(kwargs, self.span_holder)
+        assert result == "nested-model"
+
+    def test_model_kwargs_extraction(self):
+        """Test extraction from model_kwargs."""
+        kwargs = {
+            "model_kwargs": {"model_name": "model-from-kwargs"}
+        }
+
+        result = _extract_model_name_from_request(kwargs, self.span_holder)
+        assert result == "model-from-kwargs"
+
+    def test_no_model_info_returns_unknown(self):
+        """Test that missing model info returns unknown."""
+        kwargs = {}
+        serialized = {"id": ["UnknownModel"]}
+
+        result = _extract_model_name_from_request(kwargs, self.span_holder, serialized)
+        assert result == "unknown"
+
+    def test_association_metadata_extraction(self):
+        """Test model extraction from association metadata (ChatDeepSeek pattern)."""
+        kwargs = {}
+        metadata = {"ls_model_name": "deepseek-reasoner"}
+
+        result = _extract_model_name_from_request(kwargs, self.span_holder, None, metadata)
+        assert result == "deepseek-reasoner"
+
+    def test_metadata_has_priority_over_class_inference(self):
+        """Test that association metadata has higher priority than class inference."""
+        kwargs = {}
+        serialized = {
+            "id": ["ChatDeepSeek"],
+            "kwargs": {}  # No model in serialized kwargs
+        }
+        metadata = {"ls_model_name": "deepseek-v3"}
+
+        result = _extract_model_name_from_request(kwargs, self.span_holder, serialized, metadata)
+        assert result == "deepseek-v3"  # Should use metadata, not fallback to "deepseek-chat"

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_streaming_metrics.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_streaming_metrics.py
@@ -1,0 +1,228 @@
+import time
+from unittest.mock import Mock
+from uuid import uuid4
+from langchain_core.outputs import LLMResult, Generation
+from opentelemetry.instrumentation.langchain.callback_handler import TraceloopCallbackHandler
+from opentelemetry.instrumentation.langchain.span_utils import SpanHolder
+from opentelemetry.semconv_ai import SpanAttributes
+from opentelemetry.trace import Span
+
+
+class TestStreamingMetrics:
+    """Test the new streaming metrics functionality."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.tracer = Mock()
+        self.duration_histogram = Mock()
+        self.token_histogram = Mock()
+        self.ttft_histogram = Mock()
+        self.streaming_time_histogram = Mock()
+        self.choices_counter = Mock()
+        self.exception_counter = Mock()
+
+        self.handler = TraceloopCallbackHandler(
+            self.tracer,
+            self.duration_histogram,
+            self.token_histogram,
+            self.ttft_histogram,
+            self.streaming_time_histogram,
+            self.choices_counter,
+            self.exception_counter,
+        )
+
+    def test_ttft_metric_recorded_on_first_token(self):
+        """Test that TTFT metric is recorded when first token arrives."""
+        run_id = uuid4()
+        mock_span = Mock(spec=Span)
+        mock_span.attributes = {SpanAttributes.LLM_SYSTEM: "Langchain"}
+
+        # Create span holder with specific start time
+        start_time = time.time()
+        span_holder = SpanHolder(
+            span=mock_span,
+            token=None,
+            context=None,
+            children=[],
+            workflow_name="test",
+            entity_name="test",
+            entity_path="test",
+            start_time=start_time
+        )
+        self.handler.spans[run_id] = span_holder
+
+        # Simulate first token arrival after a small delay
+        time.sleep(0.1)
+        self.handler.on_llm_new_token("Hello", run_id=run_id)
+
+        # Verify TTFT metric was recorded
+        self.ttft_histogram.record.assert_called_once()
+        args = self.ttft_histogram.record.call_args
+        ttft_value = args[0][0]
+        assert ttft_value > 0.05, "TTFT should be greater than 0.05 seconds"
+
+        # Verify attributes
+        attributes = args[1]["attributes"]
+        assert attributes[SpanAttributes.LLM_SYSTEM] == "Langchain"
+
+    def test_ttft_metric_not_recorded_on_subsequent_tokens(self):
+        """Test that TTFT metric is only recorded once."""
+        run_id = uuid4()
+        mock_span = Mock(spec=Span)
+        mock_span.attributes = {SpanAttributes.LLM_SYSTEM: "Langchain"}
+
+        span_holder = SpanHolder(
+            span=mock_span,
+            token=None,
+            context=None,
+            children=[],
+            workflow_name="test",
+            entity_name="test",
+            entity_path="test",
+            start_time=time.time()
+        )
+        self.handler.spans[run_id] = span_holder
+
+        # First token
+        self.handler.on_llm_new_token("Hello", run_id=run_id)
+        # Second token
+        self.handler.on_llm_new_token(" world", run_id=run_id)
+
+        # TTFT should only be recorded once
+        assert self.ttft_histogram.record.call_count == 1
+
+    def test_generation_choices_metric_recorded(self):
+        """Test that generation choices metric is recorded."""
+        run_id = uuid4()
+        mock_span = Mock(spec=Span)
+        mock_span.attributes = {SpanAttributes.LLM_SYSTEM: "Langchain"}
+
+        span_holder = SpanHolder(
+            span=mock_span,
+            token=None,
+            context=None,
+            children=[],
+            workflow_name="test",
+            entity_name="test",
+            entity_path="test",
+            start_time=time.time()
+        )
+        self.handler.spans[run_id] = span_holder
+
+        # Mock LLMResult with multiple generations
+        generation1 = Generation(text="Response 1")
+        generation2 = Generation(text="Response 2")
+        llm_result = LLMResult(
+            generations=[[generation1, generation2]],
+            llm_output={"model_name": "test-model"}
+        )
+
+        self.handler.on_llm_end(llm_result, run_id=run_id)
+
+        # Verify choices counter was called
+        self.choices_counter.add.assert_called_once_with(
+            2,  # Two choices
+            attributes={
+                SpanAttributes.LLM_SYSTEM: "Langchain",
+                SpanAttributes.LLM_RESPONSE_MODEL: "test-model",
+            }
+        )
+
+    def test_streaming_time_to_generate_metric(self):
+        """Test that streaming time to generate metric is recorded."""
+        run_id = uuid4()
+        mock_span = Mock(spec=Span)
+        mock_span.attributes = {SpanAttributes.LLM_SYSTEM: "Langchain"}
+
+        start_time = time.time()
+        span_holder = SpanHolder(
+            span=mock_span,
+            token=None,
+            context=None,
+            children=[],
+            workflow_name="test",
+            entity_name="test",
+            entity_path="test",
+            start_time=start_time
+        )
+        self.handler.spans[run_id] = span_holder
+
+        # Simulate token arrival
+        time.sleep(0.05)
+        self.handler.on_llm_new_token("Hello", run_id=run_id)
+
+        # Simulate completion after more time
+        time.sleep(0.05)
+        llm_result = LLMResult(
+            generations=[[Generation(text="Hello world")]],
+            llm_output={"model_name": "test-model"}
+        )
+
+        self.handler.on_llm_end(llm_result, run_id=run_id)
+
+        # Verify streaming time metric was recorded
+        self.streaming_time_histogram.record.assert_called_once()
+        args = self.streaming_time_histogram.record.call_args
+        streaming_time = args[0][0]
+        assert streaming_time > 0.04, "Streaming time should be greater than 0.04 seconds"
+
+    def test_exception_metric_recorded_on_error(self):
+        """Test that exception metric is recorded on LLM errors."""
+        run_id = uuid4()
+        mock_span = Mock(spec=Span)
+        mock_span.attributes = {SpanAttributes.LLM_SYSTEM: "Langchain"}
+
+        span_holder = SpanHolder(
+            span=mock_span,
+            token=None,
+            context=None,
+            children=[],
+            workflow_name="test",
+            entity_name="test",
+            entity_path="test",
+            start_time=time.time()
+        )
+        self.handler.spans[run_id] = span_holder
+
+        # Simulate error
+        error = ValueError("API Error")
+        self.handler.on_llm_error(error, run_id=run_id)
+
+        # Verify exception counter was called
+        self.exception_counter.add.assert_called_once_with(
+            1,
+            attributes={
+                SpanAttributes.LLM_SYSTEM: "Langchain",
+                SpanAttributes.LLM_RESPONSE_MODEL: "unknown",
+                "error.type": "ValueError",
+            }
+        )
+
+    def test_no_ttft_when_no_first_token_time(self):
+        """Test streaming time metric is not recorded without first token."""
+        run_id = uuid4()
+        mock_span = Mock(spec=Span)
+        mock_span.attributes = {SpanAttributes.LLM_SYSTEM: "Langchain"}
+
+        span_holder = SpanHolder(
+            span=mock_span,
+            token=None,
+            context=None,
+            children=[],
+            workflow_name="test",
+            entity_name="test",
+            entity_path="test",
+            start_time=time.time()
+        )
+        # No first_token_time set
+        self.handler.spans[run_id] = span_holder
+
+        llm_result = LLMResult(
+            generations=[[Generation(text="Response")]],
+            llm_output={"model_name": "test-model"}
+        )
+
+        self.handler.on_llm_end(llm_result, run_id=run_id)
+
+        # Streaming time metric should not be recorded
+        self.streaming_time_histogram.record.assert_not_called()

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_third_party_models.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_third_party_models.py
@@ -1,0 +1,143 @@
+from unittest.mock import Mock
+from uuid import uuid4
+from opentelemetry.instrumentation.langchain.callback_handler import TraceloopCallbackHandler
+from opentelemetry.instrumentation.langchain.span_utils import SpanHolder
+from opentelemetry.semconv_ai import SpanAttributes
+from langchain_core.outputs import LLMResult, Generation
+
+
+class TestThirdPartyModels:
+    """Test enhanced model extraction for third-party LangChain integrations like ChatDeepSeek."""
+
+    def setup_method(self):
+        self.tracer = Mock()
+        self.duration_histogram = Mock()
+        self.token_histogram = Mock()
+        self.ttft_histogram = Mock()
+        self.streaming_time_histogram = Mock()
+        self.choices_counter = Mock()
+        self.exception_counter = Mock()
+
+        self.handler = TraceloopCallbackHandler(
+            self.tracer,
+            self.duration_histogram,
+            self.token_histogram,
+            self.ttft_histogram,
+            self.streaming_time_histogram,
+            self.choices_counter,
+            self.exception_counter,
+        )
+
+    def test_chatdeepseek_support(self):
+        """Test model extraction and streaming metrics for models that store info in serialized kwargs."""
+        run_id = uuid4()
+
+        # Test model extraction from serialized kwargs
+        serialized = {
+            "id": ["langchain_deepseek", "chat_models", "ChatDeepSeek"],
+            "kwargs": {
+                "model": "deepseek-reasoner",
+                "api_base": "https://api.deepseek.com/beta",
+                "temperature": 0.7
+            }
+        }
+
+        kwargs = {
+            "invocation_params": {
+                "temperature": 0.7
+            }
+        }
+
+        # Start chat model
+        self.handler.on_chat_model_start(
+            serialized=serialized,
+            messages=[],
+            run_id=run_id,
+            kwargs=kwargs
+        )
+
+        # Verify model extraction
+        assert run_id in self.handler.spans
+        span_holder = self.handler.spans[run_id]
+        assert span_holder.request_model == "deepseek-reasoner"
+
+        span = span_holder.span
+        span.set_attribute.assert_any_call(SpanAttributes.LLM_REQUEST_MODEL, "deepseek-reasoner")
+
+        span_attrs = {
+            SpanAttributes.LLM_SYSTEM: "Langchain",
+            SpanAttributes.LLM_REQUEST_TYPE: "chat"
+        }
+        span.attributes = Mock()
+        span.attributes.get = lambda key, default=None: span_attrs.get(key, default)
+
+        # Test fallback behavior when no model in serialized kwargs
+        fallback_serialized = {
+            "id": ["langchain_deepseek", "chat_models", "ChatDeepSeek"],
+            "kwargs": {
+                "api_base": "https://api.deepseek.com/beta"
+                # No model field
+            }
+        }
+
+        run_id_fallback = uuid4()
+        self.handler.on_chat_model_start(
+            serialized=fallback_serialized,
+            messages=[],
+            run_id=run_id_fallback,
+            kwargs={}
+        )
+
+        span_holder_fallback = self.handler.spans[run_id_fallback]
+        assert span_holder_fallback.request_model == "deepseek-unknown"
+
+        # Test response processing without model info in llm_output
+        response = LLMResult(
+            generations=[[Generation(text="Response")]],
+            llm_output={
+                "token_usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 15,
+                    "total_tokens": 25
+                }
+            }
+        )
+
+        self.handler.on_llm_end(response, run_id=run_id)
+
+        # Verify that metrics use correct model name from request fallback
+        token_calls = self.token_histogram.record.call_args_list
+
+        # Verify both calls use correct model name from request fallback
+        assert len(token_calls) == 2, f"Expected 2 token calls, got {len(token_calls)}"
+
+        for call in token_calls:
+            attributes = call[1]["attributes"]
+            assert attributes[SpanAttributes.LLM_RESPONSE_MODEL] == "deepseek-reasoner"
+
+        # Test model variant extraction
+        from opentelemetry.instrumentation.langchain.span_utils import _extract_model_name_from_request
+
+        variant_serialized = {
+            "id": ["langchain_deepseek", "ChatDeepSeek"],
+            "kwargs": {
+                "model": "deepseek-coder-v2",
+                "api_base": "https://api.deepseek.com/beta"
+            }
+        }
+
+        test_span_holder = SpanHolder(
+            span=Mock(),
+            token=None,
+            context=None,
+            children=[],
+            workflow_name="test",
+            entity_name="test",
+            entity_path="test"
+        )
+
+        test_models = ["deepseek-chat", "deepseek-coder", "deepseek-reasoner", "deepseek-coder-v2"]
+        for model in test_models:
+            variant_serialized["kwargs"]["model"] = model
+            result = _extract_model_name_from_request({}, test_span_holder, variant_serialized)
+            assert result == model, f"Failed to extract {model}"


### PR DESCRIPTION
…ty integration

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [x] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [ ] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

This PR mainly fixes two issues related to [langchain third party integration](https://github.com/langchain-ai/langchain/tree/f2b0afd0b729d781ba27f588787a1a899afe241a/libs/partners), specifically the API `ChatDeepSeek`:

- Model name detection failing
- Metrics mising like `TTFT` and streaming generation time

### Repoduce code

```python
import os
import asyncio
from langchain_core.prompts import ChatPromptTemplate

from langchain_deepseek import ChatDeepSeek

# OpenTelemetry setup (HTTP exporter to local collector)
from opentelemetry.sdk.resources import Resource
from opentelemetry.sdk.trace import TracerProvider
from opentelemetry.sdk.trace.export import BatchSpanProcessor
from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter

from opentelemetry.instrumentation.langchain import LangchainInstrumentor
from opentelemetry import metrics as otel_metrics
from opentelemetry.sdk.metrics import MeterProvider
from opentelemetry.sdk.metrics.export import ConsoleMetricExporter, PeriodicExportingMetricReader
from opentelemetry import trace as otel_trace

prompt_template = """You are a helpful assistant.
Use the following context to answer briefly.

Context:
{context}

Question:
{question}
"""

def init_otel_and_instrument(service_name: str = "langchain-scratch", collector_endpoint: str = "http://127.0.0.1:4318") -> None:    
    resource = Resource.create({"service.name": service_name})
    
    endpoint = collector_endpoint.rstrip("/") + "/v1/traces"
    trace_exporter = OTLPSpanExporter(endpoint=endpoint)
    tracer_provider = TracerProvider(resource=resource)
    tracer_provider.add_span_processor(BatchSpanProcessor(trace_exporter))
    otel_trace.set_tracer_provider(tracer_provider)

    metric_reader = PeriodicExportingMetricReader(ConsoleMetricExporter(), export_interval_millis=1000)
    meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
    otel_metrics.set_meter_provider(meter_provider)

    langchain_instrumentor = LangchainInstrumentor()
    langchain_instrumentor.instrument(
        tracer_provider=tracer_provider,
        meter_provider=meter_provider
    )
    
    return langchain_instrumentor

async def main():
    instrumentor = init_otel_and_instrument(
        service_name="langchain-scratch", 
        collector_endpoint="http://127.0.0.1:4318"
    )
    
    prompt = ChatPromptTemplate.from_template(prompt_template)

    api_key = os.getenv("OPENAI_API_KEY", "YOUR_API_KEY")
    base_url = os.getenv("OPENAI_BASE_URL", "https://api.deepseek.com/beta")
    model_name = os.getenv("MODEL_NAME", "deepseek-reasoner")

    model = ChatDeepSeek(
        api_base=base_url,
        api_key=api_key,
        model=model_name,
        stream_usage=True,
    )

    chain = prompt | model

    inputs = {"context": "some context", "question": "What's OpenTelemetry?"}
    print("Assistant:", end=" ", flush=True)
    async for chunk in chain.astream(inputs):
        piece = getattr(chunk, "content", "")
        if piece:
            print(piece, end="", flush=True)
    print()
    
    # instrumentor.uninstrument()

if __name__ == "__main__":
    asyncio.run(main())

```

<img width="1875" height="682" alt="Clipboard_Screenshot_1758409020" src="https://github.com/user-attachments/assets/140dbed3-d2aa-47cc-a8f3-3a2b4bef9d62" />

