### PR TITLE
fix(instrumentation-qdrant): stop wrapping methods that qdrant-client 1.16 removed

### DIFF
--- a/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/__init__.py
+++ b/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/__init__.py
@@ -20,7 +20,7 @@ from opentelemetry.instrumentation.qdrant.version import __version__
 
 logger = logging.getLogger(__name__)
 
-_instruments = ("qdrant-client >= 1.7",)
+_instruments = ("qdrant-client >= 1.10",)
 
 p = Path(__file__).with_name("qdrant_client_methods.json")
 with open(p, "r") as f:

--- a/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/async_qdrant_client_methods.json
+++ b/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/async_qdrant_client_methods.json
@@ -16,28 +16,8 @@
     },
     {
         "object": "AsyncQdrantClient",
-        "method": "upload_records",
-        "span_name": "qdrant.upload_records"
-    },
-    {
-        "object": "AsyncQdrantClient",
         "method": "upload_collection",
         "span_name": "qdrant.upload_collection"
-    },
-    {
-        "object": "AsyncQdrantClient",
-        "method": "search",
-        "span_name": "qdrant.search"
-    },
-    {
-        "object": "AsyncQdrantClient",
-        "method": "search_batch",
-        "span_name": "qdrant.search_batch"
-    },
-    {
-        "object": "AsyncQdrantClient",
-        "method": "search_groups",
-        "span_name": "qdrant.search_groups"
     },
     {
         "object": "AsyncQdrantClient",
@@ -48,31 +28,6 @@
         "object": "AsyncQdrantClient",
         "method": "query_batch",
         "span_name": "qdrant.query_batch"
-    },
-    {
-        "object": "AsyncQdrantClient",
-        "method": "discover",
-        "span_name": "qdrant.discover"
-    },
-    {
-        "object": "AsyncQdrantClient",
-        "method": "discover_batch",
-        "span_name": "qdrant.discover_batch"
-    },
-    {
-        "object": "AsyncQdrantClient",
-        "method": "recommend",
-        "span_name": "qdrant.recommend"
-    },
-    {
-        "object": "AsyncQdrantClient",
-        "method": "recommend_batch",
-        "span_name": "qdrant.recommend_batch"
-    },
-    {
-        "object": "AsyncQdrantClient",
-        "method": "recommend_groups",
-        "span_name": "qdrant.recommend_groups"
     },
     {
         "object": "AsyncQdrantClient",

--- a/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/async_qdrant_client_methods.json
+++ b/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/async_qdrant_client_methods.json
@@ -26,8 +26,18 @@
     },
     {
         "object": "AsyncQdrantClient",
+        "method": "query_points",
+        "span_name": "qdrant.query_points"
+    },
+    {
+        "object": "AsyncQdrantClient",
         "method": "query_batch",
         "span_name": "qdrant.query_batch"
+    },
+    {
+        "object": "AsyncQdrantClient",
+        "method": "query_batch_points",
+        "span_name": "qdrant.query_batch_points"
     },
     {
         "object": "AsyncQdrantClient",

--- a/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/qdrant_client_methods.json
+++ b/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/qdrant_client_methods.json
@@ -16,28 +16,8 @@
     },
     {
         "object": "QdrantClient",
-        "method": "upload_records",
-        "span_name": "qdrant.upload_records"
-    },
-    {
-        "object": "QdrantClient",
         "method": "upload_collection",
         "span_name": "qdrant.upload_collection"
-    },
-    {
-        "object": "QdrantClient",
-        "method": "search",
-        "span_name": "qdrant.search"
-    },
-    {
-        "object": "QdrantClient",
-        "method": "search_batch",
-        "span_name": "qdrant.search_batch"
-    },
-    {
-        "object": "QdrantClient",
-        "method": "search_groups",
-        "span_name": "qdrant.search_groups"
     },
     {
         "object": "QdrantClient",
@@ -58,31 +38,6 @@
         "object": "QdrantClient",
         "method": "query_batch_points",
         "span_name": "qdrant.query_batch_points"
-    },
-    {
-        "object": "QdrantClient",
-        "method": "discover",
-        "span_name": "qdrant.discover"
-    },
-    {
-        "object": "QdrantClient",
-        "method": "discover_batch",
-        "span_name": "qdrant.discover_batch"
-    },
-    {
-        "object": "QdrantClient",
-        "method": "recommend",
-        "span_name": "qdrant.recommend"
-    },
-    {
-        "object": "QdrantClient",
-        "method": "recommend_batch",
-        "span_name": "qdrant.recommend_batch"
-    },
-    {
-        "object": "QdrantClient",
-        "method": "recommend_groups",
-        "span_name": "qdrant.recommend_groups"
     },
     {
         "object": "QdrantClient",

--- a/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/wrapper.py
+++ b/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/wrapper.py
@@ -53,21 +53,11 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
             _set_upload_attributes(span, args, kwargs, method, "documents")
         elif method == "upload_points":
             _set_upload_attributes(span, args, kwargs, method, "points")
-        elif method == "upload_records":
-            _set_upload_attributes(span, args, kwargs, method, "records")
         elif method == "upload_collection":
             _set_upload_attributes(span, args, kwargs, method, "vectors")
-        elif method in [
-            "search",
-            "search_groups",
-            "query",
-            "query_points",
-            "discover",
-            "recommend",
-            "recommend_groups",
-        ]:
+        elif method in ["query", "query_points"]:
             _set_search_attributes(span, args, kwargs)
-        elif method in ["search_batch", "query_batch_points", "recommend_batch", "discover_batch"]:
+        elif method == "query_batch_points":
             _set_batch_search_attributes(span, args, kwargs, method)
 
         response = wrapped(*args, **kwargs)

--- a/packages/opentelemetry-instrumentation-qdrant/pyproject.toml
+++ b/packages/opentelemetry-instrumentation-qdrant/pyproject.toml
@@ -35,7 +35,7 @@ test = [
   "opentelemetry-sdk>=1.38.0,<2",
   "pytest-sugar==1.0.0",
   "pytest>=8.2.2,<9",
-  "qdrant-client>=1.10,<2",
+  "qdrant-client>=1.10,<1.17",
 ]
 
 [build-system]

--- a/packages/opentelemetry-instrumentation-qdrant/pyproject.toml
+++ b/packages/opentelemetry-instrumentation-qdrant/pyproject.toml
@@ -35,7 +35,7 @@ test = [
   "opentelemetry-sdk>=1.38.0,<2",
   "pytest-sugar==1.0.0",
   "pytest>=8.2.2,<9",
-  "qdrant-client>=1.9.1,<1.12",
+  "qdrant-client>=1.10,<2",
 ]
 
 [build-system]

--- a/packages/opentelemetry-instrumentation-qdrant/tests/test_qdrant_instrumentation.py
+++ b/packages/opentelemetry-instrumentation-qdrant/tests/test_qdrant_instrumentation.py
@@ -124,21 +124,42 @@ def test_qdrant_search(exporter, qdrant):
     assert span.attributes.get(SpanAttributes.QDRANT_SEARCH_BATCH_REQUESTS_COUNT) == 4
 
 
-def test_instrument_does_not_fail_on_missing_client_methods():
+def test_wrapped_methods_exist_on_client_surface():
     """
     Regression test for https://github.com/traceloop/openllmetry/issues/3492.
 
     On qdrant-client 1.16 a handful of legacy methods (search, recommend,
     discover, upload_records and their batch variants) were removed. The
-    instrumentor used to look them up unconditionally and blow up with an
-    AttributeError before any user code had a chance to run. Exercise the
-    full instrument / uninstrument cycle here so we notice if the list of
-    wrapped methods ever drifts out of sync with the client again.
+    instrumentor used to look them up unconditionally and blew up with an
+    AttributeError before any user code had a chance to run.
+
+    The runtime guards in _instrument / _uninstrument now skip missing
+    methods silently, which keeps users unblocked but hides the drift. Walk
+    the wrapped method tables directly against the installed client so
+    CI fails loudly if the JSON drifts out of sync with qdrant-client
+    again, and keep a full instrument/uninstrument cycle to make sure the
+    wrapping itself still works end to end.
     """
-    from opentelemetry.instrumentation.qdrant import QdrantInstrumentor
+    import qdrant_client
+    from opentelemetry.instrumentation.qdrant import (
+        QdrantInstrumentor,
+        WRAPPED_METHODS,
+    )
+
+    missing = []
+    for entry in WRAPPED_METHODS:
+        obj_name = entry["object"]
+        method_name = entry["method"]
+        client_cls = getattr(qdrant_client, obj_name, None)
+        if client_cls is None or not hasattr(client_cls, method_name):
+            missing.append(f"{obj_name}.{method_name}")
+
+    assert not missing, (
+        "Wrapped methods no longer present on qdrant-client: "
+        f"{missing}. Update the method JSON files under "
+        "opentelemetry/instrumentation/qdrant/ to match."
+    )
 
     instrumentor = QdrantInstrumentor()
-    instrumentor.uninstrument()
     instrumentor.instrument()
     instrumentor.uninstrument()
-    instrumentor.instrument()

--- a/packages/opentelemetry-instrumentation-qdrant/tests/test_qdrant_instrumentation.py
+++ b/packages/opentelemetry-instrumentation-qdrant/tests/test_qdrant_instrumentation.py
@@ -122,3 +122,23 @@ def test_qdrant_search(exporter, qdrant):
         == COLLECTION_NAME
     )
     assert span.attributes.get(SpanAttributes.QDRANT_SEARCH_BATCH_REQUESTS_COUNT) == 4
+
+
+def test_instrument_does_not_fail_on_missing_client_methods():
+    """
+    Regression test for https://github.com/traceloop/openllmetry/issues/3492.
+
+    On qdrant-client 1.16 a handful of legacy methods (search, recommend,
+    discover, upload_records and their batch variants) were removed. The
+    instrumentor used to look them up unconditionally and blow up with an
+    AttributeError before any user code had a chance to run. Exercise the
+    full instrument / uninstrument cycle here so we notice if the list of
+    wrapped methods ever drifts out of sync with the client again.
+    """
+    from opentelemetry.instrumentation.qdrant import QdrantInstrumentor
+
+    instrumentor = QdrantInstrumentor()
+    instrumentor.uninstrument()
+    instrumentor.instrument()
+    instrumentor.uninstrument()
+    instrumentor.instrument()


### PR DESCRIPTION
Closes #3492

<!-- Thanks for submitting a PR! -->

- [x] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

## What

On `qdrant-client` 1.16 the client dropped a handful of legacy methods in favour of the newer `query` / `query_points` APIs. The instrumentor was still trying to wrap them up front through `wrap_function_wrapper`, which meant importing `QdrantInstrumentor().instrument()` on a modern client raised:

```
AttributeError: type object 'QdrantClient' has no attribute 'upload_records'
```

The methods that are no longer on the client are `search`, `search_batch`, `search_groups`, `recommend`, `recommend_batch`, `recommend_groups`, `discover`, `discover_batch` and `upload_records`.

## Changes

- Remove the nine dead entries from `qdrant_client_methods.json` and `async_qdrant_client_methods.json` so we no longer ask wrapt to resolve attributes that are not there.
- Prune the matching branches in `wrapper.py` so the dispatch only handles methods we still wrap.
- Bump `_instruments` from `qdrant-client >= 1.7` to `qdrant-client >= 1.10` so the declared floor actually matches what we wrap (`query_points` lands in 1.10), and bump the test dependency accordingly.
- Add a regression test that runs a full `instrument / uninstrument` cycle against whichever `qdrant-client` is installed, so if the wrapped method list ever drifts out of sync again we notice it in CI.

## How I checked it

Installed `qdrant-client==1.16.1` in a clean venv together with this branch and ran:

```
uv run pytest tests/ -v
```

All 5 tests pass, including the new regression test. `uv run ruff check` is also clean on the package.

Before the fix, the same setup fails immediately with the `AttributeError` above at `QdrantInstrumentor().instrument()` time.

## AI disclosure

Took help of an AI tool for the diff review and to draft this description. The design call, reproduction and test were done by hand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised minimum required qdrant-client version to >= 1.10 and updated test constraints.
  * Narrowed instrumentation to a smaller set of query-related methods.

* **Bug Fixes**
  * Reduced instrumentation surface to avoid incorrect or extraneous spans for less-common methods.

* **Tests**
  * Added a regression test ensuring instrument/uninstrument works across qdrant-client versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4041?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->