### PR TITLE
fix(openai-agents): capture response.instructions as system prompt on generation spans

### DIFF
--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
@@ -310,6 +310,19 @@ def _extract_response_attributes(otel_span, response, trace_content: bool):
     return model_settings
 
 
+def _prepend_system_instruction(input_data, response, trace_content: bool):
+    """Prepend response.instructions as a system message to input data if available."""
+    if not (
+        trace_content
+        and response
+        and hasattr(response, "instructions")
+        and response.instructions
+    ):
+        return input_data
+    system_msg = {"role": "system", "content": response.instructions}
+    return [system_msg] + (input_data if input_data else [])
+
+
 class OpenTelemetryTracingProcessor(TracingProcessor):
     """
     A tracing processor that creates OpenTelemetry spans for OpenAI Agents.
@@ -622,10 +635,13 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
             ):
                 # Extract prompt data from input
                 input_data = getattr(span_data, "input", [])
-                _extract_prompt_attributes(otel_span, input_data, trace_content)
 
-                # Add function/tool specifications to the request using OpenAI semantic conventions
+                # Prepend system instructions from the response if available
+                # (the vanilla openai instrumentor already does this in responses_wrappers.py)
                 response = getattr(span_data, "response", None)
+                input_data = _prepend_system_instruction(input_data, response, trace_content)
+
+                _extract_prompt_attributes(otel_span, input_data, trace_content)
                 if (
                     response
                     and hasattr(response, "tools")
@@ -672,9 +688,11 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
             # Legacy fallback for other span types
             elif span_data:
                 input_data = getattr(span_data, "input", [])
-                _extract_prompt_attributes(otel_span, input_data, trace_content)
 
                 response = getattr(span_data, "response", None)
+                input_data = _prepend_system_instruction(input_data, response, trace_content)
+
+                _extract_prompt_attributes(otel_span, input_data, trace_content)
                 if response:
                     model_settings = _extract_response_attributes(otel_span, response, trace_content)
                     self._last_model_settings = model_settings


### PR DESCRIPTION
Fixes #3738

## Problem

The `opentelemetry-instrumentation-openai-agents` package does not capture `response.instructions` from the OpenAI Responses API. When an agent has `instructions` set (the system prompt), generation spans have no `gen_ai.prompt` entry with `role: system` — the system prompt is silently dropped.

The `_extract_response_attributes()` function reads `temperature`, `max_output_tokens`, `top_p`, `model`, `frequency_penalty`, `output`, and `usage` — but never `response.instructions`.

## Fix

In `on_span_end`, when handling `GenerationSpanData` / `ResponseSpanData`, prepend `response.instructions` as a system message to the input data before calling `_extract_prompt_attributes`. This produces:

- `gen_ai.prompt.0.role` = `"system"`
- `gen_ai.prompt.0.content` = `<agent instructions>`

Followed by the conversation history at indices 1, 2, 3, etc.

Applied to both the primary code path (ResponseSpanData / GenerationSpanData) and the legacy fallback path.

## Reference

This matches exactly how the vanilla `opentelemetry-instrumentation-openai` package handles instructions in `responses_wrappers.py`:

```python
if traced_response.instructions:
    _set_span_attribute(
        span,
        f"{GenAIAttributes.GEN_AI_PROMPT}.{prompt_index}.content",
        traced_response.instructions,
    )
    _set_span_attribute(
        span,
        f"{GenAIAttributes.GEN_AI_PROMPT}.{prompt_index}.role",
        "system",
    )
```

## Testing

Tested with an OpenAI Agents SDK agent that has `instructions` set. Before: no system prompt in generation spans. After: system prompt appears as `gen_ai.prompt.0` with role `system`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Capture `response.instructions` as a system prompt in generation spans in `on_span_end` in `_hooks.py`.
> 
>   - **Behavior**:
>     - In `on_span_end` in `_hooks.py`, prepend `response.instructions` as a system message to input data for `GenerationSpanData` and `ResponseSpanData`.
>     - Sets `gen_ai.prompt.0.role` to `"system"` and `gen_ai.prompt.0.content` to `<agent instructions>`.
>     - Applied to both primary and legacy code paths.
>   - **Reference**:
>     - Matches behavior of vanilla `opentelemetry-instrumentation-openai` in handling instructions.
>   - **Testing**:
>     - Verified with an agent having `instructions` set; system prompt now appears in generation spans.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopenllmetry&utm_source=github&utm_medium=referral)<sup> for 9b3bdd2ab44657b8448bc417d616a6842b834009. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * System instruction messages are now prepended to prompt data when content tracing is enabled, ensuring they are included in telemetry for OpenAI agent operations and improving observability and tracing accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->