### PR TITLE
fix(qdrant): support qdrant-client v1.12+ and handle removed methods gracefully

### DIFF
--- a/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/__init__.py
+++ b/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/__init__.py
@@ -53,11 +53,18 @@ class QdrantInstrumentor(BaseInstrumentor):
             wrap_method = wrapped_method.get("method")
             obj = getattr(qdrant_client, wrap_object, None)
             if obj and hasattr(obj, wrap_method):
-                wrap_function_wrapper(
-                    MODULE,
-                    f"{wrap_object}.{wrap_method}",
-                    _wrap(tracer, wrapped_method),
-                )
+                try:
+                    wrap_function_wrapper(
+                        MODULE,
+                        f"{wrap_object}.{wrap_method}",
+                        _wrap(tracer, wrapped_method),
+                    )
+                except AttributeError:
+                    logger.debug(
+                        "Failed to wrap %s.%s: method no longer exists in this version of qdrant-client",
+                        wrap_object,
+                        wrap_method,
+                    )
 
     def _uninstrument(self, **kwargs):
         for wrapped_method in WRAPPED_METHODS:

--- a/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/async_qdrant_client_methods.json
+++ b/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/async_qdrant_client_methods.json
@@ -16,11 +16,6 @@
     },
     {
         "object": "AsyncQdrantClient",
-        "method": "upload_records",
-        "span_name": "qdrant.upload_records"
-    },
-    {
-        "object": "AsyncQdrantClient",
         "method": "upload_collection",
         "span_name": "qdrant.upload_collection"
     },

--- a/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/qdrant_client_methods.json
+++ b/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/qdrant_client_methods.json
@@ -16,11 +16,6 @@
     },
     {
         "object": "QdrantClient",
-        "method": "upload_records",
-        "span_name": "qdrant.upload_records"
-    },
-    {
-        "object": "QdrantClient",
         "method": "upload_collection",
         "span_name": "qdrant.upload_collection"
     },

--- a/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/wrapper.py
+++ b/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/wrapper.py
@@ -53,8 +53,6 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
             _set_upload_attributes(span, args, kwargs, method, "documents")
         elif method == "upload_points":
             _set_upload_attributes(span, args, kwargs, method, "points")
-        elif method == "upload_records":
-            _set_upload_attributes(span, args, kwargs, method, "records")
         elif method == "upload_collection":
             _set_upload_attributes(span, args, kwargs, method, "vectors")
         elif method in [
@@ -70,7 +68,12 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         elif method in ["search_batch", "query_batch_points", "recommend_batch", "discover_batch"]:
             _set_batch_search_attributes(span, args, kwargs, method)
 
-        response = wrapped(*args, **kwargs)
+        try:
+            response = wrapped(*args, **kwargs)
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            raise
         if response:
             span.set_status(Status(StatusCode.OK))
     return response

--- a/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/wrapper.py
+++ b/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/wrapper.py
@@ -9,6 +9,7 @@ from opentelemetry.semconv_ai import SpanAttributes
 
 
 def _set_span_attribute(span, name, value):
+    """Set a span attribute if the value is not None."""
     if value is not None:
         if value != "":
             span.set_attribute(name, value)
@@ -19,7 +20,9 @@ def _with_tracer_wrapper(func):
     """Helper for providing tracer for wrapper functions."""
 
     def _with_tracer(tracer, to_wrap):
+        """Bind tracer and to_wrap parameters, returning the instrumented wrapper."""
         def wrapper(wrapped, instance, args, kwargs):
+            """Invoke the instrumented function with bound tracer parameters."""
             return func(tracer, to_wrap, wrapped, instance, args, kwargs)
 
         return wrapper
@@ -83,6 +86,7 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
 
 @dont_throw
 def _set_collection_name_attribute(span, method, args, kwargs):
+    """Set the collection name span attribute from method args or kwargs."""
     attribute_method = method
     if method == "query_points":
         attribute_method = "search"
@@ -98,6 +102,7 @@ def _set_collection_name_attribute(span, method, args, kwargs):
 
 @dont_throw
 def _set_upsert_attributes(span, args, kwargs):
+    """Set span attributes for upsert operations."""
     points = kwargs.get("points") or args[1]
     if isinstance(points, list):
         length = len(points)
@@ -110,18 +115,21 @@ def _set_upsert_attributes(span, args, kwargs):
 
 @dont_throw
 def _set_upload_attributes(span, args, kwargs, method_name, param_name):
+    """Set span attributes for upload operations."""
     points = list(kwargs.get(param_name) or args[1])
     _set_span_attribute(span, f"qdrant.{method_name}.points_count", len(points))
 
 
 @dont_throw
 def _set_search_attributes(span, args, kwargs):
+    """Set span attributes for search operations."""
     limit = kwargs.get("limit") or 10
     _set_span_attribute(span, SpanAttributes.VECTOR_DB_QUERY_TOP_K, limit)
 
 
 @dont_throw
 def _set_batch_search_attributes(span, args, kwargs, method):
+    """Set span attributes for batch search operations."""
     requests = kwargs.get("requests") or []
     # Map query_batch_points to search_batch for backward compatibility
     attribute_method = "search_batch" if method == "query_batch_points" else method

--- a/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/wrapper.py
+++ b/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/wrapper.py
@@ -41,6 +41,8 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         attributes={
             SpanAttributes.VECTOR_DB_VENDOR: "Qdrant",
         },
+        record_exception=False,
+        set_status_on_exception=False,
     ) as span:
         _set_collection_name_attribute(
             span, method, args, kwargs
@@ -72,7 +74,7 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
             response = wrapped(*args, **kwargs)
         except Exception as e:
             span.record_exception(e)
-            span.set_status(Status(StatusCode.ERROR, str(e)))
+            span.set_status(Status(StatusCode.ERROR))
             raise
         if response:
             span.set_status(Status(StatusCode.OK))

--- a/packages/opentelemetry-instrumentation-qdrant/pyproject.toml
+++ b/packages/opentelemetry-instrumentation-qdrant/pyproject.toml
@@ -35,7 +35,7 @@ test = [
   "opentelemetry-sdk>=1.38.0,<2",
   "pytest-sugar==1.0.0",
   "pytest>=8.2.2,<9",
-  "qdrant-client>=1.9.1,<1.12",
+  "qdrant-client>=1.9.1,<2",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary

Fixes #3492

- **Removes `upload_records`** from both `qdrant_client_methods.json` and `async_qdrant_client_methods.json` — this method was removed in qdrant-client 1.12 and caused an `AttributeError` on instrumentation startup
- **Wraps `wrap_function_wrapper` in `try/except AttributeError`** so any future method removals in new qdrant-client releases degrade gracefully (logs a debug message and skips the method) instead of crashing the whole instrumentation
- **Updates the test dependency upper bound** from `<1.12` to `<2` to allow testing against current qdrant-client releases
- **Adds `span.record_exception()` + `StatusCode.ERROR`** to the wrapped call in `wrapper.py` (also addresses #412 for qdrant)

## Test plan

- [ ] Install `qdrant-client>=1.12` and verify `QdrantInstrumentor().instrument()` completes without `AttributeError`
- [ ] Verify remaining methods (`upsert`, `search`, `query`, etc.) still produce spans
- [ ] Run existing test suite: `npx nx run opentelemetry-instrumentation-qdrant:test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Spans now record exceptions and set error status when operations fail.
  * Instrumentation now gracefully skips missing client methods to avoid runtime failures.
  * Removed instrumentation for the upload_records operation (no span will be created).

* **Chores**
  * Test dependency range expanded to allow newer qdrant-client versions (up to, but not including, v2).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->