### PR TITLE
fix(langchain): handle ToolNode object in create_react_agent instrumentation

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/patch.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/patch.py
@@ -486,7 +486,13 @@ def create_agent_wrapper(tracer: Tracer, provider_name: str = "langchain"):
                 tools = args[1]
             if tools:
                 tool_definitions = []
-                for tool in tools:
+                # ToolNode wraps tools but is not iterable;
+                # extract via tools_by_name
+                if hasattr(tools, 'tools_by_name'):
+                    tools_iter = tools.tools_by_name.values()
+                else:
+                    tools_iter = tools
+                for tool in tools_iter:
                     tool_def = _extract_tool_definition(tool)
                     if tool_def:
                         tool_definitions.append(tool_def)

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_langgraph.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_langgraph.py
@@ -533,15 +533,23 @@ def test_create_react_agent_span(instrument_legacy, span_exporter):
     from langgraph.prebuilt import create_react_agent
 
     class MockChatModel(BaseChatModel):
+        """Mock chat model for testing ToolNode handling."""
+
         @property
         def _llm_type(self) -> str:
+            """Return model type identifier."""
             return "mock"
 
         def _generate(self, messages, stop=None, run_manager=None, **kwargs):
-            return ChatResult(generations=[ChatGeneration(message=AIMessage(content="Mock"))])
+            """Return a mock AI response."""
+            return ChatResult(
+                generations=[ChatGeneration(message=AIMessage(content="Mock"))]
+            )
 
         def bind_tools(self, tools, **kwargs):
+            """Return self without binding tools."""
             return self
+
 
     @tool
     def get_weather(city: str) -> str:

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_langgraph.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_langgraph.py
@@ -798,3 +798,66 @@ def test_middleware_super_call_succeeds_despite_outer_failure(instrument_legacy,
     # The span from super() call should succeed (before the ValueError is raised)
     middleware_span = middleware_spans[0]
     assert middleware_span.attributes[SpanAttributes.GEN_AI_TASK_STATUS] == "success"
+
+
+def test_create_react_agent_with_toolnode(instrument_legacy, span_exporter):
+    """Test create_react_agent works when tools is a ToolNode (not a list).
+
+    Regression test for https://github.com/traceloop/openllmetry/issues/3841
+    ToolNode wraps tools but is not iterable, so iterating directly raises:
+        TypeError: 'ToolNode' object is not iterable
+    The fix uses tools_by_name.values() when tools has a tools_by_name attr.
+    """
+    import json
+
+    from langchain_core.language_models import BaseChatModel
+    from langchain_core.messages import AIMessage
+    from langchain_core.outputs import ChatGeneration, ChatResult
+    from langchain_core.tools import tool
+    from langgraph.prebuilt import ToolNode, create_react_agent
+
+    class MockChatModel(BaseChatModel):
+        @property
+        def _llm_type(self) -> str:
+            return "mock"
+
+        def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+            return ChatResult(
+                generations=[ChatGeneration(message=AIMessage(content="Mock"))]
+            )
+
+        def bind_tools(self, tools, **kwargs):
+            return self
+
+    @tool
+    def get_weather(city: str) -> str:
+        """Get weather for a city."""
+        return f"Weather in {city}"
+
+    @tool
+    def get_time(timezone: str) -> str:
+        """Get current time in a timezone."""
+        return f"Time in {timezone}"
+
+    tool_node = ToolNode([get_weather, get_time])
+
+    # This should NOT raise "TypeError: 'ToolNode' object is not iterable"
+    _ = create_react_agent(
+        model=MockChatModel(), tools=tool_node, name="ToolNodeAgent"
+    )
+
+    spans = span_exporter.get_finished_spans()
+    create_span = next(s for s in spans if "create_agent" in s.name)
+
+    assert (
+        create_span.attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]
+        == GenAiOperationNameValues.CREATE_AGENT.value
+    )
+    assert create_span.attributes[GenAIAttributes.GEN_AI_AGENT_NAME] == "ToolNodeAgent"
+    assert GenAIAttributes.GEN_AI_TOOL_DEFINITIONS in create_span.attributes
+
+    tool_defs = json.loads(
+        create_span.attributes[GenAIAttributes.GEN_AI_TOOL_DEFINITIONS]
+    )
+    tool_names = {td["name"] for td in tool_defs}
+    assert tool_names == {"get_weather", "get_time"}

--- a/packages/opentelemetry-instrumentation-langchain/uv.lock
+++ b/packages/opentelemetry-instrumentation-langchain/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <4"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1514,7 +1514,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-langchain"
-version = "0.52.6"
+version = "0.53.2"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1648,7 +1648,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions-ai"
-version = "0.4.14"
+version = "0.4.15"
 source = { editable = "../opentelemetry-semantic-conventions-ai" }
 dependencies = [
     { name = "opentelemetry-sdk" },

--- a/packages/opentelemetry-instrumentation-langchain/uv.lock
+++ b/packages/opentelemetry-instrumentation-langchain/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <4"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1514,7 +1514,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-langchain"
-version = "0.53.2"
+version = "0.52.6"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1648,7 +1648,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions-ai"
-version = "0.4.15"
+version = "0.4.14"
 source = { editable = "../opentelemetry-semantic-conventions-ai" }
 dependencies = [
     { name = "opentelemetry-sdk" },


### PR DESCRIPTION
## Summary
- Fixes #3841
- `ToolNode` (from `langgraph-prebuilt`) is not iterable, but `patch.py` assumed `tools` was always a list
- Added `hasattr(tools, 'tools_by_name')` check to extract tools via `tools_by_name.values()` when a `ToolNode` is passed
- Added regression test `test_create_react_agent_with_toolnode`

## Reproduction
```python
from langgraph.prebuilt import ToolNode
from langchain_core.tools import tool

@tool
def get_weather(city: str) -> str:
    """Get weather for a city"""
    return "Sunny"

tool_node = ToolNode([get_weather])
for t in tool_node:  # TypeError: 'ToolNode' object is not iterable
    print(t)
```

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [x] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-definition handling to support alternative tool container types, preventing a TypeError and ensuring GenAI tool definitions are properly captured in telemetry.

* **Tests**
  * Added a regression test to validate agent creation with the alternative tool container and to verify semantic telemetry attributes are recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->