### PR TITLE
fix(sdk): watsonx warning on initialization

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
+++ b/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
@@ -904,7 +904,7 @@ def init_vertexai_instrumentor(
 def init_watsonx_instrumentor():
     try:
         if is_package_installed("ibm-watsonx-ai") or is_package_installed(
-            "ibm_watson_machine_learning"
+            "ibm-watson-machine-learning"
         ):
             from opentelemetry.instrumentation.watsonx import WatsonxInstrumentor
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [ ] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes package name typo in `init_watsonx_instrumentor()` in `tracing.py` to ensure correct Watsonx instrumentor initialization.
> 
>   - **Behavior**:
>     - Fixes package name typo in `init_watsonx_instrumentor()` in `tracing.py` from `"ibm_watson_machine_learning"` to `"ibm-watson-machine-learning"`.
>     - Ensures correct package detection for Watsonx instrumentor initialization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for ca4ca4364c650a289346ea3911b25a7ed2aacdd5. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WatsonX instrumentation to correctly detect the required machine learning package dependency, ensuring proper initialization when the package is installed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->