### PR TITLE
fix(instrumentation): support wrapt 2 langchain hooks

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
@@ -434,8 +434,9 @@ class _OpenAITracingWrapper:
 
         # In legacy chains like LLMChain, suppressing model instrumentations
         # within create_llm_span doesn't work, so this should helps as a fallback
+        token = None
         try:
-            context_api.attach(
+            token = context_api.attach(
                 context_api.set_value(SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY, True)
             )
         except Exception:
@@ -443,4 +444,11 @@ class _OpenAITracingWrapper:
             # This is not critical for core functionality
             pass
 
-        return wrapped(*args, **kwargs)
+        try:
+            return wrapped(*args, **kwargs)
+        finally:
+            if token is not None:
+                try:
+                    context_api.detach(token)
+                except Exception:
+                    pass

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
@@ -36,6 +36,11 @@ logger = logging.getLogger(__name__)
 _instruments = ("langchain-core > 0.1.0", )
 
 
+def _wrap_function(module: str, name: str, wrapper) -> None:
+    """Call wrapt using the positional signature supported by wrapt 1.x and 2.x."""
+    wrap_function_wrapper(module, name, wrapper)
+
+
 class LangchainInstrumentor(BaseInstrumentor):
     """An instrumentor for Langchain SDK."""
 
@@ -97,10 +102,10 @@ class LangchainInstrumentor(BaseInstrumentor):
         traceloopCallbackHandler = TraceloopCallbackHandler(
             tracer, duration_histogram, token_histogram
         )
-        wrap_function_wrapper(
-            module="langchain_core.callbacks",
-            name="BaseCallbackManager.__init__",
-            wrapper=_BaseCallbackManagerInitWrapper(traceloopCallbackHandler),
+        _wrap_function(
+            "langchain_core.callbacks",
+            "BaseCallbackManager.__init__",
+            _BaseCallbackManagerInitWrapper(traceloopCallbackHandler),
         )
 
         # Wrap LangGraph components if available
@@ -114,67 +119,67 @@ class LangchainInstrumentor(BaseInstrumentor):
 
         if is_package_available("langchain_community"):
             # Wrap langchain_community.llms.openai.BaseOpenAI
-            wrap_function_wrapper(
-                module="langchain_community.llms.openai",
-                name="BaseOpenAI._generate",
-                wrapper=openai_tracing_wrapper,
+            _wrap_function(
+                "langchain_community.llms.openai",
+                "BaseOpenAI._generate",
+                openai_tracing_wrapper,
             )
 
-            wrap_function_wrapper(
-                module="langchain_community.llms.openai",
-                name="BaseOpenAI._agenerate",
-                wrapper=openai_tracing_wrapper,
+            _wrap_function(
+                "langchain_community.llms.openai",
+                "BaseOpenAI._agenerate",
+                openai_tracing_wrapper,
             )
 
-            wrap_function_wrapper(
-                module="langchain_community.llms.openai",
-                name="BaseOpenAI._stream",
-                wrapper=openai_tracing_wrapper,
+            _wrap_function(
+                "langchain_community.llms.openai",
+                "BaseOpenAI._stream",
+                openai_tracing_wrapper,
             )
 
-            wrap_function_wrapper(
-                module="langchain_community.llms.openai",
-                name="BaseOpenAI._astream",
-                wrapper=openai_tracing_wrapper,
+            _wrap_function(
+                "langchain_community.llms.openai",
+                "BaseOpenAI._astream",
+                openai_tracing_wrapper,
             )
 
         if is_package_available("langchain_openai"):
             # Wrap langchain_openai.llms.base.BaseOpenAI
-            wrap_function_wrapper(
-                module="langchain_openai.llms.base",
-                name="BaseOpenAI._generate",
-                wrapper=openai_tracing_wrapper,
+            _wrap_function(
+                "langchain_openai.llms.base",
+                "BaseOpenAI._generate",
+                openai_tracing_wrapper,
             )
 
-            wrap_function_wrapper(
-                module="langchain_openai.llms.base",
-                name="BaseOpenAI._agenerate",
-                wrapper=openai_tracing_wrapper,
+            _wrap_function(
+                "langchain_openai.llms.base",
+                "BaseOpenAI._agenerate",
+                openai_tracing_wrapper,
             )
 
-            wrap_function_wrapper(
-                module="langchain_openai.llms.base",
-                name="BaseOpenAI._stream",
-                wrapper=openai_tracing_wrapper,
+            _wrap_function(
+                "langchain_openai.llms.base",
+                "BaseOpenAI._stream",
+                openai_tracing_wrapper,
             )
 
-            wrap_function_wrapper(
-                module="langchain_openai.llms.base",
-                name="BaseOpenAI._astream",
-                wrapper=openai_tracing_wrapper,
+            _wrap_function(
+                "langchain_openai.llms.base",
+                "BaseOpenAI._astream",
+                openai_tracing_wrapper,
             )
 
-            # langchain_openai.chat_models.base.BaseOpenAI
-            wrap_function_wrapper(
-                module="langchain_openai.chat_models.base",
-                name="BaseChatOpenAI._generate",
-                wrapper=openai_tracing_wrapper,
+            # langchain_openai.chat_models.base.BaseChatOpenAI
+            _wrap_function(
+                "langchain_openai.chat_models.base",
+                "BaseChatOpenAI._generate",
+                openai_tracing_wrapper,
             )
 
-            wrap_function_wrapper(
-                module="langchain_openai.chat_models.base",
-                name="BaseChatOpenAI._agenerate",
-                wrapper=openai_tracing_wrapper,
+            _wrap_function(
+                "langchain_openai.chat_models.base",
+                "BaseChatOpenAI._agenerate",
+                openai_tracing_wrapper,
             )
 
             # Doesn't work :(
@@ -194,25 +199,25 @@ class LangchainInstrumentor(BaseInstrumentor):
         # Wrap Pregel.stream and Pregel.astream (graph invocation)
         if is_package_available("langgraph"):
             try:
-                wrap_function_wrapper(
-                    module="langgraph.pregel",
-                    name="Pregel.stream",
-                    wrapper=create_graph_invocation_wrapper(tracer, is_async=False),
+                _wrap_function(
+                    "langgraph.pregel",
+                    "Pregel.stream",
+                    create_graph_invocation_wrapper(tracer, is_async=False),
                 )
-                wrap_function_wrapper(
-                    module="langgraph.pregel",
-                    name="Pregel.astream",
-                    wrapper=create_graph_invocation_wrapper(tracer, is_async=True),
+                _wrap_function(
+                    "langgraph.pregel",
+                    "Pregel.astream",
+                    create_graph_invocation_wrapper(tracer, is_async=True),
                 )
             except Exception as e:
                 logger.debug("Failed to wrap Pregel methods: %s", e)
 
             # Wrap Command.__init__ to capture routing commands
             try:
-                wrap_function_wrapper(
-                    module="langgraph.types",
-                    name="Command.__init__",
-                    wrapper=create_command_init_wrapper(tracer),
+                _wrap_function(
+                    "langgraph.types",
+                    "Command.__init__",
+                    create_command_init_wrapper(tracer),
                 )
             except Exception as e:
                 logger.debug("Failed to wrap Command.__init__: %s", e)
@@ -231,19 +236,19 @@ class LangchainInstrumentor(BaseInstrumentor):
             langgraph_agent_wrapper = create_agent_wrapper(tracer, provider_name="langgraph")
             # Patch the actual module where the function is defined
             try:
-                wrap_function_wrapper(
-                    module="langgraph.prebuilt.chat_agent_executor",
-                    name="create_react_agent",
-                    wrapper=langgraph_agent_wrapper,
+                _wrap_function(
+                    "langgraph.prebuilt.chat_agent_executor",
+                    "create_react_agent",
+                    langgraph_agent_wrapper,
                 )
             except Exception as e:
                 logger.debug("Failed to wrap langgraph.prebuilt.chat_agent_executor.create_react_agent: %s", e)
             # Also patch the re-export location for imports from langgraph.prebuilt
             try:
-                wrap_function_wrapper(
-                    module="langgraph.prebuilt",
-                    name="create_react_agent",
-                    wrapper=langgraph_agent_wrapper,
+                _wrap_function(
+                    "langgraph.prebuilt",
+                    "create_react_agent",
+                    langgraph_agent_wrapper,
                 )
             except Exception as e:
                 logger.debug("Failed to wrap langgraph.prebuilt.create_react_agent: %s", e)
@@ -253,19 +258,19 @@ class LangchainInstrumentor(BaseInstrumentor):
             agent_wrapper = create_agent_wrapper(tracer, provider_name="langchain")
             # Patch the actual module where the function is defined
             try:
-                wrap_function_wrapper(
-                    module="langchain.agents.factory",
-                    name="create_agent",
-                    wrapper=agent_wrapper,
+                _wrap_function(
+                    "langchain.agents.factory",
+                    "create_agent",
+                    agent_wrapper,
                 )
             except Exception as e:
                 logger.debug("Failed to wrap langchain.agents.factory.create_agent: %s", e)
             # Also patch the re-export location for imports from langchain.agents
             try:
-                wrap_function_wrapper(
-                    module="langchain.agents",
-                    name="create_agent",
-                    wrapper=agent_wrapper,
+                _wrap_function(
+                    "langchain.agents",
+                    "create_agent",
+                    agent_wrapper,
                 )
             except Exception as e:
                 logger.debug("Failed to wrap langchain.agents.create_agent: %s", e)
@@ -276,10 +281,10 @@ class LangchainInstrumentor(BaseInstrumentor):
         sync_hooks = ["before_model", "after_model", "before_agent", "after_agent"]
         for hook_name in sync_hooks:
             try:
-                wrap_function_wrapper(
-                    module="langchain.agents.middleware.types",
-                    name=f"AgentMiddleware.{hook_name}",
-                    wrapper=create_middleware_hook_wrapper(tracer, hook_name),
+                _wrap_function(
+                    "langchain.agents.middleware.types",
+                    f"AgentMiddleware.{hook_name}",
+                    create_middleware_hook_wrapper(tracer, hook_name),
                 )
             except Exception as e:
                 logger.debug("Failed to wrap AgentMiddleware.%s: %s", hook_name, e)
@@ -288,10 +293,10 @@ class LangchainInstrumentor(BaseInstrumentor):
         async_hooks = ["abefore_model", "aafter_model", "abefore_agent", "aafter_agent"]
         for hook_name in async_hooks:
             try:
-                wrap_function_wrapper(
-                    module="langchain.agents.middleware.types",
-                    name=f"AgentMiddleware.{hook_name}",
-                    wrapper=create_async_middleware_hook_wrapper(tracer, hook_name),
+                _wrap_function(
+                    "langchain.agents.middleware.types",
+                    f"AgentMiddleware.{hook_name}",
+                    create_async_middleware_hook_wrapper(tracer, hook_name),
                 )
             except Exception as e:
                 logger.debug("Failed to wrap AgentMiddleware.%s: %s", hook_name, e)
@@ -354,10 +359,10 @@ class LangchainInstrumentor(BaseInstrumentor):
                 unwrap("langchain_openai.llms.base", "BaseOpenAI._agenerate")
                 unwrap("langchain_openai.llms.base", "BaseOpenAI._stream")
                 unwrap("langchain_openai.llms.base", "BaseOpenAI._astream")
-                unwrap("langchain_openai.chat_models.base", "BaseOpenAI._generate")
-                unwrap("langchain_openai.chat_models.base", "BaseOpenAI._agenerate")
-                # unwrap("langchain_openai.chat_models.base", "BaseOpenAI._stream")
-                # unwrap("langchain_openai.chat_models.base", "BaseOpenAI._astream")
+                unwrap("langchain_openai.chat_models.base", "BaseChatOpenAI._generate")
+                unwrap("langchain_openai.chat_models.base", "BaseChatOpenAI._agenerate")
+                # unwrap("langchain_openai.chat_models.base", "BaseChatOpenAI._stream")
+                # unwrap("langchain_openai.chat_models.base", "BaseChatOpenAI._astream")
 
 
 class _BaseCallbackManagerInitWrapper:

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
@@ -69,9 +69,11 @@ class LangchainInstrumentor(BaseInstrumentor):
         self.disable_trace_context_propagation = disable_trace_context_propagation
 
     def instrumentation_dependencies(self) -> Collection[str]:
+        """Return the package dependencies required by this instrumentor."""
         return _instruments
 
     def _instrument(self, **kwargs):
+        """Install LangChain, LangGraph, and OpenAI tracing hooks."""
         tracer_provider = kwargs.get("tracer_provider")
         tracer = get_tracer(__name__, __version__, tracer_provider)
 
@@ -115,6 +117,7 @@ class LangchainInstrumentor(BaseInstrumentor):
             self._wrap_openai_functions_for_tracing(traceloopCallbackHandler)
 
     def _wrap_openai_functions_for_tracing(self, traceloopCallbackHandler):
+        """Wrap LangChain OpenAI entry points to propagate active trace headers."""
         openai_tracing_wrapper = _OpenAITracingWrapper(traceloopCallbackHandler)
 
         if is_package_available("langchain_community"):
@@ -302,6 +305,7 @@ class LangchainInstrumentor(BaseInstrumentor):
                 logger.debug("Failed to wrap AgentMiddleware.%s: %s", hook_name, e)
 
     def _uninstrument(self, **kwargs):
+        """Remove the wrappers installed by this instrumentor."""
         unwrap("langchain_core.callbacks", "BaseCallbackManager.__init__")
 
         # Unwrap LangGraph components
@@ -366,7 +370,10 @@ class LangchainInstrumentor(BaseInstrumentor):
 
 
 class _BaseCallbackManagerInitWrapper:
+    """Attach the Traceloop callback handler to callback managers as they initialize."""
+
     def __init__(self, callback_handler: "TraceloopCallbackHandler"):
+        """Store the callback handler instance that should be attached."""
         self._callback_handler = callback_handler
 
     def __call__(
@@ -376,6 +383,7 @@ class _BaseCallbackManagerInitWrapper:
         args,
         kwargs,
     ) -> None:
+        """Add the tracing callback handler to inheritable callback managers once."""
         wrapped(*args, **kwargs)
         for handler in instance.inheritable_handlers:
             if isinstance(handler, type(self._callback_handler)):
@@ -396,7 +404,10 @@ class _BaseCallbackManagerInitWrapper:
 #    allows us to add extra headers (including tracing headers) to the OpenAI request by
 #    modifying the `extra_headers` argument in `kwargs`.
 class _OpenAITracingWrapper:
+    """Inject trace headers into downstream OpenAI requests made by LangChain."""
+
     def __init__(self, callback_manager: "TraceloopCallbackHandler"):
+        """Store the callback manager used to look up active spans by run id."""
         self._callback_manager = callback_manager
 
     def __call__(
@@ -406,6 +417,7 @@ class _OpenAITracingWrapper:
         args,
         kwargs,
     ) -> None:
+        """Forward trace context in OpenAI calls while suppressing duplicate spans."""
         run_manager = kwargs.get("run_manager")
         if run_manager:
             run_id = run_manager.run_id

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
@@ -185,18 +185,6 @@ class LangchainInstrumentor(BaseInstrumentor):
                 openai_tracing_wrapper,
             )
 
-            # Doesn't work :(
-            # wrap_function_wrapper(
-            #     module="langchain_openai.chat_models.base",
-            #     name="BaseChatOpenAI._stream",
-            #     wrapper=openai_tracing_wrapper,
-            # )
-            # wrap_function_wrapper(
-            #     module="langchain_openai.chat_models.base",
-            #     name="BaseChatOpenAI._astream",
-            #     wrapper=openai_tracing_wrapper,
-            # )
-
     def _wrap_langgraph_components(self, tracer):
         """Wrap LangGraph components for instrumentation."""
         # Wrap Pregel.stream and Pregel.astream (graph invocation)
@@ -359,12 +347,30 @@ class LangchainInstrumentor(BaseInstrumentor):
                 unwrap("langchain_community.llms.openai", "BaseOpenAI._stream")
                 unwrap("langchain_community.llms.openai", "BaseOpenAI._astream")
             if is_package_available("langchain_openai"):
-                unwrap("langchain_openai.llms.base", "BaseOpenAI._generate")
-                unwrap("langchain_openai.llms.base", "BaseOpenAI._agenerate")
-                unwrap("langchain_openai.llms.base", "BaseOpenAI._stream")
-                unwrap("langchain_openai.llms.base", "BaseOpenAI._astream")
-                unwrap("langchain_openai.chat_models.base", "BaseChatOpenAI._generate")
-                unwrap("langchain_openai.chat_models.base", "BaseChatOpenAI._agenerate")
+                try:
+                    unwrap("langchain_openai.llms.base", "BaseOpenAI._generate")
+                except Exception:
+                    pass
+                try:
+                    unwrap("langchain_openai.llms.base", "BaseOpenAI._agenerate")
+                except Exception:
+                    pass
+                try:
+                    unwrap("langchain_openai.llms.base", "BaseOpenAI._stream")
+                except Exception:
+                    pass
+                try:
+                    unwrap("langchain_openai.llms.base", "BaseOpenAI._astream")
+                except Exception:
+                    pass
+                try:
+                    unwrap("langchain_openai.chat_models.base", "BaseChatOpenAI._generate")
+                except Exception:
+                    pass
+                try:
+                    unwrap("langchain_openai.chat_models.base", "BaseChatOpenAI._agenerate")
+                except Exception:
+                    pass
 
 
 class _BaseCallbackManagerInitWrapper:

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
@@ -365,8 +365,6 @@ class LangchainInstrumentor(BaseInstrumentor):
                 unwrap("langchain_openai.llms.base", "BaseOpenAI._astream")
                 unwrap("langchain_openai.chat_models.base", "BaseChatOpenAI._generate")
                 unwrap("langchain_openai.chat_models.base", "BaseChatOpenAI._agenerate")
-                # unwrap("langchain_openai.chat_models.base", "BaseChatOpenAI._stream")
-                # unwrap("langchain_openai.chat_models.base", "BaseChatOpenAI._astream")
 
 
 class _BaseCallbackManagerInitWrapper:

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_wrapt_compat.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_wrapt_compat.py
@@ -3,9 +3,11 @@ from opentelemetry.instrumentation.langchain import LangchainInstrumentor
 
 
 def test_instrumentation_uses_wrapt_positional_signature(monkeypatch):
+    """Instrumentation should call wrapt with positional arguments only."""
     calls = []
 
     def strict_wrap_function(module, name, wrapper, /):
+        """Capture wrapt calls while enforcing a positional-only signature."""
         calls.append((module, name, wrapper))
 
     monkeypatch.setattr(
@@ -23,9 +25,11 @@ def test_instrumentation_uses_wrapt_positional_signature(monkeypatch):
 
 
 def test_uninstrumentation_unwraps_base_chat_openai(monkeypatch):
+    """Uninstrumentation should target the wrapped BaseChatOpenAI methods."""
     calls = []
 
     def capture_unwrap(module, name):
+        """Record the unwrap targets requested by the instrumentor."""
         calls.append((module, name))
 
     monkeypatch.setattr(langchain_module, "unwrap", capture_unwrap)

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_wrapt_compat.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_wrapt_compat.py
@@ -1,0 +1,47 @@
+import opentelemetry.instrumentation.langchain as langchain_module
+from opentelemetry.instrumentation.langchain import LangchainInstrumentor
+
+
+def test_instrumentation_uses_wrapt_positional_signature(monkeypatch):
+    calls = []
+
+    def strict_wrap_function(module, name, wrapper, /):
+        calls.append((module, name, wrapper))
+
+    monkeypatch.setattr(
+        langchain_module, "wrap_function_wrapper", strict_wrap_function
+    )
+    monkeypatch.setattr(
+        langchain_module, "is_package_available", lambda package_name: False
+    )
+
+    LangchainInstrumentor()._instrument()
+
+    assert len(calls) == 1
+    assert calls[0][0] == "langchain_core.callbacks"
+    assert calls[0][1] == "BaseCallbackManager.__init__"
+
+
+def test_uninstrumentation_unwraps_base_chat_openai(monkeypatch):
+    calls = []
+
+    def capture_unwrap(module, name):
+        calls.append((module, name))
+
+    monkeypatch.setattr(langchain_module, "unwrap", capture_unwrap)
+    monkeypatch.setattr(
+        langchain_module,
+        "is_package_available",
+        lambda package_name: package_name == "langchain_openai",
+    )
+
+    LangchainInstrumentor()._uninstrument()
+
+    assert (
+        "langchain_openai.chat_models.base",
+        "BaseChatOpenAI._generate",
+    ) in calls
+    assert (
+        "langchain_openai.chat_models.base",
+        "BaseChatOpenAI._agenerate",
+    ) in calls

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_wrapt_compat.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_wrapt_compat.py
@@ -17,11 +17,15 @@ def test_instrumentation_uses_wrapt_positional_signature(monkeypatch):
         langchain_module, "is_package_available", lambda package_name: False
     )
 
-    LangchainInstrumentor()._instrument()
+    instrumentor = LangchainInstrumentor()
+    try:
+        instrumentor.instrument()
 
-    assert len(calls) == 1
-    assert calls[0][0] == "langchain_core.callbacks"
-    assert calls[0][1] == "BaseCallbackManager.__init__"
+        assert len(calls) == 1
+        assert calls[0][0] == "langchain_core.callbacks"
+        assert calls[0][1] == "BaseCallbackManager.__init__"
+    finally:
+        instrumentor.uninstrument()
 
 
 def test_uninstrumentation_unwraps_base_chat_openai(monkeypatch):
@@ -41,6 +45,10 @@ def test_uninstrumentation_unwraps_base_chat_openai(monkeypatch):
 
     LangchainInstrumentor()._uninstrument()
 
+    assert (
+        "langchain_core.callbacks",
+        "BaseCallbackManager.__init__",
+    ) in calls
     assert (
         "langchain_openai.chat_models.base",
         "BaseChatOpenAI._generate",


### PR DESCRIPTION
closes #4009 
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [x] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

## Summary

Fix LangChain instrumentation compatibility with `wrapt` 2.x and correct a pre-existing uninstrumentation bug for `BaseChatOpenAI`.

Issue: https://github.com/traceloop/openllmetry/issues/4009

## What Changed

- switched LangChain `wrap_function_wrapper(...)` calls to the positional signature supported by `wrapt` 1.x and 2.x
- fixed `_uninstrument()` to unwrap `BaseChatOpenAI._generate` and `BaseChatOpenAI._agenerate` from `langchain_openai.chat_models.base`
- added regression tests for both the `wrapt` compatibility fix and the `BaseChatOpenAI` uninstrumentation fix

## Root Cause

The LangChain instrumentor called `wrap_function_wrapper` with keyword arguments (`module=...`, `name=...`, `wrapper=...`), which fails with newer `wrapt` versions. Separately, the uninstrumentation path referenced `BaseOpenAI` in `langchain_openai.chat_models.base`, while the wrapped methods actually belong to `BaseChatOpenAI`, so those wrappers were not removed correctly.

## Impact

- restores zero-code LangChain auto-instrumentation compatibility with `wrapt` 2.x
- ensures `BaseChatOpenAI` wrappers are removed correctly during `_uninstrument()`
- adds regression coverage for both behaviors

## Validation

- added `test_wrapt_compat.py`
- ran:
  - `python3 -m py_compile packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py packages/opentelemetry-instrumentation-langchain/tests/test_wrapt_compat.py`

## Notes

- I could not add observability screenshots in this environment.
- No documentation updates were needed for this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized internal wrapping logic to simplify and standardize instrumentation.

* **Documentation**
  * Expanded and clarified docstrings for instrumentors and wrappers.

* **Bug Fixes**
  * Improved reliability of context suppression handling to ensure cleanup runs even on exceptions and refined uninstrumentation to avoid unsafe unwraps.

* **Tests**
  * Added tests validating wrapper compatibility and correct uninstrumentation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->