### PR TITLE
Fix: Handle ToolNode in tools iteration for LangGraph compatibility

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/patch.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/patch.py
@@ -486,7 +486,15 @@ def create_agent_wrapper(tracer: Tracer, provider_name: str = "langchain"):
                 tools = args[1]
             if tools:
                 tool_definitions = []
-                for tool in tools:
+                if hasattr(tools, "tools_by_name"):
+                 iterable_tools = tools.tools_by_name.values()
+                elif isinstance(tools, (list, tuple, set)):
+                            iterable_tools = tools
+                else:
+                    iterable_tools = [tools]
+
+                for tool in iterable_tools:
+                    tool_def = _extract_tool_definition(tool)
                     tool_def = _extract_tool_definition(tool)
                     if tool_def:
                         tool_definitions.append(tool_def)

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/patch.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/patch.py
@@ -468,7 +468,7 @@ def create_agent_wrapper(tracer: Tracer, provider_name: str = "langchain"):
             span.set_attribute(GenAIAttributes.GEN_AI_AGENT_NAME, agent_name)
 
             # Extract system instructions from prompt/system_prompt parameter
-            # LangGraph uses "prompt", LangChain uses "system_prompt"
+            # LangGraph uses "prompt", LangChain uses "system_prompt."
             system_instructions = kwargs.get("prompt") or kwargs.get("system_prompt")
             if system_instructions:
                 if isinstance(system_instructions, str):
@@ -486,19 +486,18 @@ def create_agent_wrapper(tracer: Tracer, provider_name: str = "langchain"):
                 tools = args[1]
             if tools:
                 tool_definitions = []
-                if hasattr(tools, "tools_by_name"):
-                 iterable_tools = tools.tools_by_name.values()
-                elif isinstance(tools, (list, tuple, set)):
-                            iterable_tools = tools
-                else:
-                    iterable_tools = [tools]
+            if hasattr(tools, "tools_by_name"):
+                iterable_tools = tools.tools_by_name.values()
+            elif isinstance(tools, (list, tuple, set)):
+                 iterable_tools = tools
+            else:
+                iterable_tools = [tools]
 
                 for tool in iterable_tools:
                     tool_def = _extract_tool_definition(tool)
-                    tool_def = _extract_tool_definition(tool)
-                    if tool_def:
-                        tool_definitions.append(tool_def)
-                if tool_definitions:
+                 if tool_def:
+                    tool_definitions.append(tool_def)
+                 if tool_definitions:
                     span.set_attribute(
                         GenAIAttributes.GEN_AI_TOOL_DEFINITIONS,
                         json.dumps(tool_definitions)

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/patch.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/patch.py
@@ -486,18 +486,18 @@ def create_agent_wrapper(tracer: Tracer, provider_name: str = "langchain"):
                 tools = args[1]
             if tools:
                 tool_definitions = []
-            if hasattr(tools, "tools_by_name"):
-                iterable_tools = tools.tools_by_name.values()
-            elif isinstance(tools, (list, tuple, set)):
-                 iterable_tools = tools
-            else:
-                iterable_tools = [tools]
+                if hasattr(tools, "tools_by_name"):
+                    iterable_tools = tools.tools_by_name.values()
+                elif isinstance(tools, (list, tuple, set)):
+                    iterable_tools = tools
+                else:
+                    iterable_tools = [tools]
 
                 for tool in iterable_tools:
                     tool_def = _extract_tool_definition(tool)
-                 if tool_def:
-                    tool_definitions.append(tool_def)
-                 if tool_definitions:
+                    if tool_def:
+                        tool_definitions.append(tool_def)
+                if tool_definitions:
                     span.set_attribute(
                         GenAIAttributes.GEN_AI_TOOL_DEFINITIONS,
                         json.dumps(tool_definitions)


### PR DESCRIPTION
## Problem
 When using `langgraph-supervisor`, `create_react_agent` may pass a `ToolNode` object as `tools`. Since `ToolNode` is not directly iterable, the current loop in `patch.py` raises:

 **Fixes #3921**

```
TypeError: 'ToolNode' object is not iterable
```
 
## Root Cause
 
`ToolNode` stores tools internally via `tools_by_name` (a dict), not as a direct iterable — so `for tool in tools` fails.
 
## Fix
 
```python
if hasattr(tools, "tools_by_name"):
    iterable_tools = tools.tools_by_name.values()
elif isinstance(tools, (list, tuple, set)):
    iterable_tools = tools
else:
    iterable_tools = [tools]
 
for tool in iterable_tools:
    tool_def = _extract_tool_definition(tool)
```
 
Handles `ToolNode`, standard iterables, and single tool objects — fully backward compatible.
 
## Testing
 
```bash
python -m pytest tests/test_langgraph.py -k "not invoke"
# 11 passed, 4 deselected
```
 
> Deselected tests require a live OpenAI key — unrelated to this fix.
 
## Impact
 
- Fixes crash with `langgraph-supervisor` + `create_react_agent`
- Backward compatible with existing iterable inputs
- Minimal, focused change — no unrelated files modified
##
- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent tool input handling to support various formats (lists, tuples, sets, named collections, and single objects) for broader compatibility.
  * Only records tool definitions when actual tool metadata is present, reducing noise and improving telemetry clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->