### PR TITLE
fix(mcp): handle dict/object result shapes in stream writer error parsing

### DIFF
--- a/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
+++ b/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
@@ -547,6 +547,29 @@ class InstrumentedStreamWriter(ObjectProxy):  # type: ignore
     async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> Any:
         return await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
 
+    @staticmethod
+    def _get_value(data: Any, key: str, default: Any = None) -> Any:
+        if isinstance(data, dict):
+            return data.get(key, default)
+        return getattr(data, key, default)
+
+    @classmethod
+    def _extract_result_error(cls, result: Any) -> Tuple[bool, Union[str, None]]:
+        is_error = cls._get_value(result, "isError", False) is True
+        if not is_error:
+            return False, None
+
+        content = cls._get_value(result, "content", [])
+        if not content:
+            return True, None
+
+        first_item = content[0]
+        message = cls._get_value(first_item, "text")
+        if message is None:
+            return True, None
+
+        return True, str(message)
+
     @dont_throw
     async def send(self, item: Any) -> Any:
         from mcp.types import JSONRPCMessage, JSONRPCRequest
@@ -567,14 +590,9 @@ class InstrumentedStreamWriter(ObjectProxy):  # type: ignore
                 span.set_attribute(
                     SpanAttributes.MCP_RESPONSE_VALUE, f"{serialize(request.result)}"
                 )
-                if "isError" in request.result:
-                    if request.result["isError"] is True:
-                        span.set_status(
-                            Status(
-                                StatusCode.ERROR,
-                                f"{request.result['content'][0]['text']}",
-                            )
-                        )
+                is_error, error_message = self._extract_result_error(request.result)
+                if is_error:
+                    span.set_status(Status(StatusCode.ERROR, error_message))
             if hasattr(request, "id"):
                 span.set_attribute(SpanAttributes.MCP_REQUEST_ID, f"{request.id}")
 

--- a/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
+++ b/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
@@ -339,12 +339,12 @@ class McpInstrumentor(BaseInstrumentor):
                 span.set_attribute(
                     SpanAttributes.TRACELOOP_ENTITY_OUTPUT, serialize(result)
                 )
-            # Handle errors
-            if hasattr(result, "isError") and result.isError:
-                if len(result.content) > 0:
-                    span.set_status(
-                        Status(StatusCode.ERROR, f"{result.content[0].text}")
-                    )
+            # Handle errors (dict- and object-shaped CallToolResult)
+            is_error, error_message = InstrumentedStreamWriter._extract_result_error(
+                result
+            )
+            if is_error:
+                span.set_status(Status(StatusCode.ERROR, error_message))
             else:
                 span.set_status(Status(StatusCode.OK))
             return result
@@ -555,7 +555,7 @@ class InstrumentedStreamWriter(ObjectProxy):  # type: ignore
 
     @classmethod
     def _extract_result_error(cls, result: Any) -> Tuple[bool, Union[str, None]]:
-        is_error = cls._get_value(result, "isError", False) is True
+        is_error = bool(cls._get_value(result, "isError", False))
         if not is_error:
             return False, None
 
@@ -563,7 +563,16 @@ class InstrumentedStreamWriter(ObjectProxy):  # type: ignore
         if not content:
             return True, None
 
-        first_item = content[0]
+        try:
+            if isinstance(content, (list, tuple)):
+                first_item = content[0]
+            elif isinstance(content, dict):
+                first_item = next(iter(content.values()))
+            else:
+                first_item = next(iter(content))
+        except (StopIteration, IndexError, TypeError, KeyError):
+            return True, None
+
         message = cls._get_value(first_item, "text")
         if message is None:
             return True, None

--- a/packages/opentelemetry-instrumentation-mcp/tests/test_fastmcp.py
+++ b/packages/opentelemetry-instrumentation-mcp/tests/test_fastmcp.py
@@ -181,3 +181,26 @@ def test_extract_result_error_with_missing_content():
 
     assert is_error is True
     assert message is None
+
+
+def test_extract_result_error_when_not_error():
+    """Non-error results short-circuit before reading content."""
+    dict_explicit_false = {"isError": False, "content": [{"text": "ignored"}]}
+    is_error, message = InstrumentedStreamWriter._extract_result_error(dict_explicit_false)
+    assert is_error is False
+    assert message is None
+
+    dict_missing_flag = {"content": [{"text": "also ignored"}]}
+    is_error, message = InstrumentedStreamWriter._extract_result_error(dict_missing_flag)
+    assert is_error is False
+    assert message is None
+
+    ns_false = SimpleNamespace(isError=False, content=[SimpleNamespace(text="ignored")])
+    is_error, message = InstrumentedStreamWriter._extract_result_error(ns_false)
+    assert is_error is False
+    assert message is None
+
+    ns_no_flag = SimpleNamespace(content=[SimpleNamespace(text="ignored")])
+    is_error, message = InstrumentedStreamWriter._extract_result_error(ns_no_flag)
+    assert is_error is False
+    assert message is None

--- a/packages/opentelemetry-instrumentation-mcp/tests/test_fastmcp.py
+++ b/packages/opentelemetry-instrumentation-mcp/tests/test_fastmcp.py
@@ -1,3 +1,8 @@
+from types import SimpleNamespace
+
+from opentelemetry.instrumentation.mcp.instrumentation import InstrumentedStreamWriter
+
+
 async def test_fastmcp_instrumentor(span_exporter, tracer_provider) -> None:
     from fastmcp import FastMCP, Client
 
@@ -146,3 +151,33 @@ async def test_fastmcp_instrumentor(span_exporter, tracer_provider) -> None:
         assert workflow_name == 'test-server.mcp', (
             f"Expected workflow name 'test-server.mcp' on tool span, got '{workflow_name}'"
         )
+
+
+def test_extract_result_error_with_dict_shape():
+    result = {"isError": True, "content": [{"text": "dict error"}]}
+
+    is_error, message = InstrumentedStreamWriter._extract_result_error(result)
+
+    assert is_error is True
+    assert message == "dict error"
+
+
+def test_extract_result_error_with_object_shape():
+    result = SimpleNamespace(
+        isError=True,
+        content=[SimpleNamespace(text="object error")],
+    )
+
+    is_error, message = InstrumentedStreamWriter._extract_result_error(result)
+
+    assert is_error is True
+    assert message == "object error"
+
+
+def test_extract_result_error_with_missing_content():
+    result = {"isError": True, "content": []}
+
+    is_error, message = InstrumentedStreamWriter._extract_result_error(result)
+
+    assert is_error is True
+    assert message is None


### PR DESCRIPTION
Fixes: #4038

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [x] I have added tests that cover my changes.
- [x] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [x] (If applicable) I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection and reporting for MCP streaming responses so instrumentation consistently recognizes errors and extracts messages from varied response shapes (dict-like or object-like), reducing misreported statuses.
* **Tests**
  * Added unit tests covering multiple response formats and error/no‑error scenarios to ensure robust handling across cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->