### PR TITLE
fix(instrumentation): langchain association properties context cleanup

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
@@ -119,10 +119,12 @@ def _sanitize_metadata_value(value: Any) -> Any:
 
 
 def valid_role(role: str) -> bool:
+    """Return whether a role is valid for emitted GenAI message events."""
     return role in ["user", "assistant", "system", "tool"]
 
 
 def get_message_role(message: Type[BaseMessage]) -> str:
+    """Map a LangChain message object or chunk to a GenAI semantic role."""
     if isinstance(message, (SystemMessage, SystemMessageChunk)):
         return "system"
     elif isinstance(message, (HumanMessage, HumanMessageChunk)):
@@ -138,6 +140,7 @@ def get_message_role(message: Type[BaseMessage]) -> str:
 def _extract_tool_call_data(
     tool_calls: Optional[List[dict[str, Any]]],
 ) -> Union[List[ToolCall], None]:
+    """Normalize LangChain tool call payloads into ToolCall event objects."""
     if tool_calls is None:
         return tool_calls
 
@@ -165,6 +168,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
     def __init__(
         self, tracer: Tracer, duration_histogram: Histogram, token_histogram: Histogram
     ) -> None:
+        """Initialize the callback handler state used to track active LangChain spans."""
         super().__init__()
         self.tracer = tracer
         self.duration_histogram = duration_histogram
@@ -193,6 +197,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         return "unknown"
 
     def _get_span(self, run_id: UUID) -> Span:
+        """Return the active span currently registered for the given run id."""
         return self.spans[run_id].span
 
     def _detach_holder_contexts(self, span_holder: SpanHolder | None) -> None:
@@ -202,8 +207,10 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
 
         if span_holder.token:
             self._safe_detach_context(span_holder.token)
+            span_holder.token = None
         if span_holder.association_properties_token:
             self._safe_detach_context(span_holder.association_properties_token)
+            span_holder.association_properties_token = None
 
     def _end_span(self, span: Span, run_id: UUID) -> None:
         """End a span and clean up any tracked context tokens for it and its children."""
@@ -279,6 +286,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         entity_path: str = "",
         metadata: Optional[dict[str, Any]] = None,
     ) -> Span:
+        """Create and register a span holder, replacing any existing holder for the run id."""
         old_holder = self.spans.get(run_id)
         if old_holder is not None:
             self._detach_holder_contexts(old_holder)
@@ -375,6 +383,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         metadata: Optional[dict[str, Any]] = None,
         serialized: Optional[dict[str, Any]] = None,
     ) -> Span:
+        """Create a workflow, task, or tool span with LangChain and GenAI attributes."""
         # Determine span type
         is_agent = kind in (
             TraceloopSpanKindValues.WORKFLOW,
@@ -460,6 +469,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         metadata: Optional[dict[str, Any]] = None,
         serialized: Optional[dict[str, Any]] = None,
     ) -> Span:
+        """Create an LLM client span and swap span attachment for suppression context."""
         workflow_name = self.get_workflow_name(parent_run_id)
         entity_path = self.get_entity_path(parent_run_id)
 
@@ -500,7 +510,6 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         current_holder = self.spans.get(run_id)
         if current_holder is not None and current_holder.token is not None:
             self._safe_detach_context(current_holder.token)
-            current_holder.token = None
 
         # we already have an LLM span by this point,
         # so skip any downstream instrumentation from here
@@ -730,6 +739,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         parent_run_id: Union[UUID, None] = None,
         **kwargs: Any,
     ):
+        """Finalize an LLM span with response metadata, usage, and output content."""
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return
 
@@ -1011,11 +1021,13 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         self._end_span(span, run_id)
 
     def get_parent_span(self, parent_run_id: Optional[str] = None):
+        """Return the tracked parent span holder for a run id, if it exists."""
         if parent_run_id is None:
             return None
         return self.spans[parent_run_id]
 
     def get_workflow_name(self, parent_run_id: str):
+        """Resolve the workflow name inherited from a parent run."""
         parent_span = self.get_parent_span(parent_run_id)
 
         if parent_span is None:
@@ -1024,6 +1036,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         return parent_span.workflow_name
 
     def get_entity_path(self, parent_run_id: str):
+        """Build the child entity path inherited from the parent span holder."""
         parent_span = self.get_parent_span(parent_run_id)
 
         if parent_span is None:
@@ -1119,6 +1132,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         self._handle_error(error, run_id, parent_run_id, **kwargs)
 
     def _emit_chat_input_events(self, messages):
+        """Emit message events for each chat-model input message."""
         for message_list in messages:
             for message in message_list:
                 if hasattr(message, "tool_calls") and message.tool_calls:
@@ -1134,6 +1148,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
                 )
 
     def _emit_llm_end_events(self, response):
+        """Emit choice events for all generations contained in an LLM response."""
         for generation_list in response.generations:
             for i, generation in enumerate(generation_list):
                 self._emit_generation_choice_event(index=i, generation=generation)
@@ -1145,6 +1160,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
             ChatGeneration, ChatGenerationChunk, Generation, GenerationChunk
         ],
     ):
+        """Emit the appropriate GenAI choice event for a single generation."""
         if isinstance(generation, (ChatGeneration, ChatGenerationChunk)):
             # Get finish reason
             raw_finish_reason = None

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
@@ -195,6 +195,16 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
     def _get_span(self, run_id: UUID) -> Span:
         return self.spans[run_id].span
 
+    def _detach_holder_contexts(self, span_holder: SpanHolder | None) -> None:
+        """Detach any tracked context tokens stored on a span holder."""
+        if span_holder is None:
+            return
+
+        if span_holder.token:
+            self._safe_detach_context(span_holder.token)
+        if span_holder.association_properties_token:
+            self._safe_detach_context(span_holder.association_properties_token)
+
     def _end_span(self, span: Span, run_id: UUID) -> None:
         for child_id in self.spans[run_id].children:
             if child_id in self.spans:
@@ -202,9 +212,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
                 if child_span.end_time is None:  # avoid warning on ended spans
                     child_span.end()
         span.end()
-        token = self.spans[run_id].token
-        if token:
-            self._safe_detach_context(token)
+        self._detach_holder_contexts(self.spans[run_id])
 
         del self.spans[run_id]
 
@@ -266,6 +274,11 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         entity_path: str = "",
         metadata: Optional[dict[str, Any]] = None,
     ) -> Span:
+        old_holder = self.spans.get(run_id)
+        if old_holder is not None:
+            self._detach_holder_contexts(old_holder)
+
+        association_properties_token = None
         if metadata is not None:
             current_association_properties = (
                 context_api.get_value("association_properties") or {}
@@ -277,7 +290,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
                 if v is not None
             }
             try:
-                context_api.attach(
+                association_properties_token = context_api.attach(
                     context_api.set_value(
                         "association_properties",
                         {**current_association_properties, **sanitized_metadata},
@@ -330,7 +343,14 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
                 )
 
         self.spans[run_id] = SpanHolder(
-            span, token, None, [], workflow_name, entity_name, entity_path
+            span,
+            token,
+            None,
+            [],
+            workflow_name,
+            entity_name,
+            entity_path,
+            association_properties_token=association_properties_token,
         )
 
         if parent_run_id is not None and parent_run_id in self.spans:
@@ -444,10 +464,6 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         # Detaching here, before the overwrite, ensures we clean up the original
         # suppression token from a duplicate run_id and that the new suppression
         # is layered on top of the clean baseline context.
-        old_holder = self.spans.get(run_id)
-        if old_holder is not None and old_holder.token is not None:
-            self._safe_detach_context(old_holder.token)
-
         span = self._create_span(
             run_id,
             parent_run_id,
@@ -480,6 +496,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         current_holder = self.spans.get(run_id)
         if current_holder is not None and current_holder.token is not None:
             self._safe_detach_context(current_holder.token)
+            current_holder.token = None
 
         # we already have an LLM span by this point,
         # so skip any downstream instrumentation from here
@@ -492,7 +509,16 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
             token = None
 
         self.spans[run_id] = SpanHolder(
-            span, token, None, [], workflow_name, None, entity_path
+            span,
+            token,
+            None,
+            [],
+            workflow_name,
+            None,
+            entity_path,
+            association_properties_token=(
+                current_holder.association_properties_token if current_holder else None
+            ),
         )
 
         return span

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
@@ -215,9 +215,9 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
                 if child_span.end_time is None:  # avoid warning on ended spans
                     child_span.end()
                 del self.spans[child_id]
+        self._detach_holder_contexts(self.spans[run_id])
         if span.end_time is None:  # avoid warning on ended spans
             span.end()
-        self._detach_holder_contexts(self.spans[run_id])
 
         del self.spans[run_id]
 
@@ -463,12 +463,11 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         workflow_name = self.get_workflow_name(parent_run_id)
         entity_path = self.get_entity_path(parent_run_id)
 
-        # Capture and detach the old holder BEFORE _create_span runs.
-        # _create_span unconditionally overwrites self.spans[run_id], which
-        # would make the old SpanHolder (and its suppression token) unreachable.
-        # Detaching here, before the overwrite, ensures we clean up the original
-        # suppression token from a duplicate run_id and that the new suppression
-        # is layered on top of the clean baseline context.
+        # _create_span is responsible for detaching any existing SpanHolder for
+        # this run_id via _detach_holder_contexts before it overwrites
+        # self.spans[run_id]. Callers should rely on _create_span to manage
+        # existing suppression tokens and other context cleanup for duplicate run_id
+        # lifecycles.
         span = self._create_span(
             run_id,
             parent_run_id,

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
@@ -206,12 +206,17 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
             self._safe_detach_context(span_holder.association_properties_token)
 
     def _end_span(self, span: Span, run_id: UUID) -> None:
-        for child_id in self.spans[run_id].children:
+        """End a span and clean up any tracked context tokens for it and its children."""
+        for child_id in list(self.spans[run_id].children):
             if child_id in self.spans:
-                child_span = self.spans[child_id].span
+                child_holder = self.spans[child_id]
+                child_span = child_holder.span
+                self._detach_holder_contexts(child_holder)
                 if child_span.end_time is None:  # avoid warning on ended spans
                     child_span.end()
-        span.end()
+                del self.spans[child_id]
+        if span.end_time is None:  # avoid warning on ended spans
+            span.end()
         self._detach_holder_contexts(self.spans[run_id])
 
         del self.spans[run_id]

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/span_utils.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/span_utils.py
@@ -58,6 +58,7 @@ class SpanHolder:
     workflow_name: str
     entity_name: str
     entity_path: str
+    association_properties_token: Any = None
     start_time: float = field(default_factory=time.time)
     request_model: Optional[str] = None
 

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_context_token_lifecycle.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_context_token_lifecycle.py
@@ -26,6 +26,7 @@ from opentelemetry.instrumentation.langchain.callback_handler import (
 
 @pytest.fixture
 def handler():
+    """Create a callback handler backed by an in-memory tracer for lifecycle tests."""
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
@@ -54,10 +55,12 @@ def restore_otel_context():
 
 
 def _suppression_active() -> bool:
+    """Return whether language-model suppression is currently active in OTel context."""
     return context_api.get_value(SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY) is True
 
 
 def _association_properties() -> dict:
+    """Return the current association properties context payload, if any."""
     return context_api.get_value("association_properties") or {}
 
 
@@ -232,4 +235,49 @@ def test_duplicate_run_id_replaces_association_properties(handler):
     assert _association_properties() == {}, (
         "association_properties from the replacement span should also be cleaned up "
         "when the surviving holder is ended."
+    )
+
+
+def test_duplicate_llm_run_id_replaces_association_properties(handler):
+    """
+    Replacing an LLM span holder must clear the prior metadata context and suppression.
+    """
+    run_id = uuid4()
+
+    first_span = handler._create_llm_span(
+        run_id,
+        None,
+        "gpt-4",
+        LLMRequestTypeValues.CHAT,
+        metadata={"user_id": "12345"},
+    )
+    assert _association_properties().get("user_id") == "12345"
+    assert _suppression_active(), "suppression active after 1st call (sanity)"
+
+    second_span = handler._create_llm_span(
+        run_id,
+        None,
+        "gpt-4",
+        LLMRequestTypeValues.CHAT,
+        metadata={"request_id": "req-1"},
+    )
+
+    # The first span is intentionally not ended because the replacement path is under test.
+    assert first_span.end_time is None, "sanity: old span stays open until caller ends it"
+    assert _association_properties().get("user_id") is None, (
+        "The previous association_properties context should be detached before "
+        "creating a replacement LLM holder for the same run_id."
+    )
+    assert _association_properties().get("request_id") == "req-1"
+    assert _suppression_active(), "suppression active after 2nd call (sanity)"
+
+    handler._end_span(second_span, run_id)
+
+    assert _association_properties() == {}, (
+        "association_properties from the replacement LLM span should be cleaned up "
+        "when the surviving holder is ended."
+    )
+    assert not _suppression_active(), (
+        "Suppression must be cleared after ending the replacement LLM span, matching "
+        "the behavior verified in test_duplicate_run_id_leaks_suppression_token."
     )

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_context_token_lifecycle.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_context_token_lifecycle.py
@@ -57,6 +57,10 @@ def _suppression_active() -> bool:
     return context_api.get_value(SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY) is True
 
 
+def _association_properties() -> dict:
+    return context_api.get_value("association_properties") or {}
+
+
 # ---------------------------------------------------------------------------
 # Ordering fix (commit 2) — normal single-call lifecycle
 # ---------------------------------------------------------------------------
@@ -88,6 +92,28 @@ def test_suppression_cleared_after_end_span(handler):
     assert not _suppression_active(), (
         "Suppression must be cleared when the LLM span ends; otherwise every "
         "subsequent call in this thread/task is permanently suppressed."
+    )
+
+
+def test_association_properties_cleared_after_end_span(handler):
+    """Metadata-specific association properties must not outlive the span."""
+    run_id = uuid4()
+    assert _association_properties() == {}, "precondition: no association properties"
+
+    span = handler._create_span(
+        run_id,
+        None,
+        "test-span",
+        metadata={"user_id": "12345"},
+    )
+
+    assert _association_properties().get("user_id") == "12345"
+
+    handler._end_span(span, run_id)
+
+    assert _association_properties() == {}, (
+        "association_properties must be detached when the span ends; otherwise "
+        "later spans can inherit stale metadata."
     )
 
 
@@ -170,4 +196,40 @@ def test_duplicate_run_id_leaks_suppression_token(handler):
         "_create_span overwrites self.spans[run_id] before the old holder can be read. "
         "Fix: move `existing_holder = self.spans.get(run_id)` (and its detach) to "
         "BEFORE the `_create_span(...)` call in _create_llm_span."
+    )
+
+
+def test_duplicate_run_id_replaces_association_properties(handler):
+    """
+    Replacing a SpanHolder for the same run_id must clean up the old metadata context.
+    """
+    run_id = uuid4()
+
+    first_span = handler._create_span(
+        run_id,
+        None,
+        "first-span",
+        metadata={"user_id": "12345"},
+    )
+    assert _association_properties().get("user_id") == "12345"
+
+    second_span = handler._create_span(
+        run_id,
+        None,
+        "second-span",
+        metadata={"request_id": "req-1"},
+    )
+
+    assert first_span.end_time is None, "sanity: old span stays open until caller ends it"
+    assert _association_properties().get("user_id") is None, (
+        "The previous association_properties context should be detached before "
+        "creating a replacement holder for the same run_id."
+    )
+    assert _association_properties().get("request_id") == "req-1"
+
+    handler._end_span(second_span, run_id)
+
+    assert _association_properties() == {}, (
+        "association_properties from the replacement span should also be cleaned up "
+        "when the surviving holder is ended."
     )


### PR DESCRIPTION
closes #4054 
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [x] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
## What changed
- track the `association_properties` context attachment token on LangChain `SpanHolder`
- detach tracked holder tokens during span cleanup and before replacing an existing holder for the same `run_id`
- preserve the metadata context token when `_create_llm_span()` swaps the holder token to suppression context
- add lifecycle regression tests covering normal cleanup and duplicate `run_id` replacement

## Why
Issue #4054 identified that `_create_span()` attaches `association_properties` into OpenTelemetry context without retaining a token to detach later. That can leave stale metadata in context after the span ends or when a holder is overwritten.

## Impact
This fixes a context leak in the LangChain instrumentation so downstream spans and logs do not inherit stale `association_properties` from earlier runs.

## Root cause
`_create_span()` called `context_api.attach(context_api.set_value(...))` for `association_properties` but dropped the returned token. Since the token was never stored on the span holder, there was no matching detach during `_end_span()` or holder replacement.

## Validation
- `python3 -m compileall packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain packages/opentelemetry-instrumentation-langchain/tests/test_context_token_lifecycle.py`
- `PYTHONPATH=packages/opentelemetry-instrumentation-langchain ./.venv/bin/python -m pytest -q --noconftest packages/opentelemetry-instrumentation-langchain/tests/test_context_token_lifecycle.py`
  - result: `5 passed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace-context cleanup so association properties and suppression context are correctly detached when spans end or when span identifiers are reused, preventing stale metadata or suppression flags from leaking across operations and ensuring accurate tracing for subsequent runs.

* **Tests**
  * Added regression tests validating lifecycle and cleanup of association properties and suppression behavior for both regular and LLM-related spans, including replacement and end-of-span scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->