### PR TITLE
fix(anthropic): fix double-counted input tokens in non-streaming create() paths

### DIFF
--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
@@ -229,7 +229,7 @@ async def _aset_token_usage(
         cache_read_tokens = 0
         cache_creation_tokens = 0
 
-    input_tokens = prompt_tokens + cache_read_tokens + cache_creation_tokens
+    input_tokens = prompt_tokens
 
     if token_histogram and isinstance(input_tokens, int) and input_tokens >= 0:
         token_histogram.record(
@@ -345,7 +345,7 @@ def _set_token_usage(
         cache_read_tokens = 0
         cache_creation_tokens = 0
 
-    input_tokens = prompt_tokens + cache_read_tokens + cache_creation_tokens
+    input_tokens = prompt_tokens
 
     if token_histogram and isinstance(input_tokens, int) and input_tokens >= 0:
         token_histogram.record(

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_prompt_caching.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_prompt_caching.py
@@ -127,7 +127,7 @@ def test_anthropic_prompt_caching_legacy(
     assert json.loads(cache_creation_span.attributes[GenAIAttributes.GEN_AI_OUTPUT_MESSAGES])[-1]["role"] == "assistant"
     assert json.loads(cache_read_span.attributes[GenAIAttributes.GEN_AI_OUTPUT_MESSAGES])[-1]["role"] == "assistant"
 
-    _verify_caching_attributes(cache_creation_span, cache_read_span, 1167, 187, 202, 1163)
+    _verify_caching_attributes(cache_creation_span, cache_read_span, 4, 187, 202, 1163)
 
     # verify metrics
     metrics_data = reader.get_metrics_data()
@@ -191,7 +191,7 @@ def test_anthropic_prompt_caching_with_events_with_content(
     cache_creation_span = spans[0]
     cache_read_span = spans[1]
 
-    _verify_caching_attributes(cache_creation_span, cache_read_span, 1167, 187, 202, 1163)
+    _verify_caching_attributes(cache_creation_span, cache_read_span, 4, 187, 202, 1163)
 
     # verify metrics
     metrics_data = reader.get_metrics_data()
@@ -353,7 +353,7 @@ def test_anthropic_prompt_caching_with_events_with_no_content(
     cache_creation_span = spans[0]
     cache_read_span = spans[1]
 
-    _verify_caching_attributes(cache_creation_span, cache_read_span, 1167, 187, 202, 1163)
+    _verify_caching_attributes(cache_creation_span, cache_read_span, 4, 187, 202, 1163)
 
     # verify metrics
     metrics_data = reader.get_metrics_data()
@@ -460,7 +460,7 @@ async def test_anthropic_prompt_caching_async_legacy(
     assert json.loads(cache_creation_span.attributes[GenAIAttributes.GEN_AI_OUTPUT_MESSAGES])[-1]["role"] == "assistant"
     assert json.loads(cache_read_span.attributes[GenAIAttributes.GEN_AI_OUTPUT_MESSAGES])[-1]["role"] == "assistant"
 
-    _verify_caching_attributes(cache_creation_span, cache_read_span, 1169, 207, 224, 1165)
+    _verify_caching_attributes(cache_creation_span, cache_read_span, 4, 207, 224, 1165)
 
     # verify metrics
     metrics_data = reader.get_metrics_data()
@@ -525,7 +525,7 @@ async def test_anthropic_prompt_caching_async_with_events_with_content(
     cache_creation_span = spans[0]
     cache_read_span = spans[1]
 
-    _verify_caching_attributes(cache_creation_span, cache_read_span, 1169, 207, 224, 1165)
+    _verify_caching_attributes(cache_creation_span, cache_read_span, 4, 207, 224, 1165)
 
     # verify metrics
     metrics_data = reader.get_metrics_data()
@@ -698,7 +698,7 @@ async def test_anthropic_prompt_caching_async_with_events_with_no_content(
         == cache_read_span.attributes["gen_ai.usage.cache_read.input_tokens"]
     )
 
-    _verify_caching_attributes(cache_creation_span, cache_read_span, 1169, 207, 224, 1165)
+    _verify_caching_attributes(cache_creation_span, cache_read_span, 4, 207, 224, 1165)
 
     # verify metrics
     metrics_data = reader.get_metrics_data()

--- a/packages/opentelemetry-instrumentation-anthropic/uv.lock
+++ b/packages/opentelemetry-instrumentation-anthropic/uv.lock
@@ -348,7 +348,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-anthropic"
-version = "0.53.4"
+version = "0.60.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION
Fixes #3949. Complements PR #3976 which fixed the same arithmetic in                                                                                                                                                                                                                                     
the streaming path.                 

The problem was that Cache sub-tokens (cache_read, cache_creation) were being added to                                                                                                                                                                                                                                        
input_tokens, which already includes them per the Anthropic API spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed token usage accounting in Anthropic instrumentation where input tokens were incorrectly including cached prompt tokens. Input tokens are now calculated using only prompt tokens, with cached token metrics available as separate attributes.

## Tests
* Updated test cases to reflect the corrected token counting behavior for Anthropic prompt caching scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4099)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->