### PR TITLE
fix(openai-agents): preserve function metadata in dont_throw and fix realtime event handling

### DIFF
--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_realtime_wrappers.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_realtime_wrappers.py
@@ -529,33 +529,34 @@ def wrap_realtime_session(tracer: Tracer):
                         if content and role == "assistant":
                             state.record_completion(role, content)
 
-                elif event_type == "response":
-                    output = getattr(event, "output", None)
-                    if output and isinstance(output, list):
-                        for item in output:
+                elif event_type == "history_updated":
+                    history = getattr(event, "history", None)
+                    if history and isinstance(history, list):
+                        for item in reversed(history):
                             role = getattr(item, "role", None)
                             if role == "assistant":
                                 item_content = getattr(item, "content", None)
-                                if item_content:
-                                    if isinstance(item_content, list):
-                                        for part in item_content:
-                                            text = getattr(part, "text", None)
-                                            if text:
-                                                state.record_completion(role, text)
-                                                break
-                                    elif isinstance(item_content, str):
-                                        state.record_completion(role, item_content)
+                                if item_content and isinstance(item_content, list):
+                                    for part in item_content:
+                                        text = getattr(part, "text", None) or getattr(
+                                            part, "transcript", None
+                                        )
+                                        if text:
+                                            state.record_completion(role, text)
+                                            break
+                                break
 
                 elif event_type == "raw_model_event":
                     data = getattr(event, "data", None)
                     if data:
                         if isinstance(data, dict):
                             data_type = data.get("type")
-                            raw_data = data.get("data", data)
-                            if isinstance(raw_data, dict):
+                            raw_data = data.get("data")
+                            if raw_data and isinstance(raw_data, dict):
                                 nested_type = raw_data.get("type")
                                 if nested_type:
                                     data_type = nested_type
+                                    data = raw_data
                         else:
                             data_type = getattr(data, "type", None)
                             nested_data = getattr(data, "data", None)
@@ -586,28 +587,38 @@ def wrap_realtime_session(tracer: Tracer):
                             if usage:
                                 state.record_usage(usage)
 
-                                output = getattr(response, "output", None)
+                                if isinstance(response, dict):
+                                    output = response.get("output")
+                                else:
+                                    output = getattr(response, "output", None)
                                 if output and isinstance(output, list):
                                     for item in output:
-                                        item_type = getattr(item, "type", None)
-                                        if item_type == "message":
+                                        if isinstance(item, dict):
+                                            item_type = item.get("type")
+                                            role = item.get("role")
+                                            item_content = item.get("content")
+                                        else:
+                                            item_type = getattr(item, "type", None)
                                             role = getattr(item, "role", None)
-                                            if role == "assistant":
-                                                item_content = getattr(
-                                                    item, "content", None
-                                                )
-                                                if item_content and isinstance(
-                                                    item_content, list
-                                                ):
-                                                    for part in item_content:
+                                            item_content = getattr(
+                                                item, "content", None
+                                            )
+                                        if item_type == "message" and role == "assistant":
+                                            if item_content and isinstance(
+                                                item_content, list
+                                            ):
+                                                for part in item_content:
+                                                    if isinstance(part, dict):
+                                                        text = part.get("text")
+                                                    else:
                                                         text = getattr(
                                                             part, "text", None
                                                         )
-                                                        if text:
-                                                            state.record_completion(
-                                                                role, text
-                                                            )
-                                                            break
+                                                    if text:
+                                                        state.record_completion(
+                                                            role, text
+                                                        )
+                                                        break
 
                         elif data_type == "item_updated":
                             item = getattr(data, "item", None)

--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/utils.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import dataclasses
+import functools
 import json
 import logging
 import os
@@ -59,12 +60,14 @@ def dont_throw(func):
     """
     logger = logging.getLogger(func.__module__)
 
+    @functools.wraps(func)
     async def async_wrapper(*args, **kwargs):
         try:
             return await func(*args, **kwargs)
         except Exception as e:
             _handle_exception(e, func, logger)
 
+    @functools.wraps(func)
     def sync_wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)


### PR DESCRIPTION
## Summary

- Add `functools.wraps` to `dont_throw` decorator so wrapped functions retain `__name__`, `__doc__`, and `__wrapped__`
- Fix realtime session instrumentation to handle `history_updated` events for assistant transcript updates
- Fix dict-based data access in `response.done` handler (was using `getattr` on dicts, which silently returned `None`)
- Remove dead `response` event handler (no SDK session event has `type="response"`)

## Why

The `dont_throw` decorator stripped function metadata, making stack traces show `async_wrapper`/`sync_wrapper` instead of original function names. The realtime instrumentation had several event handling bugs: `history_updated` events were ignored (losing assistant transcript updates), and the `response.done` handler used `getattr()` on dict objects instead of `.get()`, silently failing to extract completions.

Closes #3684
Closes #3685

## Test plan

- [x] Existing 25 realtime session tests pass
- [x] All 51 package tests pass
- [x] Added 5 tests for `functools.wraps` preservation (`__name__`, `__wrapped__`, `__doc__` for sync/async)
- [x] Added test for `history_updated` assistant completion capture
- [x] Added test for dict-based `response.done` usage and completion extraction
- [x] Ruff lint passes