### PR TITLE
fix(watsonx): extract API base URL from client SDK instead of hardcoding

### DIFF
--- a/packages/opentelemetry-instrumentation-watsonx/opentelemetry/instrumentation/watsonx/__init__.py
+++ b/packages/opentelemetry-instrumentation-watsonx/opentelemetry/instrumentation/watsonx/__init__.py
@@ -109,13 +109,33 @@ def _set_span_attribute(span, name, value):
     return
 
 
-def _set_api_attributes(span):
+def _get_api_base_url(instance):
+    """Extract the API base URL from a Watsonx ModelInference instance.
+
+    Attempts to read the URL from the underlying APIClient credentials.
+    Falls back to the default us-south endpoint when unavailable.
+    """
+    default_url = "https://us-south.ml.cloud.ibm.com"
+    try:
+        client = getattr(instance, "_client", None)
+        if client is not None:
+            credentials = getattr(client, "credentials", None)
+            if credentials is not None:
+                url = getattr(credentials, "url", None)
+                if url:
+                    return url
+    except Exception:
+        pass
+    return default_url
+
+
+def _set_api_attributes(span, instance=None):
     if not span.is_recording():
         return
     _set_span_attribute(
         span,
         WatsonxSpanAttributes.WATSONX_API_BASE,
-        "https://us-south.ml.cloud.ibm.com",
+        _get_api_base_url(instance),
     )
     _set_span_attribute(span, WatsonxSpanAttributes.WATSONX_API_TYPE, "watsonx.ai")
     _set_span_attribute(span, WatsonxSpanAttributes.WATSONX_API_VERSION, "1.0")
@@ -488,7 +508,7 @@ def _with_tracer_wrapper(func):
 
 @dont_throw
 def _handle_input(span, event_logger, name, instance, response_counter, args, kwargs):
-    _set_api_attributes(span)
+    _set_api_attributes(span, instance)
 
     if "generate" in name:
         set_model_input_attributes(span, instance)

--- a/packages/opentelemetry-instrumentation-watsonx/tests/traces/test_api_base_url.py
+++ b/packages/opentelemetry-instrumentation-watsonx/tests/traces/test_api_base_url.py
@@ -1,0 +1,122 @@
+"""Unit tests for dynamic API base URL extraction from Watsonx instances."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from opentelemetry.instrumentation.watsonx import WatsonxSpanAttributes
+from opentelemetry.instrumentation.watsonx import (
+    _get_api_base_url,
+    _set_api_attributes,
+)
+
+
+DEFAULT_URL = "https://us-south.ml.cloud.ibm.com"
+FRANKFURT_URL = "https://eu-de.ml.cloud.ibm.com"
+TOKYO_URL = "https://jp-tok.ml.cloud.ibm.com"
+
+
+class TestGetApiBaseUrl:
+    """Tests for _get_api_base_url helper."""
+
+    def test_returns_url_from_instance_credentials(self):
+        instance = SimpleNamespace(
+            _client=SimpleNamespace(
+                credentials=SimpleNamespace(url=FRANKFURT_URL)
+            )
+        )
+        assert _get_api_base_url(instance) == FRANKFURT_URL
+
+    def test_returns_default_when_instance_is_none(self):
+        assert _get_api_base_url(None) == DEFAULT_URL
+
+    def test_returns_default_when_client_missing(self):
+        instance = SimpleNamespace()
+        assert _get_api_base_url(instance) == DEFAULT_URL
+
+    def test_returns_default_when_credentials_missing(self):
+        instance = SimpleNamespace(_client=SimpleNamespace())
+        assert _get_api_base_url(instance) == DEFAULT_URL
+
+    def test_returns_default_when_url_is_none(self):
+        instance = SimpleNamespace(
+            _client=SimpleNamespace(
+                credentials=SimpleNamespace(url=None)
+            )
+        )
+        assert _get_api_base_url(instance) == DEFAULT_URL
+
+    def test_returns_default_when_url_is_empty(self):
+        instance = SimpleNamespace(
+            _client=SimpleNamespace(
+                credentials=SimpleNamespace(url="")
+            )
+        )
+        assert _get_api_base_url(instance) == DEFAULT_URL
+
+    def test_handles_different_regions(self):
+        instance = SimpleNamespace(
+            _client=SimpleNamespace(
+                credentials=SimpleNamespace(url=TOKYO_URL)
+            )
+        )
+        assert _get_api_base_url(instance) == TOKYO_URL
+
+    def test_handles_attribute_error_gracefully(self):
+        """Ensure no exception is raised when accessing attributes fails."""
+        instance = MagicMock()
+        instance._client.credentials = property(
+            lambda self: (_ for _ in ()).throw(AttributeError)
+        )
+        # Should fall back to default, not raise
+        result = _get_api_base_url(instance)
+        assert isinstance(result, str)
+
+
+class TestSetApiAttributes:
+    """Tests for _set_api_attributes with dynamic URL."""
+
+    def test_sets_url_from_instance(self):
+        span = MagicMock()
+        span.is_recording.return_value = True
+        instance = SimpleNamespace(
+            _client=SimpleNamespace(
+                credentials=SimpleNamespace(url=FRANKFURT_URL)
+            )
+        )
+
+        _set_api_attributes(span, instance)
+
+        span.set_attribute.assert_any_call(
+            WatsonxSpanAttributes.WATSONX_API_BASE, FRANKFURT_URL
+        )
+
+    def test_sets_default_url_when_no_instance(self):
+        span = MagicMock()
+        span.is_recording.return_value = True
+
+        _set_api_attributes(span)
+
+        span.set_attribute.assert_any_call(
+            WatsonxSpanAttributes.WATSONX_API_BASE, DEFAULT_URL
+        )
+
+    def test_sets_api_type_and_version(self):
+        span = MagicMock()
+        span.is_recording.return_value = True
+
+        _set_api_attributes(span)
+
+        span.set_attribute.assert_any_call(
+            WatsonxSpanAttributes.WATSONX_API_TYPE, "watsonx.ai"
+        )
+        span.set_attribute.assert_any_call(
+            WatsonxSpanAttributes.WATSONX_API_VERSION, "1.0"
+        )
+
+    def test_skips_when_not_recording(self):
+        span = MagicMock()
+        span.is_recording.return_value = False
+
+        _set_api_attributes(span)
+
+        span.set_attribute.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Replaces the hardcoded `us-south` API URL in the Watsonx instrumentor with a dynamic URL extracted from the `ModelInference` client SDK instance.

Previously, `_set_api_attributes` always set `watsonx.api_base` to `https://us-south.ml.cloud.ibm.com`, which is incorrect for users in other regions (Frankfurt, Tokyo, etc.) or on-prem deployments.

Now the URL is read from `instance._client.credentials.url` — the same path the Watsonx SDK uses internally — with a safe fallback to the default `us-south` endpoint when the attribute is unavailable.

Fixes #2163

## Type of change

Bug fix — incorrect tracing data for non-US-south regions.

## How was this tested?

- Added 12 unit tests covering:
  - URL extraction from various instance shapes (valid credentials, missing client, missing credentials, None/empty URL)
  - Graceful fallback to default URL
  - Different region URLs (Frankfurt, Tokyo)
  - `_set_api_attributes` span attribute setting with and without instance
  - Span not recording skip behavior
- All tests pass: `uv run pytest tests/traces/test_api_base_url.py -v`
- Ruff lint passes

## Checklist

- [x] I have added tests that cover my changes.
- [x] PR name follows conventional commits format: `fix(instrumentation): ...`.
- [x] (If applicable) I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Watsonx instrumentation now dynamically resolves API base URLs from instance configuration, enabling support for region-specific endpoints and custom configurations instead of using a hardcoded default.

* **Tests**
  * Added comprehensive test coverage for API base URL extraction and attribute setting with various configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->