### PR TITLE
fix(sdk): crewai tracing provider conflict

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
+++ b/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
@@ -1032,6 +1032,7 @@ def init_groq_instrumentor():
 def init_crewai_instrumentor():
     try:
         if is_package_installed("crewai"):
+            os.environ.setdefault("CREWAI_DISABLE_TELEMETRY", "true")
             from opentelemetry.instrumentation.crewai import CrewAIInstrumentor
 
             instrumentor = CrewAIInstrumentor()


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

Disabled CrewAI Telemetry (https://docs.crewai.com/en/telemetry#telemetry) that caused warnings on sample apps.

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [ ] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets `CREWAI_DISABLE_TELEMETRY` to `true` in `init_crewai_instrumentor()` to prevent telemetry conflicts.
> 
>   - **Behavior**:
>     - Sets `CREWAI_DISABLE_TELEMETRY` environment variable to `true` in `init_crewai_instrumentor()` in `tracing.py` to prevent telemetry conflicts when `crewai` package is installed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for b14aabfe8f3bc1136906a45af23150e04a0597d5. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CrewAI integration now automatically disables telemetry by default during initialization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->