### PR TITLE
fix(vertexai): preserve individual message roles in Content object lists

### DIFF
--- a/packages/opentelemetry-instrumentation-vertexai/opentelemetry/instrumentation/vertexai/span_utils.py
+++ b/packages/opentelemetry-instrumentation-vertexai/opentelemetry/instrumentation/vertexai/span_utils.py
@@ -116,13 +116,54 @@ def _process_image_part_sync(item, trace_id, span_id, content_index):
         return None
 
 
+def _is_content_object(obj):
+    """Check if an object is a VertexAI Content object (has role and parts)."""
+    return hasattr(obj, 'role') and hasattr(obj, 'parts')
+
+
+async def _process_content_object(content_obj, span):
+    """Process a VertexAI Content object, returning (role, processed_parts)."""
+    role = content_obj.role or "user"
+    processed_parts = []
+    for part_index, part in enumerate(content_obj.parts):
+        processed = await _process_content_item_vertexai(part, span, part_index)
+        if processed is not None:
+            processed_parts.append(processed)
+    return role, processed_parts
+
+
+def _process_content_object_sync(content_obj, span):
+    """Synchronous version: process a VertexAI Content object, returning (role, processed_parts)."""
+    role = content_obj.role or "user"
+    processed_parts = []
+    for part_index, part in enumerate(content_obj.parts):
+        processed = _process_content_item_vertexai_sync(part, span, part_index)
+        if processed is not None:
+            processed_parts.append(processed)
+    return role, processed_parts
+
+
 async def _process_vertexai_argument(argument, span):
-    """Process a single argument for VertexAI, handling different types"""
+    """Process a single argument for VertexAI, handling different types.
+
+    Returns either:
+      - A list of processed content dicts (for simple text, Part lists, etc.)
+      - A list of (role, content_list) tuples when the argument is a list of Content objects
+    """
     if isinstance(argument, str):
         # Simple text argument in OpenAI format
         return [{"type": "text", "text": argument}]
 
     elif isinstance(argument, list):
+        # Check if the list contains Content objects (with role and parts)
+        if argument and _is_content_object(argument[0]):
+            # List of Content objects - each has its own role
+            results = []
+            for content_obj in argument:
+                role, parts = await _process_content_object(content_obj, span)
+                results.append((role, parts))
+            return results
+
         # List of mixed content (text strings and Part objects) - deep copy and process
         content_list = copy.deepcopy(argument)
         processed_items = []
@@ -133,6 +174,11 @@ async def _process_vertexai_argument(argument, span):
                 processed_items.append(processed_item)
 
         return processed_items
+
+    elif _is_content_object(argument):
+        # Single Content object
+        role, parts = await _process_content_object(argument, span)
+        return [(role, parts)]
 
     else:
         # Single Part object - convert to OpenAI format
@@ -162,12 +208,26 @@ async def _process_content_item_vertexai(content_item, span, item_index):
 
 
 def _process_vertexai_argument_sync(argument, span):
-    """Synchronous version of argument processing for VertexAI"""
+    """Synchronous version of argument processing for VertexAI.
+
+    Returns either:
+      - A list of processed content dicts (for simple text, Part lists, etc.)
+      - A list of (role, content_list) tuples when the argument is a list of Content objects
+    """
     if isinstance(argument, str):
         # Simple text argument in OpenAI format
         return [{"type": "text", "text": argument}]
 
     elif isinstance(argument, list):
+        # Check if the list contains Content objects (with role and parts)
+        if argument and _is_content_object(argument[0]):
+            # List of Content objects - each has its own role
+            results = []
+            for content_obj in argument:
+                role, parts = _process_content_object_sync(content_obj, span)
+                results.append((role, parts))
+            return results
+
         # List of mixed content (text strings and Part objects) - deep copy and process
         content_list = copy.deepcopy(argument)
         processed_items = []
@@ -178,6 +238,11 @@ def _process_vertexai_argument_sync(argument, span):
                 processed_items.append(processed_item)
 
         return processed_items
+
+    elif _is_content_object(argument):
+        # Single Content object
+        role, parts = _process_content_object_sync(argument, span)
+        return [(role, parts)]
 
     else:
         # Single Part object - convert to OpenAI format
@@ -212,21 +277,41 @@ async def set_input_attributes(span, args):
     if not span.is_recording():
         return
     if should_send_prompts() and args is not None and len(args) > 0:
-        # Process each argument using extracted helper methods
-        for arg_index, argument in enumerate(args):
+        prompt_index = 0
+        for argument in args:
             processed_content = await _process_vertexai_argument(argument, span)
 
-            if processed_content:
+            if not processed_content:
+                continue
+
+            # Check if the result is a list of (role, parts) tuples (Content objects)
+            if isinstance(processed_content[0], tuple):
+                for role, parts in processed_content:
+                    if parts:
+                        _set_span_attribute(
+                            span,
+                            f"{GenAIAttributes.GEN_AI_PROMPT}.{prompt_index}.role",
+                            role,
+                        )
+                        _set_span_attribute(
+                            span,
+                            f"{GenAIAttributes.GEN_AI_PROMPT}.{prompt_index}.content",
+                            json.dumps(parts),
+                        )
+                        prompt_index += 1
+            else:
+                # Plain content list (strings, Parts, etc.) - assign as user role
                 _set_span_attribute(
                     span,
-                    f"{GenAIAttributes.GEN_AI_PROMPT}.{arg_index}.role",
-                    "user"
+                    f"{GenAIAttributes.GEN_AI_PROMPT}.{prompt_index}.role",
+                    "user",
                 )
                 _set_span_attribute(
                     span,
-                    f"{GenAIAttributes.GEN_AI_PROMPT}.{arg_index}.content",
-                    json.dumps(processed_content)
+                    f"{GenAIAttributes.GEN_AI_PROMPT}.{prompt_index}.content",
+                    json.dumps(processed_content),
                 )
+                prompt_index += 1
 
 
 # Sync version with image processing support
@@ -236,21 +321,41 @@ def set_input_attributes_sync(span, args):
     if not span.is_recording():
         return
     if should_send_prompts() and args is not None and len(args) > 0:
-        # Process each argument using extracted helper methods
-        for arg_index, argument in enumerate(args):
+        prompt_index = 0
+        for argument in args:
             processed_content = _process_vertexai_argument_sync(argument, span)
 
-            if processed_content:
+            if not processed_content:
+                continue
+
+            # Check if the result is a list of (role, parts) tuples (Content objects)
+            if isinstance(processed_content[0], tuple):
+                for role, parts in processed_content:
+                    if parts:
+                        _set_span_attribute(
+                            span,
+                            f"{GenAIAttributes.GEN_AI_PROMPT}.{prompt_index}.role",
+                            role,
+                        )
+                        _set_span_attribute(
+                            span,
+                            f"{GenAIAttributes.GEN_AI_PROMPT}.{prompt_index}.content",
+                            json.dumps(parts),
+                        )
+                        prompt_index += 1
+            else:
+                # Plain content list (strings, Parts, etc.) - assign as user role
                 _set_span_attribute(
                     span,
-                    f"{GenAIAttributes.GEN_AI_PROMPT}.{arg_index}.role",
-                    "user"
+                    f"{GenAIAttributes.GEN_AI_PROMPT}.{prompt_index}.role",
+                    "user",
                 )
                 _set_span_attribute(
                     span,
-                    f"{GenAIAttributes.GEN_AI_PROMPT}.{arg_index}.content",
-                    json.dumps(processed_content)
+                    f"{GenAIAttributes.GEN_AI_PROMPT}.{prompt_index}.content",
+                    json.dumps(processed_content),
                 )
+                prompt_index += 1
 
 
 @dont_throw

--- a/packages/opentelemetry-instrumentation-vertexai/tests/test_role_attributes.py
+++ b/packages/opentelemetry-instrumentation-vertexai/tests/test_role_attributes.py
@@ -210,3 +210,141 @@ class TestRoleAttributes:
 
         # Verify content is also set
         assert f"{SpanAttributes.LLM_PROMPTS}.0.content" in self.span_attributes
+
+
+class TestContentObjectMessageHistory:
+    """Test that Content objects with different roles are preserved as separate messages.
+
+    Regression tests for https://github.com/traceloop/openllmetry/issues/2513
+    """
+
+    def setup_method(self):
+        """Setup test fixtures"""
+        self.mock_span = Mock()
+        self.mock_span.is_recording.return_value = True
+        self.mock_span.context.trace_id = "test_trace_id"
+        self.mock_span.context.span_id = "test_span_id"
+        self.span_attributes = {}
+
+        def capture_attribute(key, value):
+            self.span_attributes[key] = value
+
+        self.mock_span.set_attribute = capture_attribute
+
+    def _make_content(self, role, text):
+        """Create a mock VertexAI Content object."""
+        part = Mock()
+        part.text = text
+        # Ensure Part does not look like a Content object
+        del part.role
+        del part.parts
+        # Ensure Part does not look like a base64 image
+        part.inline_data = None
+        part.mime_type = None
+
+        content = Mock()
+        content.role = role
+        content.parts = [part]
+        return content
+
+    @patch("opentelemetry.instrumentation.vertexai.span_utils.should_send_prompts")
+    def test_sync_content_objects_preserve_roles(self, mock_should_send_prompts):
+        """Test that a list of Content objects preserves each message's role."""
+        mock_should_send_prompts.return_value = True
+
+        args = [
+            [
+                self._make_content("user", "What's 2+2?"),
+                self._make_content("model", "5"),
+                self._make_content("user", "really?"),
+            ]
+        ]
+        set_input_attributes_sync(self.mock_span, args)
+
+        # Verify three separate messages with correct roles
+        assert self.span_attributes[f"{SpanAttributes.LLM_PROMPTS}.0.role"] == "user"
+        content_0 = json.loads(self.span_attributes[f"{SpanAttributes.LLM_PROMPTS}.0.content"])
+        assert content_0 == [{"type": "text", "text": "What's 2+2?"}]
+
+        assert self.span_attributes[f"{SpanAttributes.LLM_PROMPTS}.1.role"] == "model"
+        content_1 = json.loads(self.span_attributes[f"{SpanAttributes.LLM_PROMPTS}.1.content"])
+        assert content_1 == [{"type": "text", "text": "5"}]
+
+        assert self.span_attributes[f"{SpanAttributes.LLM_PROMPTS}.2.role"] == "user"
+        content_2 = json.loads(self.span_attributes[f"{SpanAttributes.LLM_PROMPTS}.2.content"])
+        assert content_2 == [{"type": "text", "text": "really?"}]
+
+    @patch("opentelemetry.instrumentation.vertexai.span_utils.should_send_prompts")
+    @pytest.mark.asyncio
+    async def test_async_content_objects_preserve_roles(self, mock_should_send_prompts):
+        """Test that a list of Content objects preserves each message's role (async)."""
+        mock_should_send_prompts.return_value = True
+
+        args = [
+            [
+                self._make_content("user", "What's 2+2?"),
+                self._make_content("model", "5"),
+                self._make_content("user", "really?"),
+            ]
+        ]
+        await set_input_attributes(self.mock_span, args)
+
+        # Verify three separate messages with correct roles
+        assert self.span_attributes[f"{SpanAttributes.LLM_PROMPTS}.0.role"] == "user"
+        content_0 = json.loads(self.span_attributes[f"{SpanAttributes.LLM_PROMPTS}.0.content"])
+        assert content_0 == [{"type": "text", "text": "What's 2+2?"}]
+
+        assert self.span_attributes[f"{SpanAttributes.LLM_PROMPTS}.1.role"] == "model"
+        content_1 = json.loads(self.span_attributes[f"{SpanAttributes.LLM_PROMPTS}.1.content"])
+        assert content_1 == [{"type": "text", "text": "5"}]
+
+        assert self.span_attributes[f"{SpanAttributes.LLM_PROMPTS}.2.role"] == "user"
+        content_2 = json.loads(self.span_attributes[f"{SpanAttributes.LLM_PROMPTS}.2.content"])
+        assert content_2 == [{"type": "text", "text": "really?"}]
+
+    @patch("opentelemetry.instrumentation.vertexai.span_utils.should_send_prompts")
+    def test_sync_content_object_with_multiple_parts(self, mock_should_send_prompts):
+        """Test that a Content object with multiple parts is handled correctly."""
+        mock_should_send_prompts.return_value = True
+
+        # Create a Content with multiple text parts
+        part1 = Mock()
+        part1.text = "Hello"
+        del part1.role
+        del part1.parts
+        part1.inline_data = None
+        part1.mime_type = None
+
+        part2 = Mock()
+        part2.text = "World"
+        del part2.role
+        del part2.parts
+        part2.inline_data = None
+        part2.mime_type = None
+
+        content = Mock()
+        content.role = "user"
+        content.parts = [part1, part2]
+
+        args = [[content]]
+        set_input_attributes_sync(self.mock_span, args)
+
+        assert self.span_attributes[f"{SpanAttributes.LLM_PROMPTS}.0.role"] == "user"
+        content_parsed = json.loads(self.span_attributes[f"{SpanAttributes.LLM_PROMPTS}.0.content"])
+        assert content_parsed == [
+            {"type": "text", "text": "Hello"},
+            {"type": "text", "text": "World"},
+        ]
+
+    @patch("opentelemetry.instrumentation.vertexai.span_utils.should_send_prompts")
+    def test_sync_single_content_object_arg(self, mock_should_send_prompts):
+        """Test passing a single Content object (not in a list) as an argument."""
+        mock_should_send_prompts.return_value = True
+
+        content = self._make_content("user", "Hello!")
+        args = [content]
+        set_input_attributes_sync(self.mock_span, args)
+
+        assert self.span_attributes[f"{SpanAttributes.LLM_PROMPTS}.0.role"] == "user"
+        content_parsed = json.loads(self.span_attributes[f"{SpanAttributes.LLM_PROMPTS}.0.content"])
+        assert content_parsed == [{"type": "text", "text": "Hello!"}]


### PR DESCRIPTION
## Summary

Fixes #2513

When `generate_content()` receives a list of `Content` objects with different roles (e.g. user/model conversation history), the `_set_input_attributes` function was treating the entire list as flat content items and merging everything into a single prompt with `role="user"`. This caused the entire conversation history to be stringified into one attribute, losing message separation and role information.

### Root Cause

`_process_vertexai_argument()` (and its sync variant) did not check whether list items are `Content` objects (which have `role` and `parts` attributes). It treated all list items as raw content (strings or `Part` objects), deep-copied them, and processed them as a single flat list.

### Fix

- Added `_is_content_object()` helper to detect VertexAI `Content` objects by checking for `role` and `parts` attributes
- Added `_process_content_object()` / `_process_content_object_sync()` to extract the role and process each Content's parts individually
- Updated `_process_vertexai_argument()` / `_process_vertexai_argument_sync()` to detect Content object lists and return `(role, parts)` tuples instead of flat content
- Updated `set_input_attributes()` / `set_input_attributes_sync()` to handle the tuple format, assigning each Content object its own prompt index with the correct role

### Before (broken)
```json
{
  "gen_ai.prompt.0.user": "role: \"user\"\nparts {\n  text: \"What's 2+2?\"\n}\n\nrole: \"model\"\nparts {\n  text: \"5\"\n}\n..."
}
```

### After (fixed)
```json
{
  "gen_ai.prompt.0.role": "user",
  "gen_ai.prompt.0.content": "[{\"type\": \"text\", \"text\": \"What's 2+2?\"}]",
  "gen_ai.prompt.1.role": "model",
  "gen_ai.prompt.1.content": "[{\"type\": \"text\", \"text\": \"5\"}]",
  "gen_ai.prompt.2.role": "user",
  "gen_ai.prompt.2.content": "[{\"type\": \"text\", \"text\": \"really?\"}]"
}
```

## Test Plan

- [x] Added 4 new regression tests in `TestContentObjectMessageHistory`:
  - `test_sync_content_objects_preserve_roles` - verifies multi-turn conversation with user/model roles (exact reproduction of #2513)
  - `test_async_content_objects_preserve_roles` - same test for the async path
  - `test_sync_content_object_with_multiple_parts` - verifies Content with multiple Part objects
  - `test_sync_single_content_object_arg` - verifies a single Content object passed directly
- [x] All 12 existing tests continue to pass (string args, mixed content, image content, disabled prompts, etc.)
- [x] Ruff lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for VertexAI Content objects with improved role handling and span attribute generation.
  * Content objects with distinct roles are now properly tracked and preserved in instrumentation traces.
  * Backward compatibility maintained for existing argument processing paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->