### PR TITLE
fix(anthropic): prevent KeyError/IndexError in streaming tool use delta handler

### DIFF
--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
@@ -48,12 +48,14 @@ def _process_response_item(item, complete_response):
                 complete_response["events"][index]["input"] = """"""
     elif item.type == "content_block_delta":
         index = item.index
-        if item.delta.type == "thinking_delta":
-            complete_response["events"][index]["text"] += item.delta.thinking
-        elif item.delta.type == "text_delta":
-            complete_response["events"][index]["text"] += item.delta.text
-        elif item.delta.type == "input_json_delta":
-            complete_response["events"][index]["input"] += item.delta.partial_json
+        if index < len(complete_response.get("events", [])):
+            event = complete_response["events"][index]
+            if item.delta.type == "thinking_delta":
+                event["text"] = event.get("text", "") + item.delta.thinking
+            elif item.delta.type == "text_delta":
+                event["text"] = event.get("text", "") + item.delta.text
+            elif item.delta.type == "input_json_delta":
+                event["input"] = event.get("input", "") + item.delta.partial_json
     elif item.type == "message_delta":
         for event in complete_response.get("events", []):
             event["finish_reason"] = item.delta.stop_reason

--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
@@ -55,7 +55,8 @@ def _process_response_item(item, complete_response):
             elif item.delta.type == "text_delta":
                 event["text"] = event.get("text", "") + item.delta.text
             elif item.delta.type == "input_json_delta":
-                event["input"] = event.get("input", "") + item.delta.partial_json
+                if event.get("type") == "tool_use":
+                    event["input"] = event.get("input", "") + item.delta.partial_json
     elif item.type == "message_delta":
         for event in complete_response.get("events", []):
             event["finish_reason"] = item.delta.stop_reason

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_messages.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_messages.py
@@ -2807,3 +2807,51 @@ async def test_async_anthropic_beta_message_stream_manager_legacy(
     assert len(logs) == 0, (
         "Assert that it doesn't emit logs when use_legacy_attributes is True"
     )
+
+
+def test_process_response_item_no_crash_on_out_of_order_delta():
+    """Regression test for https://github.com/traceloop/openllmetry/issues/4050:
+    content_block_delta arriving before content_block_start (or with a missing key)
+    must not raise KeyError or IndexError — it should be silently skipped."""
+    from unittest.mock import MagicMock
+
+    from opentelemetry.instrumentation.anthropic.streaming import _process_response_item
+
+    # Simulate a content_block_delta for index 0, but events list is empty
+    # (content_block_start hasn't arrived yet)
+    item = MagicMock()
+    item.type = "content_block_delta"
+    item.index = 0
+    item.delta.type = "input_json_delta"
+    item.delta.partial_json = '{"key": "value"}'
+
+    complete_response = {"events": []}  # no entry at index 0 yet
+
+    # Before the fix this raised IndexError; after the fix it silently skips
+    _process_response_item(item, complete_response)
+
+    # Events list unchanged — nothing written, nothing crashed
+    assert complete_response["events"] == []
+
+
+def test_process_response_item_no_crash_on_missing_input_key():
+    """Regression test for https://github.com/traceloop/openllmetry/issues/4050:
+    content_block_delta with input_json_delta on a non-tool_use block (no 'input' key)
+    must not raise KeyError."""
+    from unittest.mock import MagicMock
+
+    from opentelemetry.instrumentation.anthropic.streaming import _process_response_item
+
+    # A text block that was started without an 'input' key
+    item = MagicMock()
+    item.type = "content_block_delta"
+    item.index = 0
+    item.delta.type = "input_json_delta"
+    item.delta.partial_json = '{"key": "value"}'
+
+    complete_response = {"events": [{"index": 0, "text": "", "type": "text"}]}
+
+    # Before the fix this raised KeyError on ["input"]; after the fix it uses .get()
+    _process_response_item(item, complete_response)
+
+    assert complete_response["events"][0]["input"] == '{"key": "value"}'

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_messages.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_messages.py
@@ -2836,20 +2836,20 @@ def test_process_response_item_no_crash_on_out_of_order_delta():
 
 def test_process_response_item_no_crash_on_missing_input_key():
     """Regression test for https://github.com/traceloop/openllmetry/issues/4050:
-    content_block_delta with input_json_delta on a non-tool_use block (no 'input' key)
-    must not raise KeyError."""
+    input_json_delta arriving for a tool_use block that has no 'input' key
+    must not raise KeyError — it should initialize and accumulate normally."""
     from unittest.mock import MagicMock
 
     from opentelemetry.instrumentation.anthropic.streaming import _process_response_item
 
-    # A text block that was started without an 'input' key
+    # A tool_use block missing its "input" key (e.g. content_block_start didn't initialize it)
     item = MagicMock()
     item.type = "content_block_delta"
     item.index = 0
     item.delta.type = "input_json_delta"
     item.delta.partial_json = '{"key": "value"}'
 
-    complete_response = {"events": [{"index": 0, "text": "", "type": "text"}]}
+    complete_response = {"events": [{"index": 0, "type": "tool_use", "name": "my_tool"}]}
 
     # Before the fix this raised KeyError on ["input"]; after the fix it uses .get()
     _process_response_item(item, complete_response)

--- a/packages/opentelemetry-instrumentation-anthropic/uv.lock
+++ b/packages/opentelemetry-instrumentation-anthropic/uv.lock
@@ -348,7 +348,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-anthropic"
-version = "0.53.4"
+version = "0.60.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION
Fixes #4050 — KeyError/IndexError crash in Anthropic streaming tool use delta handler 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous streaming instrumentation for non-blocking monitoring.
* **Bug Fixes**
  * Improved robustness of streaming response handling to tolerate out-of-order content deltas and missing fields without failures.
* **Tests**
  * Added regression tests validating resilience of streaming handling in these edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4079)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->