### PR TITLE
fix(openai-agents): fix realtime session event handling for prompts, completions, and usage

### DIFF
--- a/packages/opentelemetry-instrumentation-openai-agents/tests/test_realtime_session.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/tests/test_realtime_session.py
@@ -8,6 +8,7 @@ from opentelemetry.instrumentation.openai_agents._realtime_wrappers import (
     RealtimeTracingState,
     wrap_realtime_session,
     unwrap_realtime_session,
+    _extract_content_text,
 )
 
 
@@ -646,3 +647,52 @@ class TestTracedPutEventHandlers:
         assert llm_span.attributes.get("gen_ai.usage.input_tokens") == 42
         assert llm_span.attributes.get("gen_ai.usage.output_tokens") == 18
         assert llm_span.attributes.get("gen_ai.completion.0.content") == "It is sunny today."
+
+    def test_response_done_without_usage_still_captures_completion(self, tracer, tracer_provider):
+        """Test that completions are captured even when usage is absent from response.done."""
+        _, exporter = tracer_provider
+        state = RealtimeTracingState(tracer)
+        state.start_workflow_span("Test Agent")
+        state.start_agent_span("Voice Assistant")
+
+        state.record_prompt("user", "Tell me a joke")
+
+        # response.done with output but NO usage field
+        response_done_data = {
+            "type": "response.done",
+            "response": {
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "Why did the chicken cross the road?"}
+                        ],
+                    }
+                ],
+            },
+        }
+
+        response = response_done_data.get("response", {})
+        usage = response.get("usage") if isinstance(response, dict) else None
+        if usage:
+            state.record_usage(usage)
+
+        # Completion extraction should work even without usage
+        output = response.get("output") if isinstance(response, dict) else None
+        if output and isinstance(output, list):
+            for item in output:
+                if isinstance(item, dict):
+                    if item.get("type") == "message" and item.get("role") == "assistant":
+                        text = _extract_content_text(item.get("content"))
+                        if text:
+                            state.record_completion("assistant", text)
+
+        state.cleanup()
+        state.end_workflow_span()
+
+        spans = exporter.get_finished_spans()
+        llm_spans = [s for s in spans if s.name == "openai.realtime"]
+        assert len(llm_spans) == 1
+        assert llm_spans[0].attributes.get("gen_ai.completion.0.content") == "Why did the chicken cross the road?"
+        assert llm_spans[0].attributes.get("gen_ai.usage.input_tokens") is None


### PR DESCRIPTION
## Summary

- Add `history_updated` event handler to capture assistant transcript updates
- Fix dict-based data access in `response.done` handler (`getattr` on dicts silently returned `None` instead of using `.get()`)
- Fix dict-case event unwrapping where the `data` variable was not updated to the nested level
- Remove dead `response` event handler (no SDK session event has `type="response"`)

## Why

The realtime instrumentation had several event type mismatches with the openai-agents SDK (v0.6.0+):

1. `history_updated` events were completely ignored, so assistant transcript updates from multi-turn conversations were never captured as completions.
2. In the `response.done` handler, `getattr()` was used on dict objects instead of `.get()`, so completion extraction silently failed (usage was captured correctly via the dict path, but output/content was not).
3. The dict-case unwrapping in `raw_model_event` did not update the `data` reference after finding nested data, so subsequent dict-path code looked at the wrong nesting level.
4. The `response` event handler was dead code -- no SDK session event has `type="response"`.

Closes #3685

## Test plan

- [x] All 46 package tests pass
- [x] Added test for `history_updated` assistant completion capture via transcript
- [x] Added test for dict-based `response.done` usage and completion extraction
- [x] Ruff lint passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix event handling in OpenAI Agents SDK by adding `history_updated` handler, correcting `response.done` data extraction, and removing dead code.
> 
>   - **Behavior**:
>     - Add `history_updated` event handler in `_realtime_wrappers.py` to capture assistant transcript updates.
>     - Fix `response.done` handler to use `.get()` instead of `getattr()` for dicts, ensuring completion extraction.
>     - Correct dict-case event unwrapping in `raw_model_event` to update `data` to the nested level.
>     - Remove dead `response` event handler.
>   - **Tests**:
>     - Add test for `history_updated` event handling in `test_realtime_session.py`.
>     - Add test for dict-based `response.done` handling in `test_realtime_session.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for ba639deb6deea159f85ea98d0ee8530bb0689e7f. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved realtime tracing for OpenAI agent interactions: more reliable capture of assistant completions and usage metrics across varied event types and payload formats.

* **Tests**
  * Added tests validating history-based completion extraction and response payload parsing (with and without usage) to ensure tracing accuracy and robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->