### PR TITLE
feat(openai-agents): emit tool spans with correct type + durations

### DIFF
--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
@@ -45,6 +45,31 @@ except ImportError:
     SpeechGroupSpanData = None
 
 
+def _iso_to_nanoseconds(iso_str):
+    """Convert an ISO-8601 timestamp string (set by the OpenAI Agents SDK on
+    Span.started_at / Span.ended_at) to an integer nanoseconds-since-epoch
+    suitable for OTel's start_time/end_time.  Returns None when input is None
+    or unparseable; caller should fall back to default (current) time.
+
+    A datetime parsed from an ISO-8601 value without timezone information
+    is assumed to be UTC, since ``datetime.timestamp()`` would otherwise
+    interpret it as local time and produce an offset result depending on
+    the host."""
+    if not iso_str:
+        return None
+    try:
+        import datetime as _dt
+        # Python 3.11+ fromisoformat handles "Z" suffix natively, but 3.10 does
+        # not, so normalize defensively.
+        s = iso_str.replace("Z", "+00:00") if iso_str.endswith("Z") else iso_str
+        dt = _dt.datetime.fromisoformat(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=_dt.timezone.utc)
+        return int(dt.timestamp() * 1_000_000_000)
+    except Exception:
+        return None
+
+
 def _extract_prompt_attributes(otel_span, input_data, trace_content: bool):
     """
     Extract prompt/input data from messages and set them as span attributes.
@@ -465,6 +490,7 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
                 GenAIAttributes.GEN_AI_TOOL_NAME: tool_name,
                 GenAIAttributes.GEN_AI_TOOL_TYPE: "function",
                 GenAIAttributes.GEN_AI_SYSTEM: "openai_agents",
+                GenAIAttributes.GEN_AI_OPERATION_NAME: "execute_tool",
                 f"{GenAIAttributes.GEN_AI_COMPLETION}.tool.name": tool_name,
                 f"{GenAIAttributes.GEN_AI_COMPLETION}.tool.type": "function",
                 f"{GenAIAttributes.GEN_AI_COMPLETION}.tool.strict_json_schema": True,
@@ -481,6 +507,7 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
                 kind=SpanKind.INTERNAL,
                 context=parent_context,
                 attributes=tool_attributes,
+                start_time=_iso_to_nanoseconds(getattr(span, "started_at", None)),
             )
 
         elif type(span_data).__name__ == "ResponseSpanData":
@@ -772,7 +799,7 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
             else:
                 otel_span.set_status(Status(StatusCode.OK))
 
-            otel_span.end()
+            otel_span.end(end_time=_iso_to_nanoseconds(getattr(span, "ended_at", None)))
             del self._otel_spans[span]
             if span in self._span_contexts:
                 context.detach(self._span_contexts[span])

--- a/packages/opentelemetry-instrumentation-openai-agents/tests/test_openai_agents.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/tests/test_openai_agents.py
@@ -172,6 +172,19 @@ def test_agent_with_function_tool_spans(exporter, function_tool_agent):
     assert tool_span.attributes[GenAIAttributes.GEN_AI_TOOL_NAME] == "get_weather"
     assert tool_span.attributes[GenAIAttributes.GEN_AI_TOOL_TYPE] == "function"
 
+    # OTel GenAI semconv operation.name identifies this as a tool-execution
+    # span for ingestion backends that derive their span-type taxonomy from
+    # gen_ai.operation.name.
+    assert tool_span.attributes[GenAIAttributes.GEN_AI_OPERATION_NAME] == "execute_tool"
+
+    # The Agents SDK emits ISO-8601 start/end timestamps on the span; the
+    # instrumentor plumbs them through as OTel start_time/end_time so
+    # downstream durations are non-null.  Verify the exported span has a
+    # real, non-zero duration.
+    assert tool_span.start_time is not None and tool_span.start_time > 0
+    assert tool_span.end_time is not None and tool_span.end_time > 0
+    assert tool_span.end_time >= tool_span.start_time
+
     # Tool description is optional - only test if present
     if GenAIAttributes.GEN_AI_TOOL_DESCRIPTION in tool_span.attributes:
         assert (
@@ -501,3 +514,23 @@ def test_tool_call_and_result_attributes(exporter):
 
     assert tool_call_found, "No assistant message with tool_calls found in second response span"
     assert tool_result_found, "No tool message found in second response span"
+
+
+def test_iso_to_nanoseconds():
+    """Converter handles ISO-8601 (with and without 'Z') plus None/unparseable."""
+    from opentelemetry.instrumentation.openai_agents._hooks import _iso_to_nanoseconds
+
+    assert _iso_to_nanoseconds(None) is None
+    assert _iso_to_nanoseconds("") is None
+    assert _iso_to_nanoseconds("not a timestamp") is None
+
+    # Epoch 0
+    assert _iso_to_nanoseconds("1970-01-01T00:00:00+00:00") == 0
+    # Round-trip a known instant
+    assert _iso_to_nanoseconds("1970-01-01T00:00:01Z") == 1_000_000_000
+    # Nanosecond precision (ISO microseconds)
+    assert _iso_to_nanoseconds("1970-01-01T00:00:00.001234Z") == 1_234_000
+
+    # Timezone-naive input must be treated as UTC (not host local time),
+    # otherwise the returned ns value shifts by the tz offset.
+    assert _iso_to_nanoseconds("1970-01-01T00:00:01") == 1_000_000_000


### PR DESCRIPTION
## Summary

Two small, related fixes in `FunctionSpanData` handling:

1. **Tool spans weren't being recognised as tools by backends that derive their own span-type taxonomy from the OTel GenAI semantic conventions.** Adding `gen_ai.operation.name = \"execute_tool\"` (the OTel semconv value for tool-execution spans) lets ingestion layers classify them correctly. Before this change, Braintrust's OTel ingestion classified our openai-agents tool spans as generic `task` because nothing signalled \"tool\"; the anthropic/langchain/pydantic-ai instrumentors all already produce tool-recognised spans.

2. **Tool spans had null / zero duration downstream.** The instrumentor used OTel's default wall-clock inside `on_span_start` / `on_span_end` instead of the `Span.started_at` / `Span.ended_at` ISO timestamps the OpenAI Agents SDK already records on the span. Piping them through preserves the actual tool-invocation window.

## Changes

`packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py`:
- New helper `_iso_to_nanoseconds(iso_str)` — converts Agents-SDK ISO-8601 timestamps to integer ns for OTel; returns None on missing/unparseable.
- `FunctionSpanData` branch in `on_span_start`: add `GenAIAttributes.GEN_AI_OPERATION_NAME: \"execute_tool\"` to the tool attribute dict and pass `start_time=_iso_to_nanoseconds(span.started_at)`.
- `on_span_end`: pass `end_time=_iso_to_nanoseconds(span.ended_at)` to `otel_span.end(...)`.

## Tests

Added `test_iso_to_nanoseconds` in `tests/test_openai_agents.py` covering None, empty, unparseable, epoch 0, trailing-Z, and microsecond-precision inputs.

```
uv run pytest tests/test_openai_agents.py::test_iso_to_nanoseconds -v
======================== 1 passed in 0.23s ========================
uv run ruff check opentelemetry/instrumentation/openai_agents/_hooks.py tests/test_openai_agents.py
All checks passed!
```

## End-to-end verification

Installed this branch into a downstream agent repo and re-ran a tool-calling Agents SDK run. The resulting Braintrust trace:

Before:
```
[task]  get_linked_accounts.tool   dur=null   gen_ai.operation.name=null
```

After:
```
[tool]  get_linked_accounts.tool   dur=0.006s  gen_ai.operation.name=execute_tool
```

Non-tool span types (agent `task`, LLM `llm`) remain unchanged.

## Related

Independent from but complementary to #4061 (cached_tokens / reasoning_tokens recording); happy to combine if preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved tool span timing by parsing ISO-8601 timestamps to provide nanosecond-precision start/end times for spans.
  * Tool spans now include an explicit operation name attribute ("execute_tool") for clearer observability.

* **Tests**
  * Added tests validating timestamp parsing (including edge cases) and verifying non-null, monotonic span timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->