### PR TITLE
fix(langchain): handle ToolNode in create_agent_wrapper tool extraction

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/patch.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/patch.py
@@ -486,7 +486,14 @@ def create_agent_wrapper(tracer: Tracer, provider_name: str = "langchain"):
                 tools = args[1]
             if tools:
                 tool_definitions = []
-                for tool in tools:
+                # ToolNode wraps tools but is not itself iterable;
+                # fall back to its tools_by_name dict when available.
+                tools_iter = (
+                    tools.tools_by_name.values()
+                    if hasattr(tools, "tools_by_name")
+                    else tools
+                )
+                for tool in tools_iter:
                     tool_def = _extract_tool_definition(tool)
                     if tool_def:
                         tool_definitions.append(tool_def)


### PR DESCRIPTION
## Summary

Fixes #3921

### Problem

When `langgraph-supervisor`'s `create_supervisor()` passes a `ToolNode`
object to `create_react_agent`, the instrumentation crashes:

```
File "patch.py", line 489, in wrapper
    for tool in tools:
TypeError: 'ToolNode' object is not iterable
```

`ToolNode` wraps tools but does not implement `__iter__`. It exposes
tools via `tools_by_name` (a `dict[str, BaseTool]`).

### Fix

Before iterating, check if the `tools` object has a `tools_by_name`
attribute. If so, iterate over its `.values()`. Otherwise, iterate
normally (preserving existing behavior for lists/tuples).

### Files changed

- `packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/patch.py`

### Test plan

- [x] `create_supervisor()` with `ToolNode` no longer crashes
- [x] Existing tests pass (list-based tools still work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool extraction logic in agent instrumentation to properly handle different types of tool wrapper implementations, ensuring consistent behavior across various agent configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->