### PR TITLE
fix(langchain): detach orphaned context_api.attach() calls that corrupt OTel context

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
@@ -205,6 +205,9 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         token = self.spans[run_id].token
         if token:
             self._safe_detach_context(token)
+        assoc_token = self.spans[run_id].association_properties_token
+        if assoc_token:
+            self._safe_detach_context(assoc_token)
 
         del self.spans[run_id]
 
@@ -266,6 +269,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         entity_path: str = "",
         metadata: Optional[dict[str, Any]] = None,
     ) -> Span:
+        association_properties_token = None
         if metadata is not None:
             current_association_properties = (
                 context_api.get_value("association_properties") or {}
@@ -277,7 +281,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
                 if v is not None
             }
             try:
-                context_api.attach(
+                association_properties_token = context_api.attach(
                     context_api.set_value(
                         "association_properties",
                         {**current_association_properties, **sanitized_metadata},
@@ -286,7 +290,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
             except Exception:
                 # If setting association properties fails, continue without them
                 # This doesn't affect the core span functionality
-                pass
+                association_properties_token = None
 
         if parent_run_id is not None and parent_run_id in self.spans:
             span = self.tracer.start_span(
@@ -330,7 +334,14 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
                 )
 
         self.spans[run_id] = SpanHolder(
-            span, token, None, [], workflow_name, entity_name, entity_path
+            span,
+            token,
+            None,
+            [],
+            workflow_name,
+            entity_name,
+            entity_path,
+            association_properties_token=association_properties_token,
         )
 
         if parent_run_id is not None and parent_run_id in self.spans:
@@ -599,16 +610,6 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
             span.set_attribute(SpanAttributes.GEN_AI_TASK_OUTPUT, output_json)
 
         self._end_span(span, run_id)
-        if parent_run_id is None:
-            try:
-                context_api.attach(
-                    context_api.set_value(
-                        SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY, False
-                    )
-                )
-            except Exception:
-                # If context reset fails, it's not critical for functionality
-                pass
 
     @dont_throw
     def on_chat_model_start(

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/span_utils.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/span_utils.py
@@ -60,6 +60,7 @@ class SpanHolder:
     entity_path: str
     start_time: float = field(default_factory=time.time)
     request_model: Optional[str] = None
+    association_properties_token: Any = None
 
 
 def _message_type_to_role(message_type: str) -> str:


### PR DESCRIPTION
Fixes #3526

## Description

The LangChain instrumentation has two code paths where `context_api.attach()` is called without a corresponding `context_api.detach()`, leaving orphaned contexts on the OpenTelemetry stack. After LangChain execution completes, `trace.get_current_span()` returns an ended span instead of the parent span, breaking downstream trace context propagation and log correlation.

## Root cause

### 1. `_create_span()` — association_properties token lost

```python
# BEFORE: token never saved, never detached
context_api.attach(
    context_api.set_value("association_properties", {...})
)
```

**Fix:** Save the token and store it in a new `SpanHolder.association_properties_token` field. Detach it in `_end_span()` alongside the span token.

### 2. `on_chain_end()` — redundant attach without detach

```python
# BEFORE: orphaned attach to reset suppression key
context_api.attach(
    context_api.set_value(SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY, False)
)
```

**Fix:** Removed entirely. The suppression token is already properly detached by `_end_span()` via `SpanHolder.token`, so this second attach was both redundant and harmful.

## Changes

- `span_utils.py`: Added `association_properties_token` field to `SpanHolder` dataclass
- `callback_handler.py`: Save association_properties attach token and detach in `_end_span()`
- `callback_handler.py`: Remove redundant orphaned attach in `on_chain_end()`

## Testing

- `ruff check` and `ruff format` pass on all changed files
- The first commit is a pre-existing formatting fix (ruff format applied to the two files); the second commit contains the actual bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved span lifecycle and context handling for more reliable instrumentation
  * Added management of association properties to better preserve span-associated state
  * Safer teardown/detachment of span-related context to reduce leaks or misattribution
  * Removed an unnecessary conditional re-attachment step to simplify end-of-chain behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->