### PR TITLE
fix(anthropic): replace blocking thread.join() with asyncio.ensure_future in run_async

### DIFF
--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/utils.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/utils.py
@@ -278,9 +278,7 @@ def run_async(method):
         loop = None
 
     if loop and loop.is_running():
-        thread = threading.Thread(target=lambda: asyncio.run(method))
-        thread.start()
-        thread.join()
+        asyncio.ensure_future(method)
     else:
         asyncio.run(method)
 


### PR DESCRIPTION
Fixes #4052

## Summary

`run_async()` uses `threading.Thread` + `thread.join()` to bridge sync/async code. When called from within a running async event loop (FastAPI, Starlette, etc.), `thread.join()` blocks the entire event loop thread, preventing health checks and other coroutines from executing.

## Changes

Replace `thread.join()` with `asyncio.ensure_future()` when a running event loop is detected. This schedules the span attribute setting as a non-blocking background task.

```python
# Before (blocks event loop):
thread = threading.Thread(target=lambda: asyncio.run(method))
thread.start()
thread.join()

# After (non-blocking):
asyncio.ensure_future(method)
```

## Impact

In our production environment (FastAPI + Kubernetes), `thread.join()` caused pod crash loops:
1. Every `messages.stream()` / `messages.create()` call blocks the event loop
2. Tool calls with nested Anthropic API calls compound the blocking
3. K8s liveness probe can't be served → pod killed after 3 consecutive timeouts

## Related

- #4050 / #4051 — `KeyError: 'input'` in `_process_response_item` (separate bug, same incident)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of asynchronous operations when invoked from within an existing event loop, eliminating unnecessary thread overhead and optimizing coroutine scheduling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->