### PR TITLE
fix(qdrant): remove deprecated upload_records from instrumentation method lists (#3492)

### DIFF
--- a/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/async_qdrant_client_methods.json
+++ b/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/async_qdrant_client_methods.json
@@ -16,11 +16,6 @@
     },
     {
         "object": "AsyncQdrantClient",
-        "method": "upload_records",
-        "span_name": "qdrant.upload_records"
-    },
-    {
-        "object": "AsyncQdrantClient",
         "method": "upload_collection",
         "span_name": "qdrant.upload_collection"
     },

--- a/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/qdrant_client_methods.json
+++ b/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/qdrant_client_methods.json
@@ -16,11 +16,6 @@
     },
     {
         "object": "QdrantClient",
-        "method": "upload_records",
-        "span_name": "qdrant.upload_records"
-    },
-    {
-        "object": "QdrantClient",
         "method": "upload_collection",
         "span_name": "qdrant.upload_collection"
     },


### PR DESCRIPTION
## Summary

Fixes #3492

## Problem

`QdrantClient.upload_records` was removed from `qdrant-client` in v1.13 and is not present in v1.16.1+. The method was still listed in both `qdrant_client_methods.json` and `async_qdrant_client_methods.json`, causing an `AttributeError` at instrumentation time for users on newer `qdrant-client` versions:

```
AttributeError: type object 'QdrantClient' has no attribute 'upload_records'
```

Note: The `_instrument` method already guards against missing attributes via `hasattr()`, so the crash only affects older published versions of this package. However, keeping stale entries is misleading — they suggest telemetry is being captured for a method that no longer exists.

## Fix

Remove `upload_records` from both:
- `qdrant_client_methods.json`
- `async_qdrant_client_methods.json`

## Verification

Installed `qdrant-client==1.16.1` and confirmed via `dir(QdrantClient)` that `upload_points` and `upload_collection` are present, but `upload_records` is not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the tracing/observability span emitted for the upload_records operation in both synchronous and asynchronous Qdrant client integrations. This change only affects the specific upload_records span; all other client instrumentation and span mappings remain unchanged. No functional behavior of the clients is altered beyond tracing output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->