### PR TITLE
feat(sdk): add httpx instrumentation support

### DIFF
--- a/packages/traceloop-sdk/pyproject.toml
+++ b/packages/traceloop-sdk/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
   "opentelemetry-instrumentation-llamaindex",
   "opentelemetry-instrumentation-milvus",
   "opentelemetry-instrumentation-haystack",
+  "opentelemetry-instrumentation-httpx>=0.59b0",
   "opentelemetry-instrumentation-bedrock",
   "opentelemetry-instrumentation-sagemaker",
   "opentelemetry-instrumentation-replicate",

--- a/packages/traceloop-sdk/traceloop/sdk/instruments.py
+++ b/packages/traceloop-sdk/traceloop/sdk/instruments.py
@@ -13,6 +13,7 @@ class Instruments(Enum):
     GOOGLE_GENERATIVEAI = "google_generativeai"
     GROQ = "groq"
     HAYSTACK = "haystack"
+    HTTPX = "httpx"
     LANCEDB = "lancedb"
     LANGCHAIN = "langchain"
     LLAMA_INDEX = "llama_index"

--- a/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
+++ b/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
@@ -527,6 +527,9 @@ def init_instrumentations(
         elif instrument == Instruments.HAYSTACK:
             if init_haystack_instrumentor():
                 instrument_set = True
+        elif instrument == Instruments.HTTPX:
+            if init_httpx_instrumentor():
+                instrument_set = True
         elif instrument == Instruments.LANCEDB:
             if init_lancedb_instrumentor():
                 instrument_set = True
@@ -758,6 +761,20 @@ def init_haystack_instrumentor():
             return True
     except Exception as e:
         logging.error(f"Error initializing Haystack instrumentor: {e}")
+    return False
+
+
+def init_httpx_instrumentor():
+    try:
+        if is_package_installed("httpx"):
+            from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+
+            instrumentor = HTTPXClientInstrumentor()
+            if not instrumentor.is_instrumented_by_opentelemetry:
+                instrumentor.instrument(excluded_urls=EXCLUDED_URLS)
+            return True
+    except Exception as e:
+        logging.error(f"Error initializing HTTPX instrumentor: {e}")
     return False
 
 


### PR DESCRIPTION
## Summary

Closes #2283

Adds httpx instrumentation to the traceloop SDK, allowing automatic tracing of outbound HTTP calls made via httpx. This mirrors the existing requests and urllib3 instrumentation already supported by the SDK.

## Changes

- Added `HTTPX = "httpx"` enum value to `Instruments`
- Added `init_httpx_instrumentor()` function using `HTTPXClientInstrumentor` with `excluded_urls` filtering (same as requests/urllib3)
- Added the elif dispatch branch in the instrumentor initialization loop
- Added `opentelemetry-instrumentation-httpx>=0.59b0` dependency to pyproject.toml

## Test plan

- [x] Verified Python syntax parses correctly
- [ ] CI passes with new dependency
- [ ] Manual verification: import traceloop SDK with httpx installed, confirm HTTPXClientInstrumentor activates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for instrumenting the HTTPX HTTP client library, enabling automatic tracing of HTTPX requests within the SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->