### PR TITLE
fix(sdk): prefer model_dump() over json() in JSONEncoder for Pydantic v2

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/utils/json_encoder.py
+++ b/packages/traceloop-sdk/traceloop/sdk/utils/json_encoder.py
@@ -14,13 +14,15 @@ class JSONEncoder(json.JSONEncoder):
         if hasattr(o, "to_json"):
             return o.to_json()
 
-        # Prefer Pydantic v2 model_dump_json() to avoid PydanticDeprecatedSince20 warnings
-        # raised when calling the legacy .json() method on BaseModel instances.
-        if hasattr(o, "model_dump_json"):
-            return o.model_dump_json()
+        # Prefer Pydantic v2 model_dump() to avoid PydanticDeprecatedSince20 warnings.
+        # model_dump() returns a dict (JSON-serializable Python object), whereas
+        # model_dump_json() / .json() return a JSON *string* which would be
+        # double-encoded by json.JSONEncoder into an escaped string literal.
+        if hasattr(o, "model_dump"):
+            return o.model_dump()
 
-        if hasattr(o, "json"):
-            return o.json()
+        if hasattr(o, "dict"):
+            return o.dict()
 
         if hasattr(o, "__class__"):
             return o.__class__.__name__


### PR DESCRIPTION
## Problem

`JSONEncoder.default()` calls `o.json()` when serialising Pydantic model instances. In Pydantic v2, `.json()` is deprecated in favour of `.model_dump_json()`, causing a large volume of `PydanticDeprecatedSince20` warnings:

```
PydanticDeprecatedSince20: The `json` method is deprecated; use `model_dump_json` instead.
Deprecated in Pydantic V2.0 to be removed in V3.0.
```

Any workflow or task decorated with `@task`/`@workflow` whose arguments or return values are Pydantic models triggers this warning.

Reported in #3516.

## Fix

Check for `.model_dump_json()` first (Pydantic v2 path) before falling back to `.json()` (Pydantic v1 path):

```python
# Prefer Pydantic v2 model_dump_json() to avoid deprecation warnings
if hasattr(o, "model_dump_json"):
    return o.model_dump_json()

if hasattr(o, "json"):
    return o.json()
```

This eliminates the deprecation warnings for Pydantic v2 models without breaking backwards compatibility with Pydantic v1.

Fixes #3516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON serialization to better support Pydantic v2, reducing deprecation warnings and improving compatibility.
  * Preserved existing custom JSON handling and fallback behavior to ensure stable outputs when objects lack modern serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->