### PR TITLE
feat(mcp): MCP response Span Capture for Stdio Mode

### DIFF
--- a/packages/opentelemetry-instrumentation-mcp/tests/test_fastmcp.py
+++ b/packages/opentelemetry-instrumentation-mcp/tests/test_fastmcp.py
@@ -23,8 +23,8 @@ async def test_fastmcp_instrumentor(span_exporter, tracer_provider) -> None:
 
         # Test tool calling
         result = await client.call_tool("add_numbers", {"a": 5, "b": 3})
-        assert len(result.content) == 1
-        assert result.content[0].text == "8"
+        assert len(result) == 1
+        assert result[0].text == "8"
 
         # Test resource listing
         resources_res = await client.list_resources()

--- a/packages/opentelemetry-instrumentation-mcp/tests/test_fastmcp_server_span.py
+++ b/packages/opentelemetry-instrumentation-mcp/tests/test_fastmcp_server_span.py
@@ -14,8 +14,8 @@ async def test_fastmcp_server_mcp_parent_span(span_exporter, tracer_provider) ->
     async with Client(server) as client:
         # Test tool calling
         result = await client.call_tool("test_tool", {"x": 5})
-        assert len(result.content) == 1
-        assert result.content[0].text == "10"
+        assert len(result) == 1
+        assert result[0].text == "10"
 
     # Get the finished spans
     spans = span_exporter.get_finished_spans()


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [ ] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Capture MCP response spans in Stdio mode, including server name and tool execution results, with updated tests for verification.
> 
>   - **Behavior**:
>     - Capture server name in `FastMCP.__init__` using `_fastmcp_init_wrapper()` in `fastmcp_instrumentation.py`.
>     - Add MCP response to spans in `_fastmcp_tool_wrapper()` regardless of content tracing setting.
>     - Handle `ToolResult` and other result types, converting to JSON and truncating if needed.
>   - **Tests**:
>     - Update `test_fastmcp.py` to check `result.content` instead of `result` directly.
>     - Add assertions for output content only if present.
>     - Update `test_fastmcp_server_span.py` to verify parent-child span relationships and attributes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for fcfb61c56b736f72cfb4f5a91b9faa92509bcfc7. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Captures and propagates FastMCP server name into traces for clearer workflow context.
  * Enhances result serialization to handle varied output shapes, providing richer, consistent MCP response logging.
  * Logs MCP response values even when content tracing is disabled.

* **Bug Fixes**
  * Prevents dropped responses by falling back to string serialization on errors.
  * Preserves existing error/status handling while adding workflow context.

* **Tests**
  * Updated assertions to account for optional output fields in client responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->