### PR TITLE
fix(langchain): bump semconv-ai min requirement to 0.4.14 to fix GenAICustomOperationName ImportError

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/pyproject.toml
+++ b/packages/opentelemetry-instrumentation-langchain/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.10,<4"
 dependencies = [
   "opentelemetry-api>=1.38.0,<2",
   "opentelemetry-instrumentation>=0.59b0",
-  "opentelemetry-semantic-conventions-ai>=0.4.13,<0.5.0",
+  "opentelemetry-semantic-conventions-ai>=0.4.14,<0.5.0",
   "opentelemetry-semantic-conventions>=0.59b0",
 ]
 


### PR DESCRIPTION
## Problem

`opentelemetry-instrumentation-langchain` 0.53.0 imports `GenAICustomOperationName` from `opentelemetry.semconv_ai` (added in version 0.4.14). The minimum requirement in `pyproject.toml` was still `>=0.4.13`, so users who had exactly 0.4.13 installed got an `ImportError` on startup (closes #3766):

```
ImportError: cannot import name 'GenAICustomOperationName'
from 'opentelemetry.semconv_ai'
```

## Fix

Bump the lower bound from `>=0.4.13` to `>=0.4.14`:

```toml
"opentelemetry-semantic-conventions-ai>=0.4.14,<0.5.0",
```

`GenAICustomOperationName` was introduced in semconv-ai 0.4.14 (commit f687ca13). This is a minimal, non-breaking change — 0.4.14 is already published on PyPI.

Closes #3766

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenTelemetry semantic conventions for AI dependency to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->