### PR TITLE
fix(mcp): set error type for protocol errors

### DIFF
--- a/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
+++ b/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
@@ -341,6 +341,7 @@ class McpInstrumentor(BaseInstrumentor):
                 )
             # Handle errors
             if hasattr(result, "isError") and result.isError:
+                span.set_attribute(ERROR_TYPE, "MCPToolError")
                 if len(result.content) > 0:
                     span.set_status(
                         Status(StatusCode.ERROR, f"{result.content[0].text}")
@@ -569,6 +570,7 @@ class InstrumentedStreamWriter(ObjectProxy):  # type: ignore
                 )
                 if "isError" in request.result:
                     if request.result["isError"] is True:
+                        span.set_attribute(ERROR_TYPE, "MCPToolError")
                         span.set_status(
                             Status(
                                 StatusCode.ERROR,

--- a/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
+++ b/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
@@ -342,10 +342,9 @@ class McpInstrumentor(BaseInstrumentor):
             # Handle errors
             if hasattr(result, "isError") and result.isError:
                 span.set_attribute(ERROR_TYPE, "MCPToolError")
-                if len(result.content) > 0:
-                    span.set_status(
-                        Status(StatusCode.ERROR, f"{result.content[0].text}")
-                    )
+                span.set_status(
+                    Status(StatusCode.ERROR, _get_mcp_result_error_description(result))
+                )
             else:
                 span.set_status(Status(StatusCode.OK))
             return result
@@ -490,6 +489,33 @@ def serialize(request, depth=0, max_depth=4):
         return json.dumps(result)
 
 
+def _get_mcp_result_error_description(result):
+    content = getattr(result, "content", None)
+    return _get_mcp_error_description(content, "MCP tool call returned isError=True")
+
+
+def _get_mcp_response_error_description(result):
+    content = result.get("content") if isinstance(result, dict) else None
+    return _get_mcp_error_description(content, "MCP response returned isError=True")
+
+
+def _get_mcp_error_description(content, fallback):
+    if not content:
+        return fallback
+
+    try:
+        first_content = content[0]
+    except (IndexError, KeyError, TypeError):
+        return fallback
+
+    if isinstance(first_content, dict):
+        text = first_content.get("text")
+    else:
+        text = getattr(first_content, "text", None)
+
+    return f"{text}" if text else fallback
+
+
 class InstrumentedStreamReader(ObjectProxy):  # type: ignore
     # ObjectProxy missing context manager - https://github.com/GrahamDumpleton/wrapt/issues/73
     def __init__(self, wrapped, tracer):
@@ -574,7 +600,7 @@ class InstrumentedStreamWriter(ObjectProxy):  # type: ignore
                         span.set_status(
                             Status(
                                 StatusCode.ERROR,
-                                f"{request.result['content'][0]['text']}",
+                                _get_mcp_response_error_description(request.result),
                             )
                         )
             if hasattr(request, "id"):

--- a/packages/opentelemetry-instrumentation-mcp/tests/test_mcp_error_type.py
+++ b/packages/opentelemetry-instrumentation-mcp/tests/test_mcp_error_type.py
@@ -1,20 +1,39 @@
 from types import SimpleNamespace
 
+import pytest
 from opentelemetry.instrumentation.mcp import McpInstrumentor
 from opentelemetry.instrumentation.mcp.instrumentation import InstrumentedStreamWriter
 from opentelemetry.trace.status import StatusCode
 
 
+@pytest.mark.parametrize(
+    ("result", "expected_description"),
+    [
+        (
+            SimpleNamespace(
+                isError=True,
+                content=[SimpleNamespace(text="tool failed")],
+            ),
+            "tool failed",
+        ),
+        (
+            SimpleNamespace(isError=True, content=[]),
+            "MCP tool call returned isError=True",
+        ),
+        (
+            SimpleNamespace(isError=True),
+            "MCP tool call returned isError=True",
+        ),
+    ],
+)
 async def test_protocol_error_result_sets_error_type(
     span_exporter,
     tracer_provider,
+    result,
+    expected_description,
 ) -> None:
     instrumentor = McpInstrumentor()
     tracer = tracer_provider.get_tracer(__name__)
-    result = SimpleNamespace(
-        isError=True,
-        content=[SimpleNamespace(text="tool failed")],
-    )
 
     async def wrapped():
         return result
@@ -32,34 +51,60 @@ async def test_protocol_error_result_sets_error_type(
     assert actual is result
     error_span = span_exporter.get_finished_spans()[-1]
     assert error_span.status.status_code == StatusCode.ERROR
-    assert error_span.status.description == "tool failed"
+    assert error_span.status.description == expected_description
     assert error_span.attributes["error.type"] == "MCPToolError"
 
 
+@pytest.mark.parametrize(
+    ("result", "expected_description"),
+    [
+        (
+            {
+                "isError": True,
+                "content": [{"text": "streamed tool failed"}],
+            },
+            "streamed tool failed",
+        ),
+        (
+            {
+                "isError": True,
+                "content": [],
+            },
+            "MCP response returned isError=True",
+        ),
+        (
+            {
+                "isError": True,
+            },
+            "MCP response returned isError=True",
+        ),
+    ],
+)
 async def test_response_stream_protocol_error_sets_error_type(
     span_exporter,
     tracer_provider,
+    result,
+    expected_description,
 ) -> None:
     tracer = tracer_provider.get_tracer(__name__)
-    wrapped_stream = SimpleNamespace(send=_async_noop)
+    sent_items = []
+
+    async def send(item):
+        sent_items.append(item)
+
+    wrapped_stream = SimpleNamespace(send=send)
     stream_writer = InstrumentedStreamWriter(wrapped_stream, tracer)
     response = SimpleNamespace(
         id="request-1",
-        result={
-            "isError": True,
-            "content": [{"text": "streamed tool failed"}],
-        },
+        result=result,
     )
     item = SimpleNamespace(message=SimpleNamespace(root=response))
 
     await stream_writer.send(item)
 
+    assert sent_items == [item]
     error_span = span_exporter.get_finished_spans()[-1]
     assert error_span.name == "ResponseStreamWriter"
     assert error_span.status.status_code == StatusCode.ERROR
-    assert error_span.status.description == "streamed tool failed"
+    assert error_span.status.description == expected_description
     assert error_span.attributes["error.type"] == "MCPToolError"
-
-
-async def _async_noop(_item):
-    return None

--- a/packages/opentelemetry-instrumentation-mcp/tests/test_mcp_error_type.py
+++ b/packages/opentelemetry-instrumentation-mcp/tests/test_mcp_error_type.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+from opentelemetry.instrumentation.mcp import McpInstrumentor
+from opentelemetry.instrumentation.mcp.instrumentation import InstrumentedStreamWriter
+from opentelemetry.trace.status import StatusCode
+
+
+async def test_protocol_error_result_sets_error_type(
+    span_exporter,
+    tracer_provider,
+) -> None:
+    instrumentor = McpInstrumentor()
+    tracer = tracer_provider.get_tracer(__name__)
+    result = SimpleNamespace(
+        isError=True,
+        content=[SimpleNamespace(text="tool failed")],
+    )
+
+    async def wrapped():
+        return result
+
+    with tracer.start_as_current_span("test.tool") as span:
+        actual = await instrumentor._execute_and_handle_result(
+            span,
+            "tools/call",
+            (),
+            {},
+            wrapped,
+            clean_output=True,
+        )
+
+    assert actual is result
+    error_span = span_exporter.get_finished_spans()[-1]
+    assert error_span.status.status_code == StatusCode.ERROR
+    assert error_span.status.description == "tool failed"
+    assert error_span.attributes["error.type"] == "MCPToolError"
+
+
+async def test_response_stream_protocol_error_sets_error_type(
+    span_exporter,
+    tracer_provider,
+) -> None:
+    tracer = tracer_provider.get_tracer(__name__)
+    wrapped_stream = SimpleNamespace(send=_async_noop)
+    stream_writer = InstrumentedStreamWriter(wrapped_stream, tracer)
+    response = SimpleNamespace(
+        id="request-1",
+        result={
+            "isError": True,
+            "content": [{"text": "streamed tool failed"}],
+        },
+    )
+    item = SimpleNamespace(message=SimpleNamespace(root=response))
+
+    await stream_writer.send(item)
+
+    error_span = span_exporter.get_finished_spans()[-1]
+    assert error_span.name == "ResponseStreamWriter"
+    assert error_span.status.status_code == StatusCode.ERROR
+    assert error_span.status.description == "streamed tool failed"
+    assert error_span.attributes["error.type"] == "MCPToolError"
+
+
+async def _async_noop(_item):
+    return None


### PR DESCRIPTION
Adds error.type = "MCPToolError" to MCP protocol-level error spans when tool results return isError=True, and adds regression tests covering both direct result handling and response stream handling.
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [x] I have added tests that cover my changes.
- [x] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [x] (If applicable) I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust handling and consistent classification of MCP tool/response failures by tagging spans with error type "MCPToolError" and providing safer, fallback-friendly error descriptions.

* **Tests**
  * Added tests that validate instrumentation marks spans as errors with correct descriptions and error type for both tool execution results and streamed responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->