### PR TITLE
fix(langchain): preserve non-ASCII characters in JSON serialization

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/span_utils.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/span_utils.py
@@ -115,7 +115,7 @@ def _content_to_parts(content) -> list[dict]:
                     })
                 else:
                     # Unknown block type — preserve as text with JSON
-                    parts.append({"type": "text", "content": json.dumps(block, cls=CallbackFilteredJSONEncoder)})
+                    parts.append({"type": "text", "content": json.dumps(block, cls=CallbackFilteredJSONEncoder, ensure_ascii=False)})
             else:
                 parts.append({"type": "text", "content": str(block)})
         return parts
@@ -204,7 +204,7 @@ def set_request_params(span, kwargs, span_holder: SpanHolder):
         _set_span_attribute(
             span,
             GenAIAttributes.GEN_AI_TOOL_DEFINITIONS,
-            json.dumps(tool_defs, cls=CallbackFilteredJSONEncoder),
+            json.dumps(tool_defs, cls=CallbackFilteredJSONEncoder, ensure_ascii=False),
         )
 
 
@@ -228,7 +228,7 @@ def set_llm_request(
             _set_span_attribute(
                 span,
                 GenAIAttributes.GEN_AI_INPUT_MESSAGES,
-                json.dumps(input_messages, cls=CallbackFilteredJSONEncoder),
+                json.dumps(input_messages, cls=CallbackFilteredJSONEncoder, ensure_ascii=False),
             )
 
 
@@ -256,7 +256,7 @@ def set_chat_request(
             _set_span_attribute(
                 span,
                 GenAIAttributes.GEN_AI_TOOL_DEFINITIONS,
-                json.dumps(tool_defs, cls=CallbackFilteredJSONEncoder),
+                json.dumps(tool_defs, cls=CallbackFilteredJSONEncoder, ensure_ascii=False),
             )
 
         input_messages = []
@@ -275,7 +275,7 @@ def set_chat_request(
                     content_str = (
                         msg.content
                         if isinstance(msg.content, str)
-                        else json.dumps(msg.content, cls=CallbackFilteredJSONEncoder)
+                        else json.dumps(msg.content, cls=CallbackFilteredJSONEncoder, ensure_ascii=False)
                     )
                     parts = [{
                         "type": "tool_call_response",
@@ -301,13 +301,13 @@ def set_chat_request(
             _set_span_attribute(
                 span,
                 GenAIAttributes.GEN_AI_SYSTEM_INSTRUCTIONS,
-                json.dumps(system_instructions, cls=CallbackFilteredJSONEncoder),
+                json.dumps(system_instructions, cls=CallbackFilteredJSONEncoder, ensure_ascii=False),
             )
         if input_messages:
             _set_span_attribute(
                 span,
                 GenAIAttributes.GEN_AI_INPUT_MESSAGES,
-                json.dumps(input_messages, cls=CallbackFilteredJSONEncoder),
+                json.dumps(input_messages, cls=CallbackFilteredJSONEncoder, ensure_ascii=False),
             )
 
 
@@ -378,7 +378,7 @@ def set_chat_response(span: Span, response: LLMResult) -> None:
         _set_span_attribute(
             span,
             GenAIAttributes.GEN_AI_OUTPUT_MESSAGES,
-            json.dumps(output_messages, cls=CallbackFilteredJSONEncoder),
+            json.dumps(output_messages, cls=CallbackFilteredJSONEncoder, ensure_ascii=False),
         )
     if finish_reasons:
         span.set_attribute(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS, finish_reasons)

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_span_utils_non_ascii.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_span_utils_non_ascii.py
@@ -1,0 +1,44 @@
+"""Verify span_utils json.dumps preserves non-ASCII characters (complements
+test_non_ascii_content.py which covers callback_handler.py)."""
+
+import json
+from unittest.mock import MagicMock
+
+from opentelemetry.instrumentation.langchain.span_utils import (
+    _content_to_parts,
+)
+
+
+def test_content_to_parts_preserves_cjk():
+    """Non-ASCII text in multimodal content blocks must not be escaped."""
+    content = [{"type": "custom", "data": "日本語テスト"}]
+    parts = _content_to_parts(content)
+    # The unknown-block-type branch serialises via json.dumps
+    assert len(parts) == 1
+    assert parts[0]["type"] == "text"
+    raw = parts[0]["content"]
+    # Must contain the original characters, not \\uXXXX escapes
+    assert "日本語テスト" in raw
+    assert "\\u" not in raw
+
+
+def test_content_to_parts_preserves_cyrillic():
+    content = [{"type": "custom", "data": "Привет мир"}]
+    parts = _content_to_parts(content)
+    raw = parts[0]["content"]
+    assert "Привет мир" in raw
+    assert "\\u" not in raw
+
+
+def test_content_to_parts_preserves_arabic():
+    content = [{"type": "custom", "data": "مرحبا بالعالم"}]
+    parts = _content_to_parts(content)
+    raw = parts[0]["content"]
+    assert "مرحبا" in raw
+    assert "\\u" not in raw
+
+
+def test_content_to_parts_plain_string_unchanged():
+    """Plain string content should pass through without json.dumps."""
+    parts = _content_to_parts("hello world")
+    assert parts == [{"type": "text", "content": "hello world"}]

--- a/packages/opentelemetry-instrumentation-langchain/uv.lock
+++ b/packages/opentelemetry-instrumentation-langchain/uv.lock
@@ -1491,28 +1491,25 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-bedrock"
-version = "0.54.0"
+version = "0.57.0"
 source = { editable = "../opentelemetry-instrumentation-bedrock" }
 dependencies = [
-    { name = "anthropic" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-semantic-conventions-ai" },
-    { name = "tokenizers" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.17.0" },
+    { name = "anthropic", marker = "extra == 'enrichment'", specifier = ">=0.17.0" },
     { name = "boto3", marker = "extra == 'instruments'" },
     { name = "opentelemetry-api", specifier = ">=1.38.0,<2" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.59b0" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.59b0" },
     { name = "opentelemetry-semantic-conventions-ai", specifier = ">=0.5.1,<0.6.0" },
-    { name = "tokenizers", specifier = ">=0.13.0" },
 ]
-provides-extras = ["instruments"]
+provides-extras = ["instruments", "enrichment"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "ruff", specifier = ">=0.4.0" }]
@@ -1527,7 +1524,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-langchain"
-version = "0.54.0"
+version = "0.57.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1619,7 +1616,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-openai"
-version = "0.54.0"
+version = "0.57.0"
 source = { editable = "../opentelemetry-instrumentation-openai" }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION
## Summary

Adds `ensure_ascii=False` to all `json.dumps` calls in `span_utils.py` so that non-ASCII characters (CJK, Cyrillic, Arabic, etc.) in LLM prompts, tool definitions, and system instructions are preserved in OpenTelemetry span attributes rather than escaped to `\uXXXX` sequences.

This complements #3734 which fixed the same issue in `callback_handler.py` — the `span_utils.py` code paths were not covered by that PR.

## Changes

- `span_utils.py`: add `ensure_ascii=False` to 8 `json.dumps` calls across `_content_to_parts`, `set_request_params`, `set_llm_request`, `set_chat_request`, and `set_chat_response`
- New test file `test_span_utils_non_ascii.py`: 4 tests covering CJK, Cyrillic, and Arabic character preservation in the `_content_to_parts` serialisation path

## Test plan

- [x] `pytest tests/test_span_utils_non_ascii.py` — 4/4 pass
- [x] Existing `test_non_ascii_content.py` still passes