### PR TITLE
docs: fix Gemini instrumentation changelog typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -530,7 +530,7 @@
 - **openai**: record exception as span events as well (#3067)
 - **openai**: add request schema attribute (#3065)
 - **mcp**: add support for error_type in mcp instrumentation (#3050)
-- google gemini insturmentation (#3055)
+- google gemini instrumentation (#3055)
 - **openai**: completions.parse out of beta, azure remove double-slash (#3051)
 
 ## v0.40.14 (2025-06-24)


### PR DESCRIPTION
## Summary

Fixes a typo in the changelog entry for the Google Gemini instrumentation change.

## Testing

- `git diff --check`
- Confirmed `google gemini insturmentation` no longer appears in `CHANGELOG.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the changelog for a previous release.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4095)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->