### PR TITLE
fix(langchain): incorrect role on generations

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/span_utils.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/span_utils.py
@@ -269,7 +269,10 @@ def set_chat_response(span: Span, response: LLMResult) -> None:
                 )
                 if tool_calls and isinstance(tool_calls, list):
                     _set_chat_tool_calls(span, prefix, tool_calls)
-
+            else:
+                _set_span_attribute(
+                    span, f"{prefix}.role", "assistant"
+                )
             i += 1
 
 

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_span_utils.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_span_utils.py
@@ -82,5 +82,5 @@ def test_plain_generation_defaults_to_assistant_role():
     set_chat_response(span, result)
 
     prefix = f"{GenAIAttributes.GEN_AI_COMPLETION}.0"
-    assert prefix + ".role" not in span.attributes
+    assert span.attributes[prefix + ".role"] == "assistant"
     assert span.attributes[prefix + ".content"] == "plain completion"


### PR DESCRIPTION
This fixes an error introduced by #3138 that records the wrong `role` it uses the generation type instead of the message type.
The generation type is only for serialization and is NOT "ai"/"human".
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes incorrect role assignment in `set_chat_response` by using message type instead of generation type in `span_utils.py`.
> 
>   - **Bug Fix**:
>     - Corrects role assignment in `set_chat_response` in `span_utils.py` by using `generation.message.type` instead of `generation.type`.
>     - Ensures role is accurately set to "assistant" when `generation.message` is not present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 2a6c479bfee5374fe1a73091e58ec47b4019e665. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat-response span role assignment now derives from the message type when present, falls back to "assistant" for non-message generations, and no longer overwrites role when tool calls exist — improving role accuracy and attribution.

* **Tests**
  * Added tests verifying role assignment, default assistant fallback, content storage, and recording of tool calls (including function_call and parsed tool-call arguments) with trace-content enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->