### PR TITLE
fix(langchain): use positional args for wrap_function_wrapper for wrapt v1/v2 compat, fix BaseChatOpenAI uninstrument

### DIFF
--- a/packages/opentelemetry-instrumentation-agno/opentelemetry/instrumentation/agno/__init__.py
+++ b/packages/opentelemetry-instrumentation-agno/opentelemetry/instrumentation/agno/__init__.py
@@ -71,29 +71,33 @@ class AgnoInstrumentor(BaseInstrumentor):
 
         # Wrap Agent methods
         wrap_function_wrapper(
-            module="agno.agent",
-            name="Agent.run",
-            wrapper=_AgentRunWrapper(tracer, duration_histogram, token_histogram),
+            "agno.agent",
+            "Agent.run",
+            _AgentRunWrapper(tracer, duration_histogram, token_histogram,
+        ),
         )
 
         wrap_function_wrapper(
-            module="agno.agent",
-            name="Agent.arun",
-            wrapper=_AgentARunWrapper(tracer, duration_histogram, token_histogram),
+            "agno.agent",
+            "Agent.arun",
+            _AgentARunWrapper(tracer, duration_histogram, token_histogram,
+        ),
         )
 
         # Wrap Team methods if available
         try:
             wrap_function_wrapper(
-                module="agno.team",
-                name="Team.run",
-                wrapper=_TeamRunWrapper(tracer, duration_histogram, token_histogram),
+            "agno.team",
+            "Team.run",
+            _TeamRunWrapper(tracer, duration_histogram, token_histogram,
+        ),
             )
 
             wrap_function_wrapper(
-                module="agno.team",
-                name="Team.arun",
-                wrapper=_TeamARunWrapper(tracer, duration_histogram, token_histogram),
+            "agno.team",
+            "Team.arun",
+            _TeamARunWrapper(tracer, duration_histogram, token_histogram,
+        ),
             )
         except Exception as e:
             logger.debug(f"Could not instrument Team: {e}")
@@ -101,19 +105,19 @@ class AgnoInstrumentor(BaseInstrumentor):
         # Wrap FunctionCall methods for tool execution
         try:
             wrap_function_wrapper(
-                module="agno.tools",
-                name="FunctionCall.execute",
-                wrapper=_FunctionCallExecuteWrapper(
-                    tracer, duration_histogram, token_histogram
-                ),
+            "agno.tools",
+            "FunctionCall.execute",
+            _FunctionCallExecuteWrapper(
+                    tracer, duration_histogram, token_histogram,
+        ),
             )
 
             wrap_function_wrapper(
-                module="agno.tools",
-                name="FunctionCall.aexecute",
-                wrapper=_FunctionCallAExecuteWrapper(
-                    tracer, duration_histogram, token_histogram
-                ),
+            "agno.tools",
+            "FunctionCall.aexecute",
+            _FunctionCallAExecuteWrapper(
+                    tracer, duration_histogram, token_histogram,
+        ),
             )
         except Exception as e:
             logger.debug(f"Could not instrument FunctionCall: {e}")

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
@@ -98,9 +98,10 @@ class LangchainInstrumentor(BaseInstrumentor):
             tracer, duration_histogram, token_histogram
         )
         wrap_function_wrapper(
-            module="langchain_core.callbacks",
-            name="BaseCallbackManager.__init__",
-            wrapper=_BaseCallbackManagerInitWrapper(traceloopCallbackHandler),
+            "langchain_core.callbacks",
+            "BaseCallbackManager.__init__",
+            _BaseCallbackManagerInitWrapper(traceloopCallbackHandler,
+        ),
         )
 
         # Wrap LangGraph components if available
@@ -115,67 +116,67 @@ class LangchainInstrumentor(BaseInstrumentor):
         if is_package_available("langchain_community"):
             # Wrap langchain_community.llms.openai.BaseOpenAI
             wrap_function_wrapper(
-                module="langchain_community.llms.openai",
-                name="BaseOpenAI._generate",
-                wrapper=openai_tracing_wrapper,
-            )
+            "langchain_community.llms.openai",
+            "BaseOpenAI._generate",
+            openai_tracing_wrapper,
+        )
 
             wrap_function_wrapper(
-                module="langchain_community.llms.openai",
-                name="BaseOpenAI._agenerate",
-                wrapper=openai_tracing_wrapper,
-            )
+            "langchain_community.llms.openai",
+            "BaseOpenAI._agenerate",
+            openai_tracing_wrapper,
+        )
 
             wrap_function_wrapper(
-                module="langchain_community.llms.openai",
-                name="BaseOpenAI._stream",
-                wrapper=openai_tracing_wrapper,
-            )
+            "langchain_community.llms.openai",
+            "BaseOpenAI._stream",
+            openai_tracing_wrapper,
+        )
 
             wrap_function_wrapper(
-                module="langchain_community.llms.openai",
-                name="BaseOpenAI._astream",
-                wrapper=openai_tracing_wrapper,
-            )
+            "langchain_community.llms.openai",
+            "BaseOpenAI._astream",
+            openai_tracing_wrapper,
+        )
 
         if is_package_available("langchain_openai"):
             # Wrap langchain_openai.llms.base.BaseOpenAI
             wrap_function_wrapper(
-                module="langchain_openai.llms.base",
-                name="BaseOpenAI._generate",
-                wrapper=openai_tracing_wrapper,
-            )
+            "langchain_openai.llms.base",
+            "BaseOpenAI._generate",
+            openai_tracing_wrapper,
+        )
 
             wrap_function_wrapper(
-                module="langchain_openai.llms.base",
-                name="BaseOpenAI._agenerate",
-                wrapper=openai_tracing_wrapper,
-            )
+            "langchain_openai.llms.base",
+            "BaseOpenAI._agenerate",
+            openai_tracing_wrapper,
+        )
 
             wrap_function_wrapper(
-                module="langchain_openai.llms.base",
-                name="BaseOpenAI._stream",
-                wrapper=openai_tracing_wrapper,
-            )
+            "langchain_openai.llms.base",
+            "BaseOpenAI._stream",
+            openai_tracing_wrapper,
+        )
 
             wrap_function_wrapper(
-                module="langchain_openai.llms.base",
-                name="BaseOpenAI._astream",
-                wrapper=openai_tracing_wrapper,
-            )
+            "langchain_openai.llms.base",
+            "BaseOpenAI._astream",
+            openai_tracing_wrapper,
+        )
 
             # langchain_openai.chat_models.base.BaseOpenAI
             wrap_function_wrapper(
-                module="langchain_openai.chat_models.base",
-                name="BaseChatOpenAI._generate",
-                wrapper=openai_tracing_wrapper,
-            )
+            "langchain_openai.chat_models.base",
+            "BaseChatOpenAI._generate",
+            openai_tracing_wrapper,
+        )
 
             wrap_function_wrapper(
-                module="langchain_openai.chat_models.base",
-                name="BaseChatOpenAI._agenerate",
-                wrapper=openai_tracing_wrapper,
-            )
+            "langchain_openai.chat_models.base",
+            "BaseChatOpenAI._agenerate",
+            openai_tracing_wrapper,
+        )
 
             # Doesn't work :(
             # wrap_function_wrapper(
@@ -195,14 +196,16 @@ class LangchainInstrumentor(BaseInstrumentor):
         if is_package_available("langgraph"):
             try:
                 wrap_function_wrapper(
-                    module="langgraph.pregel",
-                    name="Pregel.stream",
-                    wrapper=create_graph_invocation_wrapper(tracer, is_async=False),
+            "langgraph.pregel",
+            "Pregel.stream",
+            create_graph_invocation_wrapper(tracer, is_async=False,
+        ),
                 )
                 wrap_function_wrapper(
-                    module="langgraph.pregel",
-                    name="Pregel.astream",
-                    wrapper=create_graph_invocation_wrapper(tracer, is_async=True),
+            "langgraph.pregel",
+            "Pregel.astream",
+            create_graph_invocation_wrapper(tracer, is_async=True,
+        ),
                 )
             except Exception as e:
                 logger.debug("Failed to wrap Pregel methods: %s", e)
@@ -210,9 +213,10 @@ class LangchainInstrumentor(BaseInstrumentor):
             # Wrap Command.__init__ to capture routing commands
             try:
                 wrap_function_wrapper(
-                    module="langgraph.types",
-                    name="Command.__init__",
-                    wrapper=create_command_init_wrapper(tracer),
+            "langgraph.types",
+            "Command.__init__",
+            create_command_init_wrapper(tracer,
+        ),
                 )
             except Exception as e:
                 logger.debug("Failed to wrap Command.__init__: %s", e)
@@ -232,19 +236,19 @@ class LangchainInstrumentor(BaseInstrumentor):
             # Patch the actual module where the function is defined
             try:
                 wrap_function_wrapper(
-                    module="langgraph.prebuilt.chat_agent_executor",
-                    name="create_react_agent",
-                    wrapper=langgraph_agent_wrapper,
-                )
+            "langgraph.prebuilt.chat_agent_executor",
+            "create_react_agent",
+            langgraph_agent_wrapper,
+        )
             except Exception as e:
                 logger.debug("Failed to wrap langgraph.prebuilt.chat_agent_executor.create_react_agent: %s", e)
             # Also patch the re-export location for imports from langgraph.prebuilt
             try:
                 wrap_function_wrapper(
-                    module="langgraph.prebuilt",
-                    name="create_react_agent",
-                    wrapper=langgraph_agent_wrapper,
-                )
+            "langgraph.prebuilt",
+            "create_react_agent",
+            langgraph_agent_wrapper,
+        )
             except Exception as e:
                 logger.debug("Failed to wrap langgraph.prebuilt.create_react_agent: %s", e)
 
@@ -254,19 +258,19 @@ class LangchainInstrumentor(BaseInstrumentor):
             # Patch the actual module where the function is defined
             try:
                 wrap_function_wrapper(
-                    module="langchain.agents.factory",
-                    name="create_agent",
-                    wrapper=agent_wrapper,
-                )
+            "langchain.agents.factory",
+            "create_agent",
+            agent_wrapper,
+        )
             except Exception as e:
                 logger.debug("Failed to wrap langchain.agents.factory.create_agent: %s", e)
             # Also patch the re-export location for imports from langchain.agents
             try:
                 wrap_function_wrapper(
-                    module="langchain.agents",
-                    name="create_agent",
-                    wrapper=agent_wrapper,
-                )
+            "langchain.agents",
+            "create_agent",
+            agent_wrapper,
+        )
             except Exception as e:
                 logger.debug("Failed to wrap langchain.agents.create_agent: %s", e)
 
@@ -277,9 +281,9 @@ class LangchainInstrumentor(BaseInstrumentor):
         for hook_name in sync_hooks:
             try:
                 wrap_function_wrapper(
-                    module="langchain.agents.middleware.types",
-                    name=f"AgentMiddleware.{hook_name}",
-                    wrapper=create_middleware_hook_wrapper(tracer, hook_name),
+                    "langchain.agents.middleware.types",
+                    f"AgentMiddleware.{hook_name}",
+                    create_middleware_hook_wrapper(tracer, hook_name),
                 )
             except Exception as e:
                 logger.debug("Failed to wrap AgentMiddleware.%s: %s", hook_name, e)
@@ -289,9 +293,9 @@ class LangchainInstrumentor(BaseInstrumentor):
         for hook_name in async_hooks:
             try:
                 wrap_function_wrapper(
-                    module="langchain.agents.middleware.types",
-                    name=f"AgentMiddleware.{hook_name}",
-                    wrapper=create_async_middleware_hook_wrapper(tracer, hook_name),
+                    "langchain.agents.middleware.types",
+                    f"AgentMiddleware.{hook_name}",
+                    create_async_middleware_hook_wrapper(tracer, hook_name),
                 )
             except Exception as e:
                 logger.debug("Failed to wrap AgentMiddleware.%s: %s", hook_name, e)
@@ -354,8 +358,8 @@ class LangchainInstrumentor(BaseInstrumentor):
                 unwrap("langchain_openai.llms.base", "BaseOpenAI._agenerate")
                 unwrap("langchain_openai.llms.base", "BaseOpenAI._stream")
                 unwrap("langchain_openai.llms.base", "BaseOpenAI._astream")
-                unwrap("langchain_openai.chat_models.base", "BaseOpenAI._generate")
-                unwrap("langchain_openai.chat_models.base", "BaseOpenAI._agenerate")
+                unwrap("langchain_openai.chat_models.base", "BaseChatOpenAI._generate")
+                unwrap("langchain_openai.chat_models.base", "BaseChatOpenAI._agenerate")
                 # unwrap("langchain_openai.chat_models.base", "BaseOpenAI._stream")
                 # unwrap("langchain_openai.chat_models.base", "BaseOpenAI._astream")
 


### PR DESCRIPTION
Fixes #4009 — LangChain init crash: wrap_function_wrapper() got unexpected keyword argument 'module' when using wrapt v2                                                                                                                                       
                                                                                                                                                                                                                                                                   
Also fixes a pre-existing bug where _uninstrument() was unwrapping BaseOpenAI instead of BaseChatOpenAI in langchain_openai.chat_models.base, meaning those wrappers were never actually removed on uninstrument. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded OpenTelemetry instrumentation for Agno framework (Agent, Team, function execution)
  * Extended LangChain tracing for additional OpenAI LLM/chat backends and LangGraph components

* **Bug Fixes**
  * Corrected uninstrumentation behavior for improved removal of OpenAI-related wrappers

* **Improvements**
  * Standardized wrapper handling to make tracing more consistent across instrumentations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4082)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->