### PR TITLE
fix(langchain): handle ToolNode in create_react_agent tool iteration

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/patch.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/patch.py
@@ -486,7 +486,14 @@ def create_agent_wrapper(tracer: Tracer, provider_name: str = "langchain"):
                 tools = args[1]
             if tools:
                 tool_definitions = []
-                for tool in tools:
+                # ToolNode wraps tools but is not itself iterable;
+                # fall back to its tools_by_name dict when available.
+                tools_iter = (
+                    tools.tools_by_name.values()
+                    if hasattr(tools, "tools_by_name")
+                    else tools
+                )
+                for tool in tools_iter:
                     tool_def = _extract_tool_definition(tool)
                     if tool_def:
                         tool_definitions.append(tool_def)

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_langgraph.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_langgraph.py
@@ -795,3 +795,61 @@ def test_middleware_super_call_succeeds_despite_outer_failure(instrument_legacy,
     # The span from super() call should succeed (before the ValueError is raised)
     middleware_span = middleware_spans[0]
     assert middleware_span.attributes[SpanAttributes.GEN_AI_TASK_STATUS] == "success"
+
+
+def test_create_react_agent_with_toolnode(instrument_legacy, span_exporter):
+    """Regression test for https://github.com/traceloop/openllmetry/issues/3841:
+    create_react_agent should not crash when tools is a ToolNode instead of a list."""
+    import json
+
+    from langchain_core.language_models import BaseChatModel
+    from langchain_core.messages import AIMessage
+    from langchain_core.outputs import ChatGeneration, ChatResult
+    from langchain_core.tools import tool
+    from langgraph.prebuilt import ToolNode, create_react_agent
+
+    class MockChatModel(BaseChatModel):
+        @property
+        def _llm_type(self) -> str:
+            return "mock"
+
+        def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+            return ChatResult(
+                generations=[ChatGeneration(message=AIMessage(content="Mock"))]
+            )
+
+        def bind_tools(self, tools, **kwargs):
+            return self
+
+    @tool
+    def get_weather(city: str) -> str:
+        """Get weather for a city."""
+        return f"Weather in {city}"
+
+    @tool
+    def get_time(timezone: str) -> str:
+        """Get current time in a timezone."""
+        return f"Time in {timezone}"
+
+    tool_node = ToolNode([get_weather, get_time])
+
+    # Before the fix this raised: TypeError: 'ToolNode' object is not iterable
+    _ = create_react_agent(
+        model=MockChatModel(), tools=tool_node, name="ToolNodeAgent"
+    )
+
+    spans = span_exporter.get_finished_spans()
+    create_span = next(s for s in spans if "create_agent" in s.name)
+
+    assert (
+        create_span.attributes[GenAIAttributes.GEN_AI_OPERATION_NAME]
+        == GenAiOperationNameValues.CREATE_AGENT.value
+    )
+    assert create_span.attributes[GenAIAttributes.GEN_AI_AGENT_NAME] == "ToolNodeAgent"
+    assert GenAIAttributes.GEN_AI_TOOL_DEFINITIONS in create_span.attributes
+
+    tool_defs = json.loads(
+        create_span.attributes[GenAIAttributes.GEN_AI_TOOL_DEFINITIONS]
+    )
+    tool_names = {td["name"] for td in tool_defs}
+    assert tool_names == {"get_weather", "get_time"}


### PR DESCRIPTION
Fixes #3841 — TypeError: ToolNode object is not iterable when using langgraph-supervisor with create_react_agent                                                                                                                                                 
Fixes #3921 — same root cause as #3841, duplicate issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent creation now accepts LangChain tool-wrapper objects and reliably generates GenAI tool definitions for telemetry.

* **Tests**
  * Added a regression test to verify agent creation with ToolNode-style tool inputs and confirm tool definitions are captured in telemetry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4081)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->