### PR TITLE
fix(langchain): preserve error description on span status

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
@@ -1022,7 +1022,12 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         span = self._get_span(run_id)
         # Set task status to failure
         _set_span_attribute(span, SpanAttributes.GEN_AI_TASK_STATUS, "failure")
-        span.set_status(Status(StatusCode.ERROR), str(error))
+        # The OTel SDK contract for Span.set_status() ignores the `description`
+        # argument when the first arg is already a Status object, and emits a
+        # warning. Pass the description inside Status(...) so the error message
+        # is preserved on the span. See:
+        # https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+        span.set_status(Status(StatusCode.ERROR, str(error)))
         span.record_exception(error)
         self._end_span(span, run_id)
 

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_error_status.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_error_status.py
@@ -1,0 +1,72 @@
+"""Regression tests for span status handling when a LangChain callback errors.
+
+Covers a subtle bug in `TraceloopCallbackHandler._handle_error` where the
+error message was passed as the second positional argument to
+`Span.set_status(...)` alongside a `Status` object. The OTel SDK contract
+silently drops the second argument in that case AND emits a warning,
+leaving the span without its human-readable error description.
+
+Correct call: ``span.set_status(Status(StatusCode.ERROR, str(error)))``.
+"""
+
+import logging
+
+from langchain_core.runnables import RunnableLambda
+from opentelemetry.trace import StatusCode
+
+
+def _explode(_):
+    raise ValueError("boom: something went wrong")
+
+
+def test_chain_error_sets_status_description(instrument_legacy, span_exporter, caplog):
+    """When a chain raises, the span should be ERROR with the message as description.
+
+    Pre-fix, ``span.set_status(Status(StatusCode.ERROR), str(error))`` made the
+    SDK log a ``"Description ... ignored. Use either Status or
+    (StatusCode, Description)"`` warning AND drop the description. This test
+    pins the post-fix behaviour: status description is set, no warning emitted.
+    """
+    # `span_exporter` is session-scoped (see conftest.py), so spans from earlier
+    # tests accumulate. Clear before invoking the chain so the assertions below
+    # only see spans produced by this test.
+    span_exporter.clear()
+
+    chain = RunnableLambda(_explode)
+
+    with caplog.at_level(logging.WARNING, logger="opentelemetry.sdk.trace"):
+        try:
+            chain.invoke("anything")
+        except ValueError:
+            pass  # expected
+
+    spans = span_exporter.get_finished_spans()
+    assert spans, "expected at least one span from the failing chain"
+
+    error_spans = [s for s in spans if s.status.status_code == StatusCode.ERROR]
+    assert error_spans, (
+        "expected at least one span marked ERROR; got statuses "
+        f"{[s.status.status_code for s in spans]}"
+    )
+
+    # The bug: pre-fix, status.description was None because the SDK dropped it.
+    for span in error_spans:
+        assert span.status.description == "boom: something went wrong", (
+            f"span {span.name!r} has description={span.status.description!r}; "
+            "expected the exception message to be preserved on the status."
+        )
+
+    # The bug also emits an SDK warning. After the fix, no such warning fires.
+    bad_warnings = [
+        rec
+        for rec in caplog.records
+        if rec.name == "opentelemetry.sdk.trace"
+        and "ignored" in rec.getMessage()
+        and "Use either" in rec.getMessage()
+    ]
+    assert not bad_warnings, (
+        "OTel SDK emitted a 'Description ... ignored' warning, meaning "
+        "set_status() was called with both a Status object and a separate "
+        "description argument. Messages: "
+        f"{[r.getMessage() for r in bad_warnings]}"
+    )


### PR DESCRIPTION
`Span.set_status(...)` per the OTel SDK contract silently drops the `description` argument and emits a warning when the first argument is already a `Status` object:

    Description ... ignored. Use either `Status` or `(StatusCode, Description)`

`TraceloopCallbackHandler._handle_error` was calling

    span.set_status(Status(StatusCode.ERROR), str(error))

so the human-readable error message was never set on the span's status, and every callback error caused a warning to be logged from `opentelemetry.sdk.trace`.

Pass the description inside `Status(...)` instead — matching the canonical pattern used elsewhere in the openllmetry monorepo (see PR #3970 for anthropic/groq/mistralai).

Adds `tests/test_error_status.py` as a regression test that pins the behaviour: the span's status description equals the exception message, and no `Description ... ignored` warning is emitted.

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [x] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error spans now include the exception message in their status description, ensuring tracing captures full error context and avoids lost descriptions.

* **Tests**
  * Added a regression test that verifies run-time errors produce spans marked ERROR with the exact exception message in the status description and that no SDK warnings about dropped descriptions are emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->