### PR TITLE
feat(openai-agents): capture tool call arguments + result on tool spans

### DIFF
--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
@@ -45,6 +45,30 @@ except ImportError:
     SpeechGroupSpanData = None
 
 
+def _serialize_span_payload(value):
+    """Serialise a FunctionSpanData input/output to a JSON string suitable
+    for span attributes.  Handles pydantic BaseModel instances (e.g. the
+    Agents SDK's ``ToolOutputText``) via ``model_dump``, falls back to a
+    ``default=str`` ``json.dumps`` for anything else, and final-falls-back
+    to ``str()``.  Pass-through when the value is already a ``str``."""
+    if isinstance(value, str):
+        return value
+    try:
+        if hasattr(value, "model_dump"):
+            value = value.model_dump()
+        elif isinstance(value, (list, tuple)):
+            value = [
+                v.model_dump() if hasattr(v, "model_dump") else v
+                for v in value
+            ]
+    except Exception:
+        pass
+    try:
+        return json.dumps(value, default=str)
+    except (TypeError, ValueError):
+        return str(value)
+
+
 def _extract_prompt_attributes(otel_span, input_data, trace_content: bool):
     """
     Extract prompt/input data from messages and set them as span attributes.
@@ -465,9 +489,6 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
                 GenAIAttributes.GEN_AI_TOOL_NAME: tool_name,
                 GenAIAttributes.GEN_AI_TOOL_TYPE: "function",
                 GenAIAttributes.GEN_AI_SYSTEM: "openai_agents",
-                f"{GenAIAttributes.GEN_AI_COMPLETION}.tool.name": tool_name,
-                f"{GenAIAttributes.GEN_AI_COMPLETION}.tool.type": "function",
-                f"{GenAIAttributes.GEN_AI_COMPLETION}.tool.strict_json_schema": True,
             }
 
             if hasattr(span_data, "description") and span_data.description:
@@ -668,6 +689,35 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
                 if response:
                     model_settings = _extract_response_attributes(otel_span, response, trace_content)
                     self._last_model_settings = model_settings
+
+            elif type(span_data).__name__ == "FunctionSpanData":
+                # Capture the function tool call's arguments and return value so they
+                # are visible in trace backends (matches the Agents SDK's native
+                # FunctionSpanData record + Braintrust's native tool-span input/output).
+                if trace_content:
+                    fn_input = getattr(span_data, "input", None)
+                    if fn_input is not None:
+                        input_str = _serialize_span_payload(fn_input)
+                        # OTel GenAI semconv: used by OTel-aware backends.
+                        otel_span.set_attribute(
+                            GenAIAttributes.GEN_AI_TOOL_CALL_ARGUMENTS, input_str
+                        )
+                        # Traceloop convention: matches the LangChain/other
+                        # Traceloop instrumentors so the tool arguments also
+                        # render in the trace UI's top-level Input panel.
+                        otel_span.set_attribute(
+                            SpanAttributes.TRACELOOP_ENTITY_INPUT, input_str
+                        )
+
+                    fn_output = getattr(span_data, "output", None)
+                    if fn_output is not None:
+                        output_str = _serialize_span_payload(fn_output)
+                        otel_span.set_attribute(
+                            GenAIAttributes.GEN_AI_TOOL_CALL_RESULT, output_str
+                        )
+                        otel_span.set_attribute(
+                            SpanAttributes.TRACELOOP_ENTITY_OUTPUT, output_str
+                        )
 
             # Legacy fallback for other span types
             elif span_data:

--- a/packages/opentelemetry-instrumentation-openai-agents/tests/test_openai_agents.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/tests/test_openai_agents.py
@@ -172,6 +172,32 @@ def test_agent_with_function_tool_spans(exporter, function_tool_agent):
     assert tool_span.attributes[GenAIAttributes.GEN_AI_TOOL_NAME] == "get_weather"
     assert tool_span.attributes[GenAIAttributes.GEN_AI_TOOL_TYPE] == "function"
 
+    # FunctionSpanData.input / .output are captured as GEN_AI_TOOL_CALL_*
+    # attributes so trace UIs (Braintrust, etc.) can render the actual tool
+    # call arguments and return value instead of only the tool name.
+    #
+    # The test cassette is a call of `get_weather(city="London")` which
+    # returns the string "It's cloudy with 15°C" (see the `function_tool_agent`
+    # fixture). Asserting exact values pins the serialisation contract:
+    # arguments are the Agents SDK's compact JSON, the result is passed
+    # through verbatim when it's already a string.
+    args = tool_span.attributes[GenAIAttributes.GEN_AI_TOOL_CALL_ARGUMENTS]
+    assert args == '{"city":"London"}', (
+        f"Unexpected tool call arguments: {args!r}"
+    )
+
+    result = tool_span.attributes[GenAIAttributes.GEN_AI_TOOL_CALL_RESULT]
+    assert result == "It's cloudy with 15\u00b0C", (
+        f"Unexpected tool call result: {result!r}"
+    )
+
+    # Traceloop entity input/output: matches the LangChain instrumentor
+    # convention and surfaces the tool call's arguments/result in the
+    # trace-UI top-level input/output panels.  Must carry the same payload
+    # as the GenAI pair.
+    assert tool_span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT] == args
+    assert tool_span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == result
+
     # Tool description is optional - only test if present
     if GenAIAttributes.GEN_AI_TOOL_DESCRIPTION in tool_span.attributes:
         assert (


### PR DESCRIPTION
## Summary

`FunctionSpanData` carries the tool's arguments (`input`) and return value (`output`) on every function-tool invocation, but the openai-agents instrumentor never read either — tool spans only carried the tool name and type. Braintrust's own native Agents-SDK processor (`braintrust/wrappers/openai.py:_function_log_data`) logs both as top-level input/output fields; OTel-based integrations were the outlier.

This PR captures both values and emits them under two attribute pairs so they show up both as semantic-convention metadata and as first-class Input/Output panels in trace UIs.

## Before / After

Same `get_customer_info.tool` span, same Braintrust workspace, rendered side-by-side:

![PR #4063 before/after](https://github.com/hansmire/openllmetry/raw/screenshots-pr4063/pr4063-before-after.png)

*Before*: Output panel renders the tool's JSON schema (`{"tool": {"name": ..., "strict_json_schema": true, "type": "function"}}`) — a tool *definition* leaked into the output slot, not the tool's return value.
*After*: Output panel renders the real tool call result (`hasChatEmailed: false, mailingAddress: "123 Main St, …", partyId: "risk_1a", …`).

## Changes (`_hooks.py`)

1. **Capture `FunctionSpanData.input` / `.output` in `on_span_end`** and emit them as:
    - `gen_ai.tool.call.arguments` / `gen_ai.tool.call.result` — OTel GenAI semconv (for OTel-aware backends).
    - `traceloop.entity.input` / `traceloop.entity.output` — Traceloop convention used by the LangChain instrumentor, which trace backends (Braintrust etc.) already map to the span's top-level Input / Output panels.
2. **Drop the three `gen_ai.completion.tool.*` attributes** previously set on tool spans at start time. They were a tool *definition* blob (name / type / strict_json_schema) that some backends' ingestion logic treated as the tool span's Output, producing `{"tool": {...}}` in the Output panel instead of the actual return value. The equivalent information is already carried by `gen_ai.tool.name` / `gen_ai.tool.type` + `TRACELOOP_SPAN_KIND`.
3. **Add `_serialize_span_payload` helper** — serialises the FunctionSpanData input/output reliably:
    - string passthrough,
    - `model_dump()` for pydantic models (e.g. Agents SDK `ToolOutputText`) and for lists of pydantic models,
    - `json.dumps(..., default=str)` fallback,
    - `str()` as last resort.
4. Gated on `trace_content = should_send_prompts()` so content-sensitive deployments that opt out of prompt capture also get the tool payload suppressed.

## Tests

Extended the existing VCR-backed `test_agent_with_function_tool_spans` to assert:
- `GEN_AI_TOOL_CALL_ARGUMENTS` / `GEN_AI_TOOL_CALL_RESULT` are set and non-empty.
- `TRACELOOP_ENTITY_INPUT` / `TRACELOOP_ENTITY_OUTPUT` are set and match the GenAI pair.
- Tool arguments reference the query's city name (end-to-end sanity).

All 10 tests in `tests/test_openai_agents.py` pass locally. `uv run ruff check` clean.

## Notes

Part of a small series of `openai-agents` parity fixes (#4061 cached_tokens + reasoning_tokens, #4062 tool span type + duration). Each stands alone off `main` and can be merged in any order.