### PR TITLE
fix: Change attributes datasets and experiment on client to lazyloading and mark datasets as deprecated

### DIFF
--- a/packages/traceloop-sdk/tests/test_client.py
+++ b/packages/traceloop-sdk/tests/test_client.py
@@ -3,6 +3,7 @@ from traceloop.sdk.client import Client
 from traceloop.sdk.client.http import HTTPClient
 from traceloop.sdk.annotation.user_feedback import UserFeedback
 from traceloop.sdk.datasets.datasets import Datasets
+from traceloop.sdk.experiment import Experiment
 
 
 def test_client_initialization():
@@ -70,3 +71,15 @@ def test_datasets_deprecation_warnings():
         client.datasets = Datasets(client._http)
     with pytest.deprecated_call():
         del client.datasets
+
+def test_client_lazy_loads_experiment():
+    """Test cilent.experiment is only initialized lazy."""
+    client = Client(api_key="test-key", app_name="test-app")
+    assert client._experiment is None  # Initial state is None
+
+    experiment = client.experiment
+
+    assert isinstance(experiment, Experiment)
+    assert client._experiment is not None  # Then it's loaded
+    assert client.experiment is experiment  # And always returns same instance
+


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [x] I have added tests that cover my changes.
- [ ] ~~If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change~~.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] ~~(If applicable) I have updated the documentation accordingly.~~

Changes
-------
- Import and load attributes `datasets` and `experimental` only once when actually requested
- Mark attribute `datasets` on Client as deprecated

Reasoning
---------
Calling Traceloop.init() allocates ~35 MB of memory when pandas is
installed, either by the attributes `datasets` or `experiment`. Both of these attributes seem
not relevant for production

People interested in the Datasets class should IMO just create an
instance on their own.

Since it's already released I propose a deprecation process.

**In general I think it is a bad idea to expose and initialize all these internal attributes directly on the public main class.**
 
Here you can see the memory usages done with [memray](https://github.com/bloomberg/memray) of this simple execution:

```bash
TRACELOOP_API_KEY=asdf uv  run --active memray run -c "from traceloop.sdk import Traceloop;Traceloop.init(app_name='joke_generation_service')
```

|Code| Mem-usage | Link to report |
|------|------|--------|
| Current main | 70.1 MB | [memray-flamegraph-before-patch.html](https://github.com/user-attachments/files/24965425/memray-flamegraph-before-patch.html)  |
| Patch | 37.6 MB | [memray-flamegraph-with-patch.html](https://github.com/user-attachments/files/24965438/memray-flamegraph-with-patch.html) |
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize `Client` memory usage by lazy-loading `datasets` and `experiment` attributes, marking `datasets` as deprecated.
> 
>   - **Behavior**:
>     - `datasets` and `experiment` attributes in `Client` are now lazy-loaded, reducing initial memory usage.
>     - `datasets` attribute is marked as deprecated with a warning, suggesting users create their own instances.
>   - **Tests**:
>     - Added `test_client_lazy_loads_datasets()` and `test_client_lazy_loads_experiment()` in `test_client.py` to verify lazy loading.
>     - Added `test_datasets_deprecation_warnings()` to check for deprecation warnings.
>   - **Misc**:
>     - Removed direct imports of `Datasets` and `Experiment` in `client.py` and moved them inside the properties.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 2f53649d563f152b5c032c71b6e48553f5bce00c. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * The `datasets` property on the client is deprecated, including its setter and deleter; it will be removed in a future release.

* **Changes**
  * The `experiment` property now initializes on first access instead of during client creation.

* **Tests**
  * Added tests verifying lazy-loading behavior for `experiment` and `datasets`, caching/idempotence, and that deprecation warnings are emitted for `datasets`.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->