### PR TITLE
feat(openai-agents): record response-identification metadata on LLM spans

### DIFF
--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
@@ -209,12 +209,52 @@ def _extract_response_attributes(otel_span, response, trace_content: bool):
     if hasattr(response, "model") and response.model:
         model_settings["model"] = response.model
         otel_span.set_attribute(GenAIAttributes.GEN_AI_REQUEST_MODEL, response.model)
+        otel_span.set_attribute(GenAIAttributes.GEN_AI_RESPONSE_MODEL, response.model)
 
     if (
         hasattr(response, "frequency_penalty")
         and response.frequency_penalty is not None
     ):
         model_settings["frequency_penalty"] = response.frequency_penalty
+
+    # Response-identification fields captured from the Responses API response
+    # object.  These are surfaced by the Agents SDK's own native tracing and by
+    # Braintrust's native processor (via ``response.model_dump(...)``) but were
+    # previously dropped by this instrumentor.  They let downstream UIs tie
+    # turns together (response.id / previous_response_id) and show the exact
+    # model version that answered (response.model vs request.model).
+    response_id = getattr(response, "id", None)
+    if response_id:
+        otel_span.set_attribute(GenAIAttributes.GEN_AI_RESPONSE_ID, response_id)
+
+    status = getattr(response, "status", None)
+    if status:
+        otel_span.set_attribute("gen_ai.response.status", str(status))
+
+    previous_response_id = getattr(response, "previous_response_id", None)
+    if previous_response_id:
+        otel_span.set_attribute(
+            "gen_ai.request.previous_response_id", previous_response_id
+        )
+
+    service_tier = getattr(response, "service_tier", None)
+    if service_tier:
+        otel_span.set_attribute(
+            GenAIAttributes.GEN_AI_OPENAI_REQUEST_SERVICE_TIER, service_tier
+        )
+
+    reasoning = getattr(response, "reasoning", None)
+    if reasoning is not None:
+        effort = getattr(reasoning, "effort", None)
+        if effort:
+            otel_span.set_attribute(
+                SpanAttributes.LLM_REQUEST_REASONING_EFFORT, str(effort)
+            )
+        summary = getattr(reasoning, "summary", None)
+        if summary:
+            otel_span.set_attribute(
+                SpanAttributes.LLM_REQUEST_REASONING_SUMMARY, str(summary)
+            )
 
     # Extract completions from response.output
     if hasattr(response, "output") and response.output:

--- a/packages/opentelemetry-instrumentation-openai-agents/tests/test_openai_agents.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/tests/test_openai_agents.py
@@ -501,3 +501,91 @@ def test_tool_call_and_result_attributes(exporter):
 
     assert tool_call_found, "No assistant message with tool_calls found in second response span"
     assert tool_result_found, "No tool message found in second response span"
+
+
+def test_extract_response_captures_response_identification_fields():
+    """response.id / .model / .status / .previous_response_id / .service_tier /
+    .reasoning.effort / .reasoning.summary must surface as GenAI semconv
+    attributes on the span so downstream UIs can chain turns, distinguish
+    request-vs-actual model versions, and render reasoning / service-tier
+    settings.  Pins the attribute mapping contract."""
+    from types import SimpleNamespace
+    from opentelemetry.instrumentation.openai_agents._hooks import (
+        _extract_response_attributes,
+    )
+
+    recorded: dict[str, object] = {}
+
+    class _FakeSpan:
+        def set_attribute(self, key, value):
+            recorded[key] = value
+
+    response = SimpleNamespace(
+        id="resp_0123456789abcdef",
+        model="gpt-5.4-2026-03-05",
+        status="completed",
+        previous_response_id="resp_prevABCDEF",
+        service_tier="priority",
+        reasoning=SimpleNamespace(effort="medium", summary="concise"),
+        # Existing fields handled by earlier branches; include a minimum so
+        # the surrounding code doesn't choke.
+        temperature=None,
+        max_output_tokens=None,
+        top_p=None,
+        frequency_penalty=None,
+        usage=None,
+        output=None,
+    )
+
+    _extract_response_attributes(_FakeSpan(), response, trace_content=False)
+
+    assert recorded[GenAIAttributes.GEN_AI_RESPONSE_ID] == "resp_0123456789abcdef"
+    assert recorded[GenAIAttributes.GEN_AI_RESPONSE_MODEL] == "gpt-5.4-2026-03-05"
+    assert recorded["gen_ai.response.status"] == "completed"
+    assert recorded["gen_ai.request.previous_response_id"] == "resp_prevABCDEF"
+    assert recorded[GenAIAttributes.GEN_AI_OPENAI_REQUEST_SERVICE_TIER] == "priority"
+    assert recorded[SpanAttributes.LLM_REQUEST_REASONING_EFFORT] == "medium"
+    assert recorded[SpanAttributes.LLM_REQUEST_REASONING_SUMMARY] == "concise"
+
+
+def test_extract_response_absent_fields_dont_set_attributes():
+    """Regression guard: when a field is None / missing on the Response, no
+    attribute is written (no stringified ``None`` values)."""
+    from types import SimpleNamespace
+    from opentelemetry.instrumentation.openai_agents._hooks import (
+        _extract_response_attributes,
+    )
+
+    recorded: dict[str, object] = {}
+
+    class _FakeSpan:
+        def set_attribute(self, key, value):
+            recorded[key] = value
+
+    response = SimpleNamespace(
+        id=None,
+        model=None,
+        status=None,
+        previous_response_id=None,
+        service_tier=None,
+        reasoning=None,
+        temperature=None,
+        max_output_tokens=None,
+        top_p=None,
+        frequency_penalty=None,
+        usage=None,
+        output=None,
+    )
+
+    _extract_response_attributes(_FakeSpan(), response, trace_content=False)
+
+    for key in (
+        GenAIAttributes.GEN_AI_RESPONSE_ID,
+        GenAIAttributes.GEN_AI_RESPONSE_MODEL,
+        "gen_ai.response.status",
+        "gen_ai.request.previous_response_id",
+        GenAIAttributes.GEN_AI_OPENAI_REQUEST_SERVICE_TIER,
+        SpanAttributes.LLM_REQUEST_REASONING_EFFORT,
+        SpanAttributes.LLM_REQUEST_REASONING_SUMMARY,
+    ):
+        assert key not in recorded, f"Expected {key!r} not to be set"


### PR DESCRIPTION
## Summary

The Responses API `Response` object carries several fields that downstream trace backends rely on for turn chaining, model-version debugging, and reasoning / service-tier visibility, but that this instrumentor dropped on the floor. This PR plumbs them through to OTel span attributes on every LLM span.

| Response field | Span attribute |
|---|---|
| `response.id` | `gen_ai.response.id` |
| `response.model` | `gen_ai.response.model` (kept `gen_ai.request.model` for back-compat) |
| `response.status` | `gen_ai.response.status` |
| `response.previous_response_id` | `gen_ai.request.previous_response_id` |
| `response.service_tier` | `gen_ai.openai.request.service_tier` |
| `response.reasoning.effort` | `gen_ai.request.reasoning_effort` |
| `response.reasoning.summary` | `gen_ai.request.reasoning_summary` |

All additions are defensive: when a field is missing / None on the response, no attribute is emitted (no stringified `"None"` values — pinned by a regression test).

## Before / After

Same 529 eval, same agent, same LLM-span detail panel in the Braintrust trace UI:

![PR #4065 before/after](https://github.com/hansmire/openllmetry/raw/screenshots-pr4063/pr4065-before-after.png)

*Before* the LLM span's Metadata panel contains only `gen_ai.request.model`, `temperature`, `top_p`, `usage.*` — no response identification, no service tier, no reasoning config.
*After* the panel additionally renders `gen_ai.response.id`, `gen_ai.response.model`, `gen_ai.response.status`, `gen_ai.openai.request.service_tier`, and `gen_ai.request.reasoning_effort` — exposing turn chain, served-model version, and reasoning/service-tier settings for debugging.

## Why

Braintrust's own native Agents SDK processor surfaces the full `response.model_dump(exclude={"input","output","metadata","usage"})` on every LLM span — which is how its UI shows turn-by-turn chains and the exact model version that served each request. Previously openllmetry's equivalent `openai.response` span carried only `temperature`, `top_p`, `max_tokens` and a conflated `gen_ai.request.model`. Trace backends couldn't:

- **Chain turns** (no `response.id` / `previous_response_id`) — critical for debugging agents that use `auto_previous_response_id=True`.
- **Tell what actually ran** (only request.model was set; the specific served version like `gpt-5.4-2026-03-05` was lost).
- **See request config** (service tier, reasoning effort / summary all absent).

## Constants

OTel semconv constants are used where available:

- `GenAIAttributes.GEN_AI_RESPONSE_ID`
- `GenAIAttributes.GEN_AI_RESPONSE_MODEL`
- `GenAIAttributes.GEN_AI_OPENAI_REQUEST_SERVICE_TIER`
- `SpanAttributes.LLM_REQUEST_REASONING_EFFORT`
- `SpanAttributes.LLM_REQUEST_REASONING_SUMMARY`

Two fields fall back to string literals because `semconv_ai` doesn't publish a constant yet:

- `gen_ai.response.status`
- `gen_ai.request.previous_response_id`

Happy to add them upstream in `semconv_ai` in a follow-up if preferred.

## Tests

Two new direct unit tests on `_extract_response_attributes` (no VCR needed):

- `test_extract_response_captures_response_identification_fields` — feeds a `SimpleNamespace` with every field set, asserts each maps to the correct span attribute with the expected value.
- `test_extract_response_absent_fields_dont_set_attributes` — regression guard for the None-passthrough branches.

All 12 tests in `tests/test_openai_agents.py` pass locally. `uv run ruff check` clean.

## Notes

Part of a small series of `openai-agents` parity fixes (#4061 cached_tokens + reasoning_tokens, #4062 tool span type + duration, #4063 tool span input + output). Each stands alone off `main` and can be merged in any order.