### PR TITLE
fix(anthropic): prevent KeyError in _process_response_item during streaming

### DIFF
--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
@@ -48,12 +48,14 @@ def _process_response_item(item, complete_response):
                 complete_response["events"][index]["input"] = """"""
     elif item.type == "content_block_delta":
         index = item.index
-        if item.delta.type == "thinking_delta":
-            complete_response["events"][index]["text"] += item.delta.thinking
-        elif item.delta.type == "text_delta":
-            complete_response["events"][index]["text"] += item.delta.text
-        elif item.delta.type == "input_json_delta":
-            complete_response["events"][index]["input"] += item.delta.partial_json
+        if index < len(complete_response.get("events", [])):
+            event = complete_response["events"][index]
+            if item.delta.type == "thinking_delta":
+                event["text"] = event.get("text", "") + item.delta.thinking
+            elif item.delta.type == "text_delta":
+                event["text"] = event.get("text", "") + item.delta.text
+            elif item.delta.type == "input_json_delta":
+                event["input"] = event.get("input", "") + item.delta.partial_json
     elif item.type == "message_delta":
         for event in complete_response.get("events", []):
             event["finish_reason"] = item.delta.stop_reason


### PR DESCRIPTION
Fixes #4050

## Summary

`_process_response_item` in the Anthropic streaming instrumentation crashes with `KeyError: 'input'` because the `content_block_delta` handler accesses `complete_response["events"][index]["input"]` with a bare dict subscription, but the `"input"` key is only set for `tool_use` content blocks in the `content_block_start` handler.

## Changes

- Add bounds-check on `index` before accessing the events list (prevents `IndexError`)
- Use `.get(key, "")` instead of bare `[key]` for all dict accesses in the `content_block_delta` handler
- Use local `event` variable to avoid repeated list indexing

## Impact

This bug causes `KeyError: 'input'` on every streaming chunk. While `@dont_throw` catches the exception, `traceback.format_exc()` still writes to stderr in a tight loop, destabilizing production pods (we experienced a full crash loop across all K8s pods in production).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming delta processing to properly handle edge cases and prevent errors during content accumulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->