### PR TITLE
fix(cohere): prevent experimental_kwarg_decorator from shadowing instrumentation

### DIFF
--- a/packages/opentelemetry-instrumentation-cohere/opentelemetry/instrumentation/cohere/__init__.py
+++ b/packages/opentelemetry-instrumentation-cohere/opentelemetry/instrumentation/cohere/__init__.py
@@ -163,6 +163,44 @@ WRAPPED_AMETHODS = [
     },
 ]
 
+# Client classes whose __init__ may overwrite chat/chat_stream with
+# experimental_kwarg_decorator, adding instance attributes that shadow the
+# class-level wrapt wrappers.  We wrap __init__ to remove those instance
+# overrides so that the class-level wrapt instrumentation stays effective.
+_INIT_OVERWRITTEN_METHODS = {
+    ("cohere.client", "Client"): ["chat", "chat_stream"],
+    ("cohere.client", "AsyncClient"): ["chat", "chat_stream"],
+    ("cohere.client_v2", "ClientV2"): ["chat", "chat_stream"],
+    ("cohere.client_v2", "AsyncClientV2"): ["chat", "chat_stream"],
+}
+
+
+def _make_init_wrapper(method_names):
+    """Create an __init__ wrapper that removes instance-level method overrides.
+
+    Cohere SDK's Client/AsyncClient __init__ overwrite self.chat and
+    self.chat_stream with experimental_kwarg_decorator wrappers stored as
+    instance attributes.  These shadow the class-level wrapt wrappers
+    installed by wrap_function_wrapper, which can interfere with
+    instrumentation.
+
+    By deleting those instance attributes after __init__, Python's normal
+    attribute lookup falls back to the class-level descriptors where our
+    wrapt wrappers live, ensuring clean instrumentation.
+    """
+
+    def init_wrapper(wrapped, instance, args, kwargs):
+        result = wrapped(*args, **kwargs)
+        for method_name in method_names:
+            if method_name in instance.__dict__:
+                try:
+                    delattr(instance, method_name)
+                except AttributeError:
+                    pass
+        return result
+
+    return init_wrapper
+
 
 def _with_tracer_wrapper(func):
     """Helper for providing tracer for wrapper functions."""
@@ -343,6 +381,19 @@ class CohereInstrumentor(BaseInstrumentor):
             except (ImportError, ModuleNotFoundError, AttributeError):
                 logger.debug(f"Failed to instrument {wrap_module}.{wrap_object}.{wrap_method}")
 
+        # Wrap __init__ of client classes to remove instance-level method
+        # overrides that Cohere SDK's experimental_kwarg_decorator adds
+        # during client construction.
+        for (mod_name, cls_name), method_names in _INIT_OVERWRITTEN_METHODS.items():
+            try:
+                wrap_function_wrapper(
+                    mod_name,
+                    f"{cls_name}.__init__",
+                    _make_init_wrapper(method_names),
+                )
+            except (ImportError, ModuleNotFoundError, AttributeError):
+                logger.debug(f"Failed to wrap {mod_name}.{cls_name}.__init__")
+
     def _uninstrument(self, **kwargs):
         for wrapped_method in WRAPPED_METHODS:
             wrap_module = wrapped_method.get("module")
@@ -366,3 +417,11 @@ class CohereInstrumentor(BaseInstrumentor):
                 )
             except (ImportError, ModuleNotFoundError, AttributeError):
                 logger.debug(f"Failed to uninstrument {wrap_module}.{wrap_object}.{wrap_method}")
+        for mod_name, cls_name in _INIT_OVERWRITTEN_METHODS:
+            try:
+                unwrap(
+                    f"{mod_name}.{cls_name}",
+                    "__init__",
+                )
+            except (ImportError, ModuleNotFoundError, AttributeError):
+                logger.debug(f"Failed to uninstrument {mod_name}.{cls_name}.__init__")

--- a/packages/opentelemetry-instrumentation-cohere/tests/test_init_wrapper.py
+++ b/packages/opentelemetry-instrumentation-cohere/tests/test_init_wrapper.py
@@ -1,0 +1,113 @@
+"""Tests that instrumentation survives Cohere SDK's __init__ method overrides.
+
+Cohere SDK's Client and AsyncClient __init__ methods overwrite self.chat and
+self.chat_stream with experimental_kwarg_decorator wrappers.  These tests
+verify that our __init__ wrapper correctly removes those instance-level
+overrides so that the class-level wrapt wrappers remain effective.
+"""
+
+import os
+
+import cohere
+import pytest
+from opentelemetry.instrumentation.cohere import CohereInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+
+@pytest.fixture(autouse=True)
+def environment():
+    if "COHERE_API_KEY" not in os.environ:
+        os.environ["COHERE_API_KEY"] = "test_api_key"
+
+
+@pytest.fixture
+def tracer_provider():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider
+
+
+@pytest.fixture
+def instrumentor(tracer_provider):
+    inst = CohereInstrumentor()
+    inst.instrument(tracer_provider=tracer_provider)
+    yield inst
+    inst.uninstrument()
+
+
+def test_client_chat_not_shadowed_by_instance_attribute(instrumentor):
+    """Client.chat should go through wrapt wrapper, not instance attribute."""
+    client = cohere.Client("test_key")
+    assert "chat" not in client.__dict__, (
+        "chat should not be an instance attribute after instrumentation"
+    )
+    assert "BoundFunctionWrapper" in type(client.chat).__name__
+
+
+def test_client_chat_stream_not_shadowed_by_instance_attribute(instrumentor):
+    """Client.chat_stream should go through wrapt wrapper, not instance attribute."""
+    client = cohere.Client("test_key")
+    assert "chat_stream" not in client.__dict__, (
+        "chat_stream should not be an instance attribute after instrumentation"
+    )
+    assert "BoundFunctionWrapper" in type(client.chat_stream).__name__
+
+
+def test_async_client_chat_not_shadowed_by_instance_attribute(instrumentor):
+    """AsyncClient.chat should go through wrapt wrapper, not instance attribute."""
+    client = cohere.AsyncClient("test_key")
+    assert "chat" not in client.__dict__, (
+        "chat should not be an instance attribute after instrumentation"
+    )
+    assert "BoundFunctionWrapper" in type(client.chat).__name__
+
+
+def test_async_client_chat_stream_not_shadowed_by_instance_attribute(instrumentor):
+    """AsyncClient.chat_stream should go through wrapt wrapper, not instance attribute."""
+    client = cohere.AsyncClient("test_key")
+    assert "chat_stream" not in client.__dict__, (
+        "chat_stream should not be an instance attribute after instrumentation"
+    )
+    assert "BoundFunctionWrapper" in type(client.chat_stream).__name__
+
+
+def test_client_v2_chat_not_shadowed_by_instance_attribute(instrumentor):
+    """ClientV2.chat should go through wrapt wrapper, not instance attribute."""
+    client = cohere.ClientV2("test_key")
+    assert "chat" not in client.__dict__, (
+        "chat should not be an instance attribute after instrumentation"
+    )
+    assert "BoundFunctionWrapper" in type(client.chat).__name__
+
+
+def test_async_client_v2_chat_not_shadowed_by_instance_attribute(instrumentor):
+    """AsyncClientV2.chat should go through wrapt wrapper, not instance attribute."""
+    client = cohere.AsyncClientV2("test_key")
+    assert "chat" not in client.__dict__, (
+        "chat should not be an instance attribute after instrumentation"
+    )
+    assert "BoundFunctionWrapper" in type(client.chat).__name__
+
+
+def test_non_overwritten_methods_still_wrapped(instrumentor):
+    """Methods not affected by experimental_kwarg_decorator should still be wrapped."""
+    client = cohere.Client("test_key")
+    assert "BoundFunctionWrapper" in type(client.rerank).__name__
+    assert "BoundFunctionWrapper" in type(client.embed).__name__
+    assert "BoundFunctionWrapper" in type(client.generate).__name__
+
+
+def test_uninstrument_restores_original(tracer_provider):
+    """After uninstrument, __init__ should no longer be wrapped."""
+    inst = CohereInstrumentor()
+    inst.instrument(tracer_provider=tracer_provider)
+    inst.uninstrument()
+
+    # After uninstrument, creating a new client should have the instance
+    # attributes back (from experimental_kwarg_decorator)
+    client = cohere.Client("test_key")
+    # The methods should be regular functions, not FunctionWrappers
+    assert "FunctionWrapper" not in type(client.rerank).__name__


### PR DESCRIPTION
## Summary

Fixes #2338

Cohere SDK's `Client` and `AsyncClient` `__init__` methods overwrite `self.chat` and `self.chat_stream` with `experimental_kwarg_decorator` wrappers stored as instance attributes. These instance attributes shadow the class-level `wrapt` instrumentation wrappers installed by `CohereInstrumentor`, which can interfere with clean instrumentation and span context propagation.

### Root Cause

When `cohere.Client.__init__` runs with `log_warning_experimental_features=True` (the default), it executes:

```python
self.chat = experimental_kwarg_decorator(self.chat, "response_format.schema")
self.chat_stream = experimental_kwarg_decorator(self.chat_stream, "response_format.schema")
```

This creates plain function instance attributes that shadow the class-level `wrapt.FunctionWrapper` descriptors. While the `experimental_kwarg_decorator` captures the `BoundFunctionWrapper` internally (so spans are still generated through an indirect path), this extra layer is fragile and can cause issues.

### Fix

This PR wraps `__init__` of all four client classes (`Client`, `AsyncClient`, `ClientV2`, `AsyncClientV2`) to remove those instance-level overrides after construction. Python's attribute lookup then falls back directly to the class-level `wrapt` wrappers, ensuring clean and reliable instrumentation.

### Changes

- **`__init__.py`**: Added `_INIT_OVERWRITTEN_METHODS` mapping and `_make_init_wrapper()` function. Updated `_instrument()` to wrap client `__init__` methods, and `_uninstrument()` to unwrap them.
- **`tests/test_init_wrapper.py`**: New test file with 8 tests verifying that instance-level method overrides are properly removed for all client types, and that `uninstrument()` correctly restores original behavior.

## Test plan

- [x] All 25 existing tests pass
- [x] 8 new tests verify the fix across all client types (Client, AsyncClient, ClientV2, AsyncClientV2)
- [x] Lint passes (`ruff check`)
- [x] Verified that `chat` and `chat_stream` resolve to `BoundFunctionWrapper` on all client instances after instrumentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved instrumentation resilience for Cohere client initialization to ensure consistent and reliable tracing behavior across all client variants and versions.

* **Tests**
  * Added comprehensive test coverage for instrumentation behavior, verifying correct tracing for Cohere SDK clients in both synchronous and asynchronous scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->