### PR TITLE
fix(openai): guard against AsyncAPIResponse without .id in async responses wrapper

### DIFF
--- a/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
+++ b/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
@@ -736,6 +736,9 @@ async def async_responses_get_or_create_wrapper(
         raise
     parsed_response = parse_response(response)
 
+    if not hasattr(parsed_response, "id"):
+        return response
+
     existing_data = responses.get(parsed_response.id)
     if existing_data is None:
         existing_data = {}

--- a/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
+++ b/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
@@ -234,10 +234,16 @@ def _derive_finish_reason(traced_data: TracedData) -> str:
     return ""
 
 
-def parse_response(response: Union[LegacyAPIResponse, APIResponse, AsyncAPIResponse, Response]) -> Response:
-    if isinstance(response, (LegacyAPIResponse, APIResponse, AsyncAPIResponse)):
+def parse_response(response: Union[LegacyAPIResponse, APIResponse, Response]) -> Response:
+    if isinstance(response, (LegacyAPIResponse, APIResponse)):
         return response.parse()
     return response
+
+
+async def async_parse_response(response: Union[LegacyAPIResponse, APIResponse, AsyncAPIResponse, Response]) -> Response:
+    if isinstance(response, AsyncAPIResponse):
+        return await response.parse()
+    return parse_response(response)
 
 
 def get_tools_from_kwargs(kwargs: dict) -> list[ToolParam]:
@@ -735,7 +741,7 @@ async def async_responses_get_or_create_wrapper(
             set_data_attributes(traced_data, span)
         span.end()
         raise
-    parsed_response = parse_response(response)
+    parsed_response = await async_parse_response(response)
 
     existing_data = responses.get(parsed_response.id)
     if existing_data is None:
@@ -854,7 +860,7 @@ async def async_responses_cancel_wrapper(
     response = await wrapped(*args, **kwargs)
     if isinstance(response, (Stream, AsyncStream)):
         return response
-    parsed_response = parse_response(response)
+    parsed_response = await async_parse_response(response)
     existing_data = responses.pop(parsed_response.id, None)
     if existing_data is not None:
         # Restore the original trace context to maintain trace continuity

--- a/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
+++ b/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
@@ -7,6 +7,7 @@ from typing import Any, Optional, Union
 
 from openai import AsyncStream, Stream
 from openai._legacy_response import LegacyAPIResponse
+from openai._response import APIResponse, AsyncAPIResponse
 from opentelemetry import context as context_api
 from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.semconv._incubating.attributes import (
@@ -233,8 +234,8 @@ def _derive_finish_reason(traced_data: TracedData) -> str:
     return ""
 
 
-def parse_response(response: Union[LegacyAPIResponse, Response]) -> Response:
-    if isinstance(response, LegacyAPIResponse):
+def parse_response(response: Union[LegacyAPIResponse, APIResponse, AsyncAPIResponse, Response]) -> Response:
+    if isinstance(response, (LegacyAPIResponse, APIResponse, AsyncAPIResponse)):
         return response.parse()
     return response
 
@@ -735,9 +736,6 @@ async def async_responses_get_or_create_wrapper(
         span.end()
         raise
     parsed_response = parse_response(response)
-
-    if not hasattr(parsed_response, "id"):
-        return response
 
     existing_data = responses.get(parsed_response.id)
     if existing_data is None:

--- a/packages/opentelemetry-instrumentation-openai/tests/traces/test_responses.py
+++ b/packages/opentelemetry-instrumentation-openai/tests/traces/test_responses.py
@@ -793,3 +793,26 @@ def test_response_stream_init_with_omit_reasoning():
     assert stream is not None
     assert stream._traced_data is not None
     assert stream._traced_data.request_reasoning_summary is None
+
+
+def test_parse_response_without_id_is_returned_safely(
+    instrument_legacy, span_exporter: InMemorySpanExporter
+):
+    """Regression test for https://github.com/traceloop/openllmetry/issues/4058:
+    parse_response returning an object without .id (e.g. AsyncAPIResponse) must not
+    crash instrumentation — guard should return early."""
+    from unittest.mock import MagicMock
+
+    from opentelemetry.instrumentation.openai.v1.responses_wrappers import parse_response
+
+    # Simulate what happens when parse_response receives an AsyncAPIResponse:
+    # it falls through to `return response` unchanged, giving back an object with no .id
+    raw_response = MagicMock(spec=[])  # spec=[] means NO attributes at all
+
+    # parse_response returns it as-is (not LegacyAPIResponse, so no .parse() call)
+    result = parse_response(raw_response)
+
+    # The result has no .id — this is the condition our guard checks
+    assert not hasattr(result, "id")
+    # And it is the exact same object passed in
+    assert result is raw_response

--- a/packages/opentelemetry-instrumentation-openai/tests/traces/test_responses.py
+++ b/packages/opentelemetry-instrumentation-openai/tests/traces/test_responses.py
@@ -836,21 +836,22 @@ def test_parse_response_unwraps_api_response():
     assert result.id == "resp_456"
 
 
-def test_parse_response_unwraps_async_api_response():
-    """parse_response must unwrap AsyncAPIResponse (async with_raw_response variant)."""
-    from unittest.mock import MagicMock, patch
+@pytest.mark.asyncio
+async def test_async_parse_response_unwraps_async_api_response():
+    """async_parse_response must unwrap AsyncAPIResponse using await."""
+    from unittest.mock import AsyncMock, MagicMock
     from openai._response import AsyncAPIResponse
-    from opentelemetry.instrumentation.openai.v1.responses_wrappers import parse_response
+    from opentelemetry.instrumentation.openai.v1.responses_wrappers import async_parse_response
 
     inner = MagicMock()
     inner.id = "resp_789"
 
     wrapper = MagicMock(spec=AsyncAPIResponse)
-    wrapper.parse.return_value = inner
+    wrapper.parse = AsyncMock(return_value=inner)
 
-    with patch.object(type(wrapper), "parse", return_value=inner, create=True):
-        result = parse_response(wrapper)
+    result = await async_parse_response(wrapper)
 
+    wrapper.parse.assert_awaited_once()
     assert result is inner
     assert result.id == "resp_789"
 

--- a/packages/opentelemetry-instrumentation-openai/tests/traces/test_responses.py
+++ b/packages/opentelemetry-instrumentation-openai/tests/traces/test_responses.py
@@ -795,24 +795,74 @@ def test_response_stream_init_with_omit_reasoning():
     assert stream._traced_data.request_reasoning_summary is None
 
 
-def test_parse_response_without_id_is_returned_safely(
-    instrument_legacy, span_exporter: InMemorySpanExporter
-):
+def test_parse_response_unwraps_legacy_api_response():
     """Regression test for https://github.com/traceloop/openllmetry/issues/4058:
-    parse_response returning an object without .id (e.g. AsyncAPIResponse) must not
-    crash instrumentation — guard should return early."""
+    parse_response must unwrap LegacyAPIResponse (what with_raw_response currently
+    returns for the Responses API) so downstream code can access .id without crashing."""
     from unittest.mock import MagicMock
-
+    from openai._legacy_response import LegacyAPIResponse
     from opentelemetry.instrumentation.openai.v1.responses_wrappers import parse_response
 
-    # Simulate what happens when parse_response receives an AsyncAPIResponse:
-    # it falls through to `return response` unchanged, giving back an object with no .id
-    raw_response = MagicMock(spec=[])  # spec=[] means NO attributes at all
+    inner = MagicMock()
+    inner.id = "resp_123"
 
-    # parse_response returns it as-is (not LegacyAPIResponse, so no .parse() call)
-    result = parse_response(raw_response)
+    wrapper = MagicMock(spec=LegacyAPIResponse)
+    wrapper.parse.return_value = inner
 
-    # The result has no .id — this is the condition our guard checks
-    assert not hasattr(result, "id")
-    # And it is the exact same object passed in
-    assert result is raw_response
+    result = parse_response(wrapper)
+
+    wrapper.parse.assert_called_once()
+    assert result is inner
+    assert result.id == "resp_123"
+
+
+def test_parse_response_unwraps_api_response():
+    """parse_response must also unwrap APIResponse/AsyncAPIResponse in case
+    the OpenAI SDK changes with_raw_response to return the non-legacy variants."""
+    from unittest.mock import MagicMock
+    from openai._response import APIResponse
+    from opentelemetry.instrumentation.openai.v1.responses_wrappers import parse_response
+
+    inner = MagicMock()
+    inner.id = "resp_456"
+
+    wrapper = MagicMock(spec=APIResponse)
+    wrapper.parse.return_value = inner
+
+    result = parse_response(wrapper)
+
+    wrapper.parse.assert_called_once()
+    assert result is inner
+    assert result.id == "resp_456"
+
+
+def test_parse_response_unwraps_async_api_response():
+    """parse_response must unwrap AsyncAPIResponse (async with_raw_response variant)."""
+    from unittest.mock import MagicMock, patch
+    from openai._response import AsyncAPIResponse
+    from opentelemetry.instrumentation.openai.v1.responses_wrappers import parse_response
+
+    inner = MagicMock()
+    inner.id = "resp_789"
+
+    wrapper = MagicMock(spec=AsyncAPIResponse)
+    wrapper.parse.return_value = inner
+
+    with patch.object(type(wrapper), "parse", return_value=inner, create=True):
+        result = parse_response(wrapper)
+
+    assert result is inner
+    assert result.id == "resp_789"
+
+
+def test_parse_response_passes_through_plain_response():
+    """parse_response should return a plain Response object unchanged."""
+    from unittest.mock import MagicMock
+    from opentelemetry.instrumentation.openai.v1.responses_wrappers import parse_response
+
+    plain = MagicMock()
+    plain.id = "resp_456"
+
+    result = parse_response(plain)
+
+    assert result is plain

--- a/packages/opentelemetry-instrumentation-openai/uv.lock
+++ b/packages/opentelemetry-instrumentation-openai/uv.lock
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-openai"
-version = "0.54.0"
+version = "0.60.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },

--- a/packages/sample-app/uv.lock
+++ b/packages/sample-app/uv.lock
@@ -3654,7 +3654,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-agno"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-agno" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3694,7 +3694,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-alephalpha"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-alephalpha" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3732,7 +3732,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-anthropic"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-anthropic" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3770,7 +3770,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-bedrock"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-bedrock" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3803,7 +3803,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-chromadb"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-chromadb" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3838,7 +3838,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-cohere"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-cohere" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3876,7 +3876,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-crewai"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-crewai" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3912,7 +3912,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-google-generativeai"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-google-generativeai" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3934,23 +3934,22 @@ provides-extras = ["instruments"]
 [package.metadata.requires-dev]
 dev = [
     { name = "autopep8", specifier = ">=2.2.0,<3" },
-    { name = "pytest", specifier = ">=8.2.2,<9" },
-    { name = "pytest-sugar", specifier = "==1.0.0" },
+    { name = "pytest", specifier = ">=8.2.2,<10" },
     { name = "ruff", specifier = ">=0.4.0" },
 ]
 test = [
     { name = "google-genai", specifier = ">=1.0.0,<2" },
     { name = "opentelemetry-sdk", specifier = ">=1.38.0,<2" },
-    { name = "pytest", specifier = ">=8.2.2,<9" },
+    { name = "pytest", specifier = ">=8.2.2,<10" },
     { name = "pytest-asyncio", specifier = ">=1.2.0,<2" },
     { name = "pytest-recording", specifier = ">=0.13.1,<0.14.0" },
-    { name = "pytest-sugar", specifier = "==1.0.0" },
+    { name = "pytest-sugar", specifier = "==1.1.1" },
     { name = "vcrpy", specifier = ">=8.0.0,<9" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-groq"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-groq" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3977,7 +3976,7 @@ dev = [
     { name = "ruff", specifier = ">=0.4.0" },
 ]
 test = [
-    { name = "groq", specifier = ">=0.18.0" },
+    { name = "groq", specifier = ">=1.2.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.38.0,<2" },
     { name = "pytest", specifier = ">=8.2.2,<9" },
     { name = "pytest-asyncio", specifier = ">=0.23.7,<0.24.0" },
@@ -3988,7 +3987,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-haystack"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-haystack" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4025,7 +4024,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-lancedb"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-lancedb" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4065,7 +4064,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-langchain"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-langchain" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4119,7 +4118,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-llamaindex"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-llamaindex" }
 dependencies = [
     { name = "inflection" },
@@ -4182,7 +4181,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-marqo"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-marqo" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4220,7 +4219,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-mcp"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-mcp" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4260,7 +4259,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-milvus"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-milvus" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4296,7 +4295,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-mistralai"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-mistralai" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4333,7 +4332,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-ollama"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-ollama" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4371,7 +4370,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-openai"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-openai" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4408,7 +4407,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-openai-agents"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-openai-agents" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4436,7 +4435,7 @@ dev = [
 ]
 test = [
     { name = "litellm", specifier = ">=1.71.2,<2" },
-    { name = "openai-agents", specifier = ">=0.6.9" },
+    { name = "openai-agents", specifier = ">=0.14.2" },
     { name = "opentelemetry-sdk", specifier = ">=1.38.0,<2" },
     { name = "pytest", specifier = ">=8.2.2,<9" },
     { name = "pytest-asyncio", specifier = ">=1.0.0,<2" },
@@ -4447,7 +4446,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-pinecone"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-pinecone" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4486,7 +4485,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-qdrant"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-qdrant" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4534,7 +4533,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-replicate"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-replicate" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4586,7 +4585,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-sagemaker"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-sagemaker" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4651,7 +4650,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-together"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-together" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4689,7 +4688,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-transformers"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-transformers" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4736,7 +4735,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-vertexai"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-vertexai" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4774,7 +4773,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-voyageai"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-voyageai" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4812,7 +4811,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-watsonx"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-watsonx" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4850,7 +4849,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-weaviate"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-weaviate" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4889,7 +4888,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-writer"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-writer" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -7030,7 +7029,7 @@ wheels = [
 
 [[package]]
 name = "traceloop-sdk"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../traceloop-sdk" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Fixes #4058 — OpenAI Agents crash when AsyncAPIResponse without .id is returned by parse_response 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Response parsing now correctly unwraps legacy, modern, and async response wrappers, returning the underlying response objects to avoid wrapped results and improve compatibility.

* **Tests**
  * Added unit tests verifying synchronous and asynchronous unwrapping for legacy and modern wrappers, and that plain response-like objects remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4078)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->