### PR TITLE
fix(chromadb,pinecone,weaviate,lancedb,milvus): record exceptions on error spans

### DIFF
--- a/packages/opentelemetry-instrumentation-chromadb/opentelemetry/instrumentation/chromadb/wrapper.py
+++ b/packages/opentelemetry-instrumentation-chromadb/opentelemetry/instrumentation/chromadb/wrapper.py
@@ -38,7 +38,9 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
 
     name = to_wrap.get("span_name")
-    with tracer.start_as_current_span(name) as span:
+    with tracer.start_as_current_span(
+        name, record_exception=False, set_status_on_exception=False
+    ) as span:
         span.set_attribute(SpanAttributes.DB_SYSTEM, "chroma")
         span.set_attribute(SpanAttributes.DB_OPERATION, to_wrap.get("method"))
 
@@ -66,7 +68,7 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
             return_value = wrapped(*args, **kwargs)
         except Exception as e:
             span.record_exception(e)
-            span.set_status(Status(StatusCode.ERROR, str(e)))
+            span.set_status(Status(StatusCode.ERROR))
             raise
         if to_wrap.get("method") == "query":
             _add_query_result_events(span, return_value)

--- a/packages/opentelemetry-instrumentation-chromadb/opentelemetry/instrumentation/chromadb/wrapper.py
+++ b/packages/opentelemetry-instrumentation-chromadb/opentelemetry/instrumentation/chromadb/wrapper.py
@@ -7,6 +7,7 @@ from opentelemetry.instrumentation.utils import (
 )
 from opentelemetry.semconv_ai import EventAttributes, Events
 from opentelemetry.semconv_ai import SpanAttributes as AISpanAttributes
+from opentelemetry.trace.status import Status, StatusCode
 import itertools
 import json
 
@@ -61,7 +62,12 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         elif to_wrap.get("method") == "delete":
             _set_delete_attributes(span, kwargs)
 
-        return_value = wrapped(*args, **kwargs)
+        try:
+            return_value = wrapped(*args, **kwargs)
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            raise
         if to_wrap.get("method") == "query":
             _add_query_result_events(span, return_value)
 

--- a/packages/opentelemetry-instrumentation-lancedb/opentelemetry/instrumentation/lancedb/wrapper.py
+++ b/packages/opentelemetry-instrumentation-lancedb/opentelemetry/instrumentation/lancedb/wrapper.py
@@ -6,6 +6,7 @@ from opentelemetry.instrumentation.utils import (
     _SUPPRESS_INSTRUMENTATION_KEY,
 )
 from opentelemetry.semconv_ai import SpanAttributes as AISpanAttributes
+from opentelemetry.trace.status import Status, StatusCode
 
 
 def _with_tracer_wrapper(func):
@@ -45,7 +46,12 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         elif to_wrap.get("method") == "delete":
             _set_delete_attributes(span, kwargs)
 
-        return_value = wrapped(*args, **kwargs)
+        try:
+            return_value = wrapped(*args, **kwargs)
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            raise
 
     return return_value
 

--- a/packages/opentelemetry-instrumentation-lancedb/opentelemetry/instrumentation/lancedb/wrapper.py
+++ b/packages/opentelemetry-instrumentation-lancedb/opentelemetry/instrumentation/lancedb/wrapper.py
@@ -35,7 +35,9 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
 
     name = to_wrap.get("span_name")
-    with tracer.start_as_current_span(name) as span:
+    with tracer.start_as_current_span(
+        name, record_exception=False, set_status_on_exception=False
+    ) as span:
         span.set_attribute(SpanAttributes.DB_SYSTEM, "lancedb")
         span.set_attribute(SpanAttributes.DB_OPERATION, to_wrap.get("method"))
 
@@ -50,7 +52,7 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
             return_value = wrapped(*args, **kwargs)
         except Exception as e:
             span.record_exception(e)
-            span.set_status(Status(StatusCode.ERROR, str(e)))
+            span.set_status(Status(StatusCode.ERROR))
             raise
 
     return return_value

--- a/packages/opentelemetry-instrumentation-milvus/opentelemetry/instrumentation/milvus/wrapper.py
+++ b/packages/opentelemetry-instrumentation-milvus/opentelemetry/instrumentation/milvus/wrapper.py
@@ -77,7 +77,9 @@ def _wrap(
 
     method = to_wrap.get("method")
     name = to_wrap.get("span_name")
-    with tracer.start_as_current_span(name) as span:
+    with tracer.start_as_current_span(
+        name, record_exception=False, set_status_on_exception=False
+    ) as span:
         span.set_attribute(SpanAttributes.DB_SYSTEM, "milvus")
         span.set_attribute(SpanAttributes.DB_OPERATION, to_wrap.get("method"))
 
@@ -114,7 +116,7 @@ def _wrap(
             )
             span.set_attribute(ERROR_TYPE, error_type)
             span.record_exception(e)
-            span.set_status(SpanStatus(StatusCode.ERROR, str(e)))
+            span.set_status(SpanStatus(StatusCode.ERROR))
             raise
 
         shared_attributes = {

--- a/packages/opentelemetry-instrumentation-milvus/opentelemetry/instrumentation/milvus/wrapper.py
+++ b/packages/opentelemetry-instrumentation-milvus/opentelemetry/instrumentation/milvus/wrapper.py
@@ -9,6 +9,7 @@ from opentelemetry.instrumentation.utils import (
 from opentelemetry.semconv_ai import Events, EventAttributes
 from opentelemetry.semconv_ai import SpanAttributes as AISpanAttributes
 
+from opentelemetry.trace.status import Status as SpanStatus, StatusCode
 from pymilvus.client.types import Status
 from pymilvus.exceptions import ErrorCode
 
@@ -112,6 +113,8 @@ def _wrap(
                 getattr(e, "code", None), type(e).__name__
             )
             span.set_attribute(ERROR_TYPE, error_type)
+            span.record_exception(e)
+            span.set_status(SpanStatus(StatusCode.ERROR, str(e)))
             raise
 
         shared_attributes = {

--- a/packages/opentelemetry-instrumentation-pinecone/opentelemetry/instrumentation/pinecone/__init__.py
+++ b/packages/opentelemetry-instrumentation-pinecone/opentelemetry/instrumentation/pinecone/__init__.py
@@ -154,7 +154,12 @@ def _wrap(
             shared_attributes["server.address"] = instance._config.host
 
         start_time = time.time()
-        response = wrapped(*args, **kwargs)
+        try:
+            response = wrapped(*args, **kwargs)
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            raise
         end_time = time.time()
 
         duration = end_time - start_time

--- a/packages/opentelemetry-instrumentation-pinecone/opentelemetry/instrumentation/pinecone/__init__.py
+++ b/packages/opentelemetry-instrumentation-pinecone/opentelemetry/instrumentation/pinecone/__init__.py
@@ -143,6 +143,8 @@ def _wrap(
         attributes={
             AISpanAttributes.VECTOR_DB_VENDOR: "Pinecone",
         },
+        record_exception=False,
+        set_status_on_exception=False,
     ) as span:
         if span.is_recording():
             _set_input_attributes(span, instance, kwargs)
@@ -158,7 +160,7 @@ def _wrap(
             response = wrapped(*args, **kwargs)
         except Exception as e:
             span.record_exception(e)
-            span.set_status(Status(StatusCode.ERROR, str(e)))
+            span.set_status(Status(StatusCode.ERROR))
             raise
         end_time = time.time()
 

--- a/packages/opentelemetry-instrumentation-weaviate/opentelemetry/instrumentation/weaviate/wrapper.py
+++ b/packages/opentelemetry-instrumentation-weaviate/opentelemetry/instrumentation/weaviate/wrapper.py
@@ -6,6 +6,7 @@ from opentelemetry import context as context_api
 from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.instrumentation.weaviate.utils import dont_throw
 from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.trace.status import Status, StatusCode
 
 
 logger = logging.getLogger(__name__)
@@ -46,7 +47,12 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         if instrumentor:
             instrumentor.instrument(to_wrap.get("method"), span, args, kwargs)
 
-        return_value = wrapped(*args, **kwargs)
+        try:
+            return_value = wrapped(*args, **kwargs)
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            raise
 
     return return_value
 

--- a/packages/opentelemetry-instrumentation-weaviate/opentelemetry/instrumentation/weaviate/wrapper.py
+++ b/packages/opentelemetry-instrumentation-weaviate/opentelemetry/instrumentation/weaviate/wrapper.py
@@ -38,7 +38,9 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
 
     name = to_wrap.get("span_name")
-    with tracer.start_as_current_span(name) as span:
+    with tracer.start_as_current_span(
+        name, record_exception=False, set_status_on_exception=False
+    ) as span:
         span.set_attribute(SpanAttributes.DB_SYSTEM, "weaviate")
         span.set_attribute(SpanAttributes.DB_OPERATION, to_wrap.get("method"))
 
@@ -51,7 +53,7 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
             return_value = wrapped(*args, **kwargs)
         except Exception as e:
             span.record_exception(e)
-            span.set_status(Status(StatusCode.ERROR, str(e)))
+            span.set_status(Status(StatusCode.ERROR))
             raise
 
     return return_value


### PR DESCRIPTION
## Summary

Fixes #412 (partial — vector DB instrumentation packages)

When vector DB calls raise exceptions, spans were left in `UNSET` status with no error information. This PR adds proper error recording to five vector DB packages:

- **chromadb** (`wrapper.py`): adds `Status, StatusCode` import + try/except around `wrapped(*args, **kwargs)`
- **pinecone** (`__init__.py`): adds try/except around the wrapped call inside the `with tracer.start_as_current_span()` block
- **weaviate** (`wrapper.py`): adds `Status, StatusCode` import + try/except
- **lancedb** (`wrapper.py`): adds `Status, StatusCode` import + try/except
- **milvus** (`wrapper.py`): already had a try/except that set `ERROR_TYPE` attribute — extended it with `span.record_exception(e)` and `span.set_status(SpanStatus(StatusCode.ERROR))` to complete OTel span status (aliased to avoid conflict with pymilvus `Status`)

This follows the same approach as traceloop/openllmetry#3970 (anthropic/groq/mistralai) and companion PR for LLM instrumentations.

## Test plan

- [ ] Trigger an error (e.g. wrong collection name, network failure) for each DB
- [ ] Verify the resulting span has `status=ERROR` with an attached exception event
- [ ] Verify successful calls still produce `status=OK` (or `UNSET` where OK was never set)
- [ ] Run existing test suites: `npx nx run-many -t test --projects=opentelemetry-instrumentation-chromadb,opentelemetry-instrumentation-pinecone,opentelemetry-instrumentation-weaviate,opentelemetry-instrumentation-lancedb,opentelemetry-instrumentation-milvus`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for ChromaDB, LanceDB, Milvus, Pinecone, and Weaviate instrumentations: operation failures are now explicitly recorded and marked as errors in traces, ensuring more accurate and reliable observability of failed calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->