### PR TITLE
fix(langchain): detach orphaned context tokens in _create_llm_span

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
@@ -472,6 +472,14 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
             # If context setting fails, continue without suppression token
             token = None
 
+        # Detach orphaned context tokens before overwriting (see #3957).
+        existing = self.spans.get(run_id)
+        if existing is not None:
+            if existing.token:
+                self._safe_detach_context(existing.token)
+            if getattr(existing, "association_properties_token", None):
+                self._safe_detach_context(existing.association_properties_token)
+
         self.spans[run_id] = SpanHolder(
             span, token, None, [], workflow_name, None, entity_path
         )


### PR DESCRIPTION
## Summary

Fixes #3957

### Problem

`_create_llm_span()` overwrites an existing `SpanHolder` entry
without detaching the old holder's context tokens (`token` and
`association_properties_token`). This silently corrupts the
OpenTelemetry context stack, causing downstream spans to inherit
incorrect or stale context.

Related to fixes in #3526 and #3807 which addressed similar
orphaned `context_api.attach()` calls in other code paths.

### Fix

Before replacing a `SpanHolder` entry, check if one already exists
for the given `run_id`. If so, safely detach its context tokens
using the existing `_safe_detach_context()` helper.

### Files changed

- `packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py`

### Test plan

- [x] Existing tests pass
- [x] Under concurrent LLM calls, context tokens are properly cleaned up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where context tokens could become orphaned when reusing span identifiers during LLM operations, improving resource cleanup and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->