### PR TITLE
feat(openai-agents): record cache_read_input_tokens and reasoning_tokens

### DIFF
--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
@@ -307,6 +307,24 @@ def _extract_response_attributes(otel_span, response, trace_content: bool):
                 SpanAttributes.LLM_USAGE_TOTAL_TOKENS, usage.total_tokens
             )
 
+        input_details = getattr(usage, "input_tokens_details", None)
+        if input_details is not None:
+            cached_tokens = getattr(input_details, "cached_tokens", None)
+            if cached_tokens is not None:
+                otel_span.set_attribute(
+                    SpanAttributes.LLM_USAGE_CACHE_READ_INPUT_TOKENS,
+                    cached_tokens,
+                )
+
+        output_details = getattr(usage, "output_tokens_details", None)
+        if output_details is not None:
+            reasoning_tokens = getattr(output_details, "reasoning_tokens", None)
+            if reasoning_tokens is not None:
+                otel_span.set_attribute(
+                    SpanAttributes.LLM_USAGE_REASONING_TOKENS,
+                    reasoning_tokens,
+                )
+
     return model_settings
 
 

--- a/packages/opentelemetry-instrumentation-openai-agents/tests/test_openai_agents.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/tests/test_openai_agents.py
@@ -501,3 +501,64 @@ def test_tool_call_and_result_attributes(exporter):
 
     assert tool_call_found, "No assistant message with tool_calls found in second response span"
     assert tool_result_found, "No tool message found in second response span"
+
+
+def test_extract_response_cached_and_reasoning_tokens():
+    """Verify cache-read and reasoning tokens are recorded when the Agents SDK
+    Usage object carries them via input_tokens_details / output_tokens_details.
+    """
+    from types import SimpleNamespace
+    from opentelemetry.instrumentation.openai_agents._hooks import (
+        _extract_response_attributes,
+    )
+
+    recorded: dict[str, object] = {}
+
+    class _FakeSpan:
+        def set_attribute(self, key, value):
+            recorded[key] = value
+
+    response = SimpleNamespace(
+        usage=SimpleNamespace(
+            input_tokens=20_750,
+            output_tokens=97,
+            total_tokens=20_847,
+            input_tokens_details=SimpleNamespace(cached_tokens=20_608),
+            output_tokens_details=SimpleNamespace(reasoning_tokens=64),
+        ),
+    )
+
+    _extract_response_attributes(_FakeSpan(), response, trace_content=False)
+
+    assert recorded[SpanAttributes.LLM_USAGE_CACHE_READ_INPUT_TOKENS] == 20_608
+    assert recorded[SpanAttributes.LLM_USAGE_REASONING_TOKENS] == 64
+    assert recorded[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS] == 20_750
+    assert recorded[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS] == 97
+
+
+def test_extract_response_cache_tokens_absent_when_missing():
+    """When input_tokens_details / output_tokens_details are absent the new
+    attributes must not be set (regression guard)."""
+    from types import SimpleNamespace
+    from opentelemetry.instrumentation.openai_agents._hooks import (
+        _extract_response_attributes,
+    )
+
+    recorded: dict[str, object] = {}
+
+    class _FakeSpan:
+        def set_attribute(self, key, value):
+            recorded[key] = value
+
+    response = SimpleNamespace(
+        usage=SimpleNamespace(
+            input_tokens=100,
+            output_tokens=10,
+            total_tokens=110,
+        ),
+    )
+
+    _extract_response_attributes(_FakeSpan(), response, trace_content=False)
+
+    assert SpanAttributes.LLM_USAGE_CACHE_READ_INPUT_TOKENS not in recorded
+    assert SpanAttributes.LLM_USAGE_REASONING_TOKENS not in recorded


### PR DESCRIPTION
## Summary

The OpenAI Agents SDK `Usage` object carries two additional token-count fields not currently captured by this instrumentor:

- `usage.input_tokens_details.cached_tokens` — prompt-cache hits returned by the Responses API.
- `usage.output_tokens_details.reasoning_tokens` — reasoning-model reasoning-token breakdown.

Users who install only the openai-agents instrumentor (e.g. via `Traceloop.init(block_instruments={Instruments.OPENAI})` to avoid duplicate spans with the raw-client instrumentor) currently have **no cache visibility**, even when caching is working at 99%+. That makes prompt-caching verification impossible and, downstream, causes backends like Braintrust to render empty `prompt_cached_tokens` columns.

Fixes #4060.

## Changes

`packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py` — in `_extract_response_attributes`, after the existing `total_tokens` handler, read the two `_tokens_details` sub-objects and record them under the conventional OTel GenAI attribute names:

- `gen_ai.usage.cache_read_input_tokens` via `SpanAttributes.LLM_USAGE_CACHE_READ_INPUT_TOKENS` (same constant already used by the anthropic and langchain instrumentors in this repo).
- `gen_ai.usage.reasoning_tokens` (string literal — no corresponding constant in `semconv_ai` yet; happy to add one in a follow-up if preferred).

Diff: 18 insertions, 0 deletions in `_hooks.py`; 61 insertions, 0 deletions in tests.

## Tests

Added two unit tests in `tests/test_openai_agents.py` that exercise `_extract_response_attributes` directly (no VCR needed):

- `test_extract_response_cached_and_reasoning_tokens` — asserts both new attributes are recorded when the Usage object carries the detail fields.
- `test_extract_response_cache_tokens_absent_when_missing` — regression guard: when the detail objects are absent, the new attributes must not be set.

Both pass locally:
```
uv run pytest tests/test_openai_agents.py::test_extract_response_cached_and_reasoning_tokens tests/test_openai_agents.py::test_extract_response_cache_tokens_absent_when_missing -v
======================== 2 passed in 0.25s ========================
```

`uv run ruff check` on both modified files is clean.

## End-to-end verification

I installed this branch into a downstream agent repo that uses `Traceloop.init(block_instruments={Instruments.OPENAI})` and re-ran a two-turn agent case against the OpenAI Responses API with `auto_previous_response_id=True`. The resulting `openai.response` span metadata now includes:

```
gen_ai.usage.input_tokens = 22026
gen_ai.usage.output_tokens = 347
gen_ai.usage.cache_read_input_tokens = 20608   ← new
gen_ai.usage.reasoning_tokens = 0              ← new
```

Before the patch, the same run produced a span with `input_tokens` and `output_tokens` only — no way to see that 93% of the prompt was served from cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instrumentation now records cached input-token and reasoning-token metrics from responses when available, improving observability of token usage.
* **Tests**
  * Added unit tests to confirm the new token attributes are emitted when present and omitted when absent, preserving existing token reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->