### PR TITLE
fix(openai-agents): add functools.wraps to dont_throw decorator

### DIFF
--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/utils.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import dataclasses
+import functools
 import json
 import logging
 import os
@@ -59,12 +60,14 @@ def dont_throw(func):
     """
     logger = logging.getLogger(func.__module__)
 
+    @functools.wraps(func)
     async def async_wrapper(*args, **kwargs):
         try:
             return await func(*args, **kwargs)
         except Exception as e:
             _handle_exception(e, func, logger)
 
+    @functools.wraps(func)
     def sync_wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)

--- a/packages/opentelemetry-instrumentation-openai-agents/tests/test_realtime_session.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/tests/test_realtime_session.py
@@ -475,3 +475,60 @@ class TestSpanHierarchy:
         audio_span = next(s for s in spans if s.name == "openai.realtime")
 
         assert audio_span.parent.span_id == agent_span.context.span_id
+
+
+class TestDontThrowWraps:
+    """Tests that dont_throw preserves function metadata via functools.wraps."""
+
+    def test_sync_function_preserves_name(self):
+        """Test that dont_throw preserves __name__ for sync functions."""
+        from opentelemetry.instrumentation.openai_agents.utils import dont_throw
+
+        @dont_throw
+        def my_sync_function():
+            pass
+
+        assert my_sync_function.__name__ == "my_sync_function"
+
+    def test_async_function_preserves_name(self):
+        """Test that dont_throw preserves __name__ for async functions."""
+        from opentelemetry.instrumentation.openai_agents.utils import dont_throw
+
+        @dont_throw
+        async def my_async_function():
+            pass
+
+        assert my_async_function.__name__ == "my_async_function"
+
+    def test_sync_function_preserves_wrapped(self):
+        """Test that dont_throw sets __wrapped__ for sync functions."""
+        from opentelemetry.instrumentation.openai_agents.utils import dont_throw
+
+        def original():
+            pass
+
+        wrapped = dont_throw(original)
+        assert hasattr(wrapped, "__wrapped__")
+        assert wrapped.__wrapped__ is original
+
+    def test_async_function_preserves_wrapped(self):
+        """Test that dont_throw sets __wrapped__ for async functions."""
+        from opentelemetry.instrumentation.openai_agents.utils import dont_throw
+
+        async def original():
+            pass
+
+        wrapped = dont_throw(original)
+        assert hasattr(wrapped, "__wrapped__")
+        assert wrapped.__wrapped__ is original
+
+    def test_sync_function_preserves_docstring(self):
+        """Test that dont_throw preserves __doc__ for sync functions."""
+        from opentelemetry.instrumentation.openai_agents.utils import dont_throw
+
+        @dont_throw
+        def my_func():
+            """My docstring."""
+            pass
+
+        assert my_func.__doc__ == "My docstring."


### PR DESCRIPTION
## Summary

- Add `@functools.wraps(func)` to both `async_wrapper` and `sync_wrapper` inside the `dont_throw` decorator

## Why

The `dont_throw` decorator did not preserve function metadata, so wrapped functions lost `__name__`, `__doc__`, `__qualname__`, and `__wrapped__`. This caused stack traces to show `async_wrapper`/`sync_wrapper` instead of the original function name, and prevented consumers from using `__wrapped__` to access the original function.

Closes #3684

## Test plan

- [x] Added 5 tests verifying `__name__`, `__wrapped__`, and `__doc__` preservation for sync and async functions
- [x] All existing tests pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `functools.wraps` to `dont_throw` decorator to preserve function metadata for wrapped functions.
> 
>   - **Behavior**:
>     - Add `@functools.wraps(func)` to `async_wrapper` and `sync_wrapper` in `dont_throw` decorator in `utils.py` to preserve function metadata.
>     - Preserves `__name__`, `__doc__`, and `__wrapped__` attributes for wrapped functions.
>   - **Tests**:
>     - Add tests in `test_realtime_session.py` to verify preservation of `__name__`, `__doc__`, and `__wrapped__` for both sync and async functions.
>     - Tests ensure that function metadata is correctly preserved after decoration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 1013b063ed29a5439fa2ad72540dfd16e67ff7b9. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced function metadata preservation in internal utilities to maintain original function information during wrapping.

* **Tests**
  * Added comprehensive test coverage validating metadata preservation for both synchronous and asynchronous wrapped functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->