### PR TITLE
fix(sdk): replace deprecated Pydantic .json() and double-encoding .model_dump_json() in JSONEncoders

### DIFF
--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/utils.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import json
 import logging
 import os
@@ -302,7 +303,12 @@ class JSONEncoder(json.JSONEncoder):
             return o.model_dump()
 
         if hasattr(o, "dict"):
-            return o.dict()
+            dict_method = o.dict
+            if callable(dict_method) and not inspect.iscoroutinefunction(dict_method):
+                result = dict_method()
+                if not inspect.iscoroutine(result):
+                    return result
+                result.close()
 
         try:
             return str(o)

--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/utils.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/utils.py
@@ -298,8 +298,11 @@ class JSONEncoder(json.JSONEncoder):
         if hasattr(o, "to_json"):
             return o.to_json()
 
-        if hasattr(o, "model_dump_json"):
-            return o.model_dump_json()
+        if hasattr(o, "model_dump"):
+            return o.model_dump()
+
+        if hasattr(o, "dict"):
+            return o.dict()
 
         try:
             return str(o)

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_json_encoder.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_json_encoder.py
@@ -1,0 +1,50 @@
+import json
+
+import pytest
+
+from opentelemetry.instrumentation.anthropic.utils import JSONEncoder
+
+
+class PydanticV2Model:
+    def model_dump(self):
+        return {"name": "Alice", "age": 30}
+
+
+class PydanticV1Model:
+    def dict(self):
+        return {"name": "Bob", "age": 25}
+
+
+def test_pydantic_v2_uses_model_dump():
+    assert json.loads(json.dumps(PydanticV2Model(), cls=JSONEncoder)) == {"name": "Alice", "age": 30}
+
+
+def test_pydantic_v2_no_double_encoding():
+    # Regression: model_dump_json() would emit a JSON-encoded string literal.
+    parsed = json.loads(json.dumps(PydanticV2Model(), cls=JSONEncoder))
+    assert isinstance(parsed, dict), "result must decode to a dict, not a string"
+
+
+def test_pydantic_v1_uses_dict():
+    assert json.loads(json.dumps(PydanticV1Model(), cls=JSONEncoder)) == {"name": "Bob", "age": 25}
+
+
+@pytest.mark.parametrize("model_factory", [
+    pytest.param(lambda: type("HasDictDataAttribute", (), {"dict": {"not": "callable"}})(),
+                 id="non-callable-dict"),
+])
+def test_non_pydantic_dict_attribute_does_not_crash(model_factory):
+    # Non-Pydantic objects with a `.dict` attribute must not raise TypeError.
+    # The anthropic encoder falls back to str(o) — just assert it doesn't crash.
+    result = json.dumps(model_factory(), cls=JSONEncoder)
+    assert isinstance(json.loads(result), str)
+
+
+def test_coroutine_dict_method_does_not_crash():
+    class AsyncDictModel:
+        async def dict(self):
+            return {"async": "result"}
+
+    # Must not emit un-encodable garbage; falls back to str(o).
+    result = json.dumps(AsyncDictModel(), cls=JSONEncoder)
+    assert isinstance(json.loads(result), str)

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/utils.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/utils.py
@@ -32,8 +32,8 @@ class CallbackFilteredJSONEncoder(json.JSONEncoder):
         if hasattr(o, "to_json"):
             return o.to_json()
 
-        if isinstance(o, BaseModel) and hasattr(o, "model_dump_json"):
-            return o.model_dump_json()
+        if isinstance(o, BaseModel) and hasattr(o, "model_dump"):
+            return o.model_dump()
 
         if isinstance(o, datetime.datetime):
             return o.isoformat()

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_json_encoder.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_json_encoder.py
@@ -1,0 +1,42 @@
+import json
+
+from pydantic import BaseModel
+
+from opentelemetry.instrumentation.langchain.utils import CallbackFilteredJSONEncoder
+
+
+class PydanticV2Model(BaseModel):
+    name: str
+    age: int
+
+
+def test_pydantic_v2_uses_model_dump():
+    model = PydanticV2Model(name="Alice", age=30)
+    assert json.loads(json.dumps(model, cls=CallbackFilteredJSONEncoder)) == {"name": "Alice", "age": 30}
+
+
+def test_pydantic_v2_no_double_encoding():
+    # Regression: model_dump_json() would emit a JSON-encoded string literal.
+    model = PydanticV2Model(name="Alice", age=30)
+    parsed = json.loads(json.dumps(model, cls=CallbackFilteredJSONEncoder))
+    assert isinstance(parsed, dict), "result must decode to a dict, not a string"
+
+
+def test_default_strips_callbacks_from_dict():
+    # The `isinstance(o, dict)` branch is only reachable when default() is
+    # invoked directly (json.dumps natively handles dicts and their subclasses
+    # without calling default()).
+    data = {"callbacks": ["cb1"], "key": "value"}
+    result = CallbackFilteredJSONEncoder().default(data)
+    assert "callbacks" not in result
+    assert result["key"] == "value"
+
+
+def test_non_basemodel_with_dict_attribute_is_not_called():
+    # The BaseModel gate prevents this from invoking the non-callable .dict attribute,
+    # which would otherwise raise TypeError.
+    class HasDictDataAttribute:
+        dict = {"not": "callable"}
+
+    result = json.dumps(HasDictDataAttribute(), cls=CallbackFilteredJSONEncoder)
+    assert isinstance(json.loads(result), str)

--- a/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/utils.py
+++ b/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/utils.py
@@ -76,6 +76,20 @@ class JSONEncoder(json.JSONEncoder):
                 if not inspect.iscoroutine(result):
                     return result
                 result.close()
+        if hasattr(o, "json"):
+            json_method = o.json
+            if callable(json_method) and not inspect.iscoroutinefunction(json_method):
+                result = json_method()
+                if inspect.iscoroutine(result):
+                    result.close()
+                elif isinstance(result, str):
+                    # .json() returns a JSON string; parse to avoid double-encoding.
+                    try:
+                        return json.loads(result)
+                    except (ValueError, TypeError):
+                        return result
+                else:
+                    return result
         return super().default(o)
 
 

--- a/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/utils.py
+++ b/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/utils.py
@@ -64,10 +64,12 @@ class JSONEncoder(json.JSONEncoder):
     def default(self, o):
         if dataclasses.is_dataclass(o):
             return dataclasses.asdict(o)
-        elif hasattr(o, "json"):
-            return o.json()
-        elif hasattr(o, "to_json"):
+        if hasattr(o, "to_json"):
             return o.to_json()
+        if hasattr(o, "model_dump"):
+            return o.model_dump()
+        if hasattr(o, "dict"):
+            return o.dict()
         return super().default(o)
 
 

--- a/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/utils.py
+++ b/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/utils.py
@@ -1,4 +1,5 @@
 import dataclasses
+import inspect
 import json
 import logging
 import os
@@ -69,7 +70,12 @@ class JSONEncoder(json.JSONEncoder):
         if hasattr(o, "model_dump"):
             return o.model_dump()
         if hasattr(o, "dict"):
-            return o.dict()
+            dict_method = o.dict
+            if callable(dict_method) and not inspect.iscoroutinefunction(dict_method):
+                result = dict_method()
+                if not inspect.iscoroutine(result):
+                    return result
+                result.close()
         return super().default(o)
 
 

--- a/packages/opentelemetry-instrumentation-llamaindex/tests/test_json_encoder.py
+++ b/packages/opentelemetry-instrumentation-llamaindex/tests/test_json_encoder.py
@@ -1,0 +1,71 @@
+import json
+
+import pytest
+
+from opentelemetry.instrumentation.llamaindex.utils import JSONEncoder
+
+
+class PydanticV2Model:
+    def model_dump(self):
+        return {"name": "Alice", "age": 30}
+
+
+class PydanticV1Model:
+    def dict(self):
+        return {"name": "Bob", "age": 25}
+
+
+class LegacyJsonModel:
+    def json(self):
+        return '{"name": "Charlie"}'
+
+
+def test_pydantic_v2_uses_model_dump():
+    assert json.loads(json.dumps(PydanticV2Model(), cls=JSONEncoder)) == {"name": "Alice", "age": 30}
+
+
+def test_pydantic_v2_no_double_encoding():
+    # Regression: model_dump_json() would emit a JSON-encoded string literal.
+    parsed = json.loads(json.dumps(PydanticV2Model(), cls=JSONEncoder))
+    assert isinstance(parsed, dict), "result must decode to a dict, not a string"
+
+
+def test_pydantic_v1_uses_dict():
+    assert json.loads(json.dumps(PydanticV1Model(), cls=JSONEncoder)) == {"name": "Bob", "age": 25}
+
+
+def test_legacy_json_method_fallback():
+    # Pydantic v1-style objects exposing only .json() must serialize without
+    # crashing or double-encoding.
+    assert json.loads(json.dumps(LegacyJsonModel(), cls=JSONEncoder)) == {"name": "Charlie"}
+
+
+def test_non_callable_json_attribute_does_not_crash():
+    class HasJsonDataAttribute:
+        json = {"not": "callable"}
+
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        json.dumps(HasJsonDataAttribute(), cls=JSONEncoder)
+
+
+def test_non_callable_dict_attribute_does_not_crash_with_typeerror():
+    # Non-Pydantic objects with a `.dict` data attribute would previously raise
+    # TypeError (dict is not callable). The guard now skips and falls through
+    # to super().default(), which raises TypeError for unknown types — but
+    # critically NOT from trying to call a non-callable.
+    class HasDictDataAttribute:
+        dict = {"not": "callable"}
+
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        json.dumps(HasDictDataAttribute(), cls=JSONEncoder)
+
+
+def test_coroutine_dict_method_does_not_emit_garbage():
+    # Async dict() returns a coroutine; encoder must skip rather than emit
+    # un-encodable garbage. Falls through to super().default().
+    class AsyncDictModel:
+        async def dict(self):
+            return {"async": "result"}
+
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        json.dumps(AsyncDictModel(), cls=JSONEncoder)

--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/utils.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import dataclasses
 import functools
+import inspect
 import json
 import logging
 import os
@@ -48,10 +49,27 @@ class JSONEncoder(json.JSONEncoder):
             return o.model_dump()
 
         if hasattr(o, "dict"):
-            return o.dict()
+            dict_method = o.dict
+            if callable(dict_method) and not inspect.iscoroutinefunction(dict_method):
+                result = dict_method()
+                if not inspect.iscoroutine(result):
+                    return result
+                result.close()
 
         if hasattr(o, "json"):
-            return o.json()
+            json_method = o.json
+            if callable(json_method) and not inspect.iscoroutinefunction(json_method):
+                result = json_method()
+                if inspect.iscoroutine(result):
+                    result.close()
+                elif isinstance(result, str):
+                    # .json() returns a JSON string; parse to avoid double-encoding.
+                    try:
+                        return json.loads(result)
+                    except (ValueError, TypeError):
+                        return result
+                else:
+                    return result
 
         if hasattr(o, "__class__"):
             return o.__class__.__name__

--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/utils.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/utils.py
@@ -44,9 +44,13 @@ class JSONEncoder(json.JSONEncoder):
         if hasattr(o, "to_json"):
             return o.to_json()
 
-        if hasattr(o, "model_dump_json"):
-            return o.model_dump_json()
-        elif hasattr(o, "json"):
+        if hasattr(o, "model_dump"):
+            return o.model_dump()
+
+        if hasattr(o, "dict"):
+            return o.dict()
+
+        if hasattr(o, "json"):
             return o.json()
 
         if hasattr(o, "__class__"):

--- a/packages/opentelemetry-instrumentation-openai-agents/tests/test_json_encoder.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/tests/test_json_encoder.py
@@ -1,0 +1,61 @@
+import json
+
+from opentelemetry.instrumentation.openai_agents.utils import JSONEncoder
+
+
+class PydanticV2Model:
+    def model_dump(self):
+        return {"name": "Alice", "age": 30}
+
+
+class PydanticV1Model:
+    def dict(self):
+        return {"name": "Bob", "age": 25}
+
+
+class LegacyJsonModel:
+    def json(self):
+        return '{"name": "Charlie"}'
+
+
+def test_pydantic_v2_uses_model_dump():
+    assert json.loads(json.dumps(PydanticV2Model(), cls=JSONEncoder)) == {"name": "Alice", "age": 30}
+
+
+def test_pydantic_v2_no_double_encoding():
+    # Regression: model_dump_json() would emit a JSON-encoded string literal.
+    parsed = json.loads(json.dumps(PydanticV2Model(), cls=JSONEncoder))
+    assert isinstance(parsed, dict), "result must decode to a dict, not a string"
+
+
+def test_pydantic_v1_uses_dict():
+    assert json.loads(json.dumps(PydanticV1Model(), cls=JSONEncoder)) == {"name": "Bob", "age": 25}
+
+
+def test_legacy_json_method_fallback():
+    assert json.loads(json.dumps(LegacyJsonModel(), cls=JSONEncoder)) == {"name": "Charlie"}
+
+
+def test_non_callable_dict_attribute_does_not_crash():
+    class HasDictDataAttribute:
+        dict = {"not": "callable"}
+
+    result = json.dumps(HasDictDataAttribute(), cls=JSONEncoder)
+    assert result == '"HasDictDataAttribute"'
+
+
+def test_coroutine_dict_method_does_not_crash():
+    class AsyncDictModel:
+        async def dict(self):
+            return {"async": "result"}
+
+    result = json.dumps(AsyncDictModel(), cls=JSONEncoder)
+    assert result == '"AsyncDictModel"'
+
+
+def test_non_callable_json_attribute_does_not_crash():
+    class HasJsonDataAttribute:
+        json = {"not": "callable"}
+
+    result = json.dumps(HasJsonDataAttribute(), cls=JSONEncoder)
+    assert result == '"HasJsonDataAttribute"'

--- a/packages/opentelemetry-instrumentation-openai-agents/uv.lock
+++ b/packages/opentelemetry-instrumentation-openai-agents/uv.lock
@@ -1307,7 +1307,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-openai-agents"
-version = "0.59.2"
+version = "0.60.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },

--- a/packages/traceloop-sdk/tests/test_json_encoder.py
+++ b/packages/traceloop-sdk/tests/test_json_encoder.py
@@ -2,8 +2,6 @@ import dataclasses
 import json
 import warnings
 
-import pytest
-
 from traceloop.sdk.utils.json_encoder import JSONEncoder
 
 
@@ -63,6 +61,36 @@ def test_pydantic_v1_uses_dict():
     assert result == '{"name": "Bob", "age": 25}'
 
 
+def test_legacy_json_method_fallback():
+    # Regression test for #3516: .json() was the original deprecated path.
+    # Objects exposing only .json() should still serialize without crashing.
+    result = json.loads(json.dumps(LegacyJsonModel(), cls=JSONEncoder))
+    assert result == {"name": "Charlie"}
+
+
+def test_non_callable_dict_attribute_does_not_crash():
+    # Many non-Pydantic objects (e.g., enum.DynamicClassAttribute) expose
+    # a non-callable `.dict` attribute. The encoder must skip it instead
+    # of raising TypeError.
+    class HasDictDataAttribute:
+        dict = {"not": "callable"}
+
+    # Should fall through to __class__ name rather than raising.
+    result = json.dumps(HasDictDataAttribute(), cls=JSONEncoder)
+    assert result == '"HasDictDataAttribute"'
+
+
+def test_coroutine_dict_method_does_not_crash():
+    # Async dict() (e.g., some ORM models) returns a coroutine.
+    # The encoder must skip and not emit un-encodable garbage.
+    class AsyncDictModel:
+        async def dict(self):
+            return {"async": "result"}
+
+    result = json.dumps(AsyncDictModel(), cls=JSONEncoder)
+    assert result == '"AsyncDictModel"'
+
+
 def test_to_json_takes_priority_over_model_dump():
     class Both:
         def to_json(self):
@@ -91,17 +119,12 @@ def test_no_pydantic_deprecation_warning():
         json.dumps(PydanticV2Model(), cls=JSONEncoder)
 
 
-def test_dict_with_callbacks_stripped():
-    # default() is only called for non-natively-serializable objects,
-    # so we wrap the dict in a custom object to trigger default()
-    class DictWrapper:
-        def __init__(self, d):
-            self._d = d
-        # no model_dump / dict / json — falls through to __class__ normally,
-        # but we simulate the "isinstance dict" path via a subclass
+def test_default_strips_callbacks_from_dict():
+    # The `isinstance(o, dict)` branch is only reachable when default() is
+    # invoked directly (json.dumps natively handles dicts and their subclasses
+    # without calling default()). Callers that hand a dict to .default()
+    # explicitly — e.g., upstream callback-filtering glue — get callbacks stripped.
     data = {"callbacks": ["cb1"], "key": "value"}
-    # Directly invoke default() since plain dicts bypass it
-    encoder = JSONEncoder()
-    result = encoder.default(data)
+    result = JSONEncoder().default(data)
     assert "callbacks" not in result
     assert result["key"] == "value"

--- a/packages/traceloop-sdk/tests/test_json_encoder.py
+++ b/packages/traceloop-sdk/tests/test_json_encoder.py
@@ -1,0 +1,107 @@
+import dataclasses
+import json
+import warnings
+
+import pytest
+
+from traceloop.sdk.utils.json_encoder import JSONEncoder
+
+
+# --- minimal Pydantic stubs (no real Pydantic dependency needed) ---
+
+class PydanticV2Model:
+    """Stub that mimics a Pydantic v2 model."""
+    def model_dump(self):
+        return {"name": "Alice", "age": 30}
+
+
+class PydanticV1Model:
+    """Stub that mimics a Pydantic v1 model (no model_dump)."""
+    def dict(self):
+        return {"name": "Bob", "age": 25}
+
+
+class LegacyJsonModel:
+    """Stub with only .json() — legacy path."""
+    def json(self):
+        return '{"name": "Charlie"}'
+
+
+class ToJsonModel:
+    """Stub with .to_json() — highest-priority path."""
+    def to_json(self):
+        return {"name": "Dave"}
+
+
+@dataclasses.dataclass
+class MyDataclass:
+    x: int
+    y: str
+
+
+class PlainObject:
+    pass
+
+
+# --- tests ---
+
+def test_pydantic_v2_uses_model_dump():
+    result = json.dumps(PydanticV2Model(), cls=JSONEncoder)
+    assert result == '{"name": "Alice", "age": 30}'
+
+
+def test_pydantic_v2_no_double_encoding():
+    # If model_dump_json() were used instead of model_dump(), the output would be
+    # a JSON-encoded string literal: '"{\\"name\\": \\"Alice\\"}"'
+    result = json.dumps(PydanticV2Model(), cls=JSONEncoder)
+    parsed = json.loads(result)
+    assert isinstance(parsed, dict), "result must decode to a dict, not a string"
+
+
+def test_pydantic_v1_uses_dict():
+    result = json.dumps(PydanticV1Model(), cls=JSONEncoder)
+    assert result == '{"name": "Bob", "age": 25}'
+
+
+def test_to_json_takes_priority_over_model_dump():
+    class Both:
+        def to_json(self):
+            return {"source": "to_json"}
+        def model_dump(self):
+            return {"source": "model_dump"}
+
+    result = json.loads(json.dumps(Both(), cls=JSONEncoder))
+    assert result["source"] == "to_json"
+
+
+def test_dataclass_serialization():
+    result = json.loads(json.dumps(MyDataclass(x=1, y="hello"), cls=JSONEncoder))
+    assert result == {"x": 1, "y": "hello"}
+
+
+def test_plain_object_falls_back_to_class_name():
+    result = json.dumps(PlainObject(), cls=JSONEncoder)
+    assert result == '"PlainObject"'
+
+
+def test_no_pydantic_deprecation_warning():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        # Should not raise any DeprecationWarning
+        json.dumps(PydanticV2Model(), cls=JSONEncoder)
+
+
+def test_dict_with_callbacks_stripped():
+    # default() is only called for non-natively-serializable objects,
+    # so we wrap the dict in a custom object to trigger default()
+    class DictWrapper:
+        def __init__(self, d):
+            self._d = d
+        # no model_dump / dict / json — falls through to __class__ normally,
+        # but we simulate the "isinstance dict" path via a subclass
+    data = {"callbacks": ["cb1"], "key": "value"}
+    # Directly invoke default() since plain dicts bypass it
+    encoder = JSONEncoder()
+    result = encoder.default(data)
+    assert "callbacks" not in result
+    assert result["key"] == "value"

--- a/packages/traceloop-sdk/traceloop/sdk/utils/json_encoder.py
+++ b/packages/traceloop-sdk/traceloop/sdk/utils/json_encoder.py
@@ -15,6 +15,17 @@ class JSONEncoder(json.JSONEncoder):
         if hasattr(o, "to_json"):
             return o.to_json()
 
+        if hasattr(o, "model_dump"):
+            return o.model_dump()
+
+        if hasattr(o, "dict"):
+            dict_method = o.dict
+            if callable(dict_method) and not inspect.iscoroutinefunction(dict_method):
+                result = dict_method()
+                if not inspect.iscoroutine(result):
+                    return result
+                result.close()
+
         if hasattr(o, "json"):
             json_method = o.json
             if callable(json_method) and not inspect.iscoroutinefunction(json_method):

--- a/packages/traceloop-sdk/traceloop/sdk/utils/json_encoder.py
+++ b/packages/traceloop-sdk/traceloop/sdk/utils/json_encoder.py
@@ -30,9 +30,16 @@ class JSONEncoder(json.JSONEncoder):
             json_method = o.json
             if callable(json_method) and not inspect.iscoroutinefunction(json_method):
                 result = json_method()
-                if not inspect.iscoroutine(result):
+                if inspect.iscoroutine(result):
+                    result.close()
+                elif isinstance(result, str):
+                    # .json() returns a JSON string; parse to avoid double-encoding.
+                    try:
+                        return json.loads(result)
+                    except (ValueError, TypeError):
+                        return result
+                else:
                     return result
-                result.close()
 
         if hasattr(o, "__class__"):
             return o.__class__.__name__


### PR DESCRIPTION
Fixes #3516. Applies across sdk, llamaindex, openai-agents, langchain, and anthropic packages.

Problem:                                                                                                                                                                                                                                                                                                 
Several JSONEncoder classes across the repo were serializing Pydantic models using either .json() (deprecated in Pydantic v2) or .model_dump_json() (returns a JSON string). Using .model_dump_json() inside JSONEncoder.default() causes double-encoding — the string gets JSON-encoded again by the
outer encoder, turning {"name": "Alice"} into "{\"name\": \"Alice\"}".                                                                                                                                                                                                                                   
   
Fix:                                                                                                                                                                                                                                                                                                     
Replace both with .model_dump() (Pydantic v2) which returns a plain dict — exactly what JSONEncoder.default() expects. A .dict() fallback covers Pydantic v1, and .json() is kept at the end as a last resort for non-Pydantic objects that happen to have that method. Applied consistently across 5
packages: sdk, llamaindex, openai-agents, langchain, anthropic.    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved JSON serialization across instrumentations: prefers modern model representations, avoids double-encoding, and handles non-standard or asynchronous object outputs more safely to produce stable, predictable JSON.

* **Tests**
  * Added comprehensive tests covering serialization ordering, dataclass and model support, async-safe handling, legacy fallbacks, and regression safeguards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4098?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->