### PR TITLE
fix(langchain,anthropic,groq,mistralai,bedrock,ollama,sagemaker,together): record exceptions and set ERROR status on failed spans

### DIFF
--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
@@ -51,6 +51,7 @@ from opentelemetry.semconv_ai import (
 )
 from opentelemetry.trace import Span, SpanKind, Tracer, get_tracer
 from opentelemetry.trace.status import Status, StatusCode
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from typing_extensions import Coroutine
 from wrapt import wrap_function_wrapper
 
@@ -575,6 +576,10 @@ def _wrap(
         if exception_counter:
             exception_counter.add(1, attributes=attributes)
 
+        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+        span.record_exception(e)
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        span.end()
         raise e
 
     end_time = time.time()
@@ -703,6 +708,10 @@ async def _awrap(
         if exception_counter:
             exception_counter.add(1, attributes=attributes)
 
+        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+        span.record_exception(e)
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        span.end()
         raise e
 
     if is_streaming_response(response):

--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
@@ -44,6 +44,7 @@ from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
     GenAiOperationNameValues,
     GenAiSystemValues,
 )
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from opentelemetry.semconv_ai import (
     SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY,
     Meters,
@@ -51,7 +52,6 @@ from opentelemetry.semconv_ai import (
 )
 from opentelemetry.trace import Span, SpanKind, Tracer, get_tracer
 from opentelemetry.trace.status import Status, StatusCode
-from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from typing_extensions import Coroutine
 from wrapt import wrap_function_wrapper
 
@@ -580,7 +580,7 @@ def _wrap(
         span.record_exception(e)
         span.set_status(Status(StatusCode.ERROR, str(e)))
         span.end()
-        raise e
+        raise
 
     end_time = time.time()
 
@@ -712,7 +712,7 @@ async def _awrap(
         span.record_exception(e)
         span.set_status(Status(StatusCode.ERROR, str(e)))
         span.end()
-        raise e
+        raise
 
     if is_streaming_response(response):
         return AnthropicAsyncStream(

--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
@@ -259,7 +259,7 @@ class AnthropicStream(ObjectProxy):
             attributes = error_metrics_attributes(e)
             if self._exception_counter:
                 self._exception_counter.add(1, attributes=attributes)
-            raise e
+            raise
         _process_response_item(item, self._complete_response)
         return item
 

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_completion.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_completion.py
@@ -19,13 +19,6 @@ def test_anthropic_completion_legacy(
         max_tokens_to_sample=2048,
         top_p=0.1,
     )
-    try:
-        anthropic_client.completions.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     spans = span_exporter.get_finished_spans()
     assert all(span.name == "anthropic.completion" for span in spans)
 
@@ -65,13 +58,6 @@ def test_anthropic_completion_with_events_with_content(
         max_tokens_to_sample=2048,
         top_p=0.1,
     )
-    try:
-        anthropic_client.completions.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     spans = span_exporter.get_finished_spans()
     assert all(span.name == "anthropic.completion" for span in spans)
 
@@ -109,13 +95,6 @@ def test_anthropic_completion_with_events_with_no_content(
         max_tokens_to_sample=2048,
         top_p=0.1,
     )
-    try:
-        anthropic_client.completions.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     spans = span_exporter.get_finished_spans()
     assert all(span.name == "anthropic.completion" for span in spans)
 

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_messages.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_messages.py
@@ -258,7 +258,7 @@ def test_anthropic_multi_modal_legacy(
         model="claude-3-opus-20240229",
     )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -322,7 +322,7 @@ def test_anthropic_multi_modal_with_events_with_content(
         model="claude-3-opus-20240229",
     )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -383,7 +383,7 @@ def test_anthropic_multi_modal_with_events_with_no_content(
         model="claude-3-opus-20240229",
     )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -449,7 +449,7 @@ def test_anthropic_image_with_history(
         ],
     )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert all(span.name == "anthropic.chat" for span in spans)
 
     # span 0: system + first user message
@@ -514,7 +514,7 @@ async def test_anthropic_async_multi_modal_legacy(
         model="claude-3-opus-20240229",
     )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -579,7 +579,7 @@ async def test_anthropic_async_multi_modal_with_events_with_content(
         model="claude-3-opus-20240229",
     )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -641,7 +641,7 @@ async def test_anthropic_async_multi_modal_with_events_with_no_content(
         model="claude-3-opus-20240229",
     )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2193,7 +2193,7 @@ def test_with_asyncio_run_legacy(
         )
     )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2227,7 +2227,7 @@ def test_with_asyncio_run_with_events_with_content(
         )
     )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2285,7 +2285,7 @@ def test_with_asyncio_run_with_events_with_no_content(
         )
     )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2715,7 +2715,7 @@ async def test_anthropic_streaming_helper_methods_legacy(
         assert hasattr(stream, 'text_stream')
         assert hasattr(stream, 'until_done')
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert len(spans) == 1, f"Expected 1 span, got {len(spans)}"
     assert spans[0].name == "anthropic.chat"
 
@@ -2741,7 +2741,7 @@ async def test_anthropic_text_stream_helper_method_legacy(
         async for text in stream.text_stream:
             text_content += text
         assert len(text_content) > 0
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     print(f"Number of spans created: {len(spans)}")
     assert len(spans) == 1, f"Expected 1 span, got {len(spans)}"
     assert spans[0].name == "anthropic.chat"
@@ -2768,7 +2768,7 @@ def test_anthropic_sync_streaming_helper_methods_legacy(
         for event in stream:
             events.append(event)
         assert len(events) > 0
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
     assert spans[0].name == "anthropic.chat"
 
@@ -2795,7 +2795,7 @@ async def test_async_anthropic_beta_message_stream_manager_legacy(
 
     assert response_content != ""
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_messages.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_messages.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 from opentelemetry.sdk._logs import ReadableLogRecord
-from opentelemetry.trace.status import StatusCode
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
@@ -79,14 +78,7 @@ def test_anthropic_message_create_legacy(
         ],
         model="claude-3-opus-20240229",
     )
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert all(span.name == "anthropic.chat" for span in spans)
 
     anthropic_span = spans[0]
@@ -133,14 +125,7 @@ def test_anthropic_message_create_with_events_with_content(
         ],
         model="claude-3-opus-20240229",
     )
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert all(span.name == "anthropic.chat" for span in spans)
 
     anthropic_span = spans[0]
@@ -198,14 +183,7 @@ def test_anthropic_message_create_with_events_with_no_content(
         ],
         model="claude-3-opus-20240229",
     )
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert all(span.name == "anthropic.chat" for span in spans)
 
     anthropic_span = spans[0]
@@ -684,19 +662,12 @@ def test_anthropic_message_streaming_legacy(
         model="claude-3-haiku-20240307",
         stream=True,
     )
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     response_content = ""
     for event in response:
         if event.type == "content_block_delta" and event.delta.type == "text_delta":
             response_content += event.delta.text
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -745,19 +716,12 @@ def test_anthropic_message_streaming_with_events_with_content(
         model="claude-3-haiku-20240307",
         stream=True,
     )
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     response_content = ""
     for event in response:
         if event.type == "content_block_delta" and event.delta.type == "text_delta":
             response_content += event.delta.text
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -810,19 +774,12 @@ def test_anthropic_message_streaming_with_events_with_no_content(
         model="claude-3-haiku-20240307",
         stream=True,
     )
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     response_content = ""
     for event in response:
         if event.type == "content_block_delta" and event.delta.type == "text_delta":
             response_content += event.delta.text
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -870,14 +827,7 @@ async def test_async_anthropic_message_create_legacy(
         ],
         model="claude-3-opus-20240229",
     )
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -924,14 +874,7 @@ async def test_async_anthropic_message_create_with_events_with_content(
         messages=[user_message],
         model="claude-3-opus-20240229",
     )
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -982,14 +925,7 @@ async def test_async_anthropic_message_create_with_events_with_no_content(
         ],
         model="claude-3-opus-20240229",
     )
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -1026,13 +962,6 @@ async def test_async_anthropic_message_create_with_events_with_no_content(
 async def test_async_anthropic_message_streaming_legacy(
     instrument_legacy, async_anthropic_client, span_exporter, log_exporter, reader
 ):
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     response = await async_anthropic_client.messages.create(
         max_tokens=1024,
         messages=[
@@ -1049,7 +978,7 @@ async def test_async_anthropic_message_streaming_legacy(
         if event.type == "content_block_delta" and event.delta.type == "text_delta":
             response_content += event.delta.text
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -1087,13 +1016,6 @@ async def test_async_anthropic_message_streaming_legacy(
 async def test_async_anthropic_message_streaming_with_events_with_content(
     instrument_with_content, async_anthropic_client, span_exporter, log_exporter, reader
 ):
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     user_message = {
         "role": "user",
         "content": "Tell me a joke about OpenTelemetry",
@@ -1110,7 +1032,7 @@ async def test_async_anthropic_message_streaming_with_events_with_content(
         if event.type == "content_block_delta" and event.delta.type == "text_delta":
             response_content += event.delta.text
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -1151,13 +1073,6 @@ async def test_async_anthropic_message_streaming_with_events_with_no_content(
     log_exporter,
     reader,
 ):
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     response = await async_anthropic_client.messages.create(
         max_tokens=1024,
         messages=[
@@ -1174,7 +1089,7 @@ async def test_async_anthropic_message_streaming_with_events_with_no_content(
         if event.type == "content_block_delta" and event.delta.type == "text_delta":
             response_content += event.delta.text
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -1221,14 +1136,7 @@ def test_anthropic_tools_legacy(
             }
         ],
     )
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -1325,13 +1233,7 @@ def test_anthropic_tools_with_events_with_content(
         tools=TOOLS,
         messages=[user_message],
     )
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -1426,14 +1328,7 @@ def test_anthropic_tools_with_events_with_no_content(
             }
         ],
     )
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -1548,14 +1443,7 @@ def test_anthropic_tools_history_legacy(
         ],
     )
 
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -1682,14 +1570,7 @@ def test_anthropic_tools_history_with_events_with_content(
             tool_result_message,
         ],
     )
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -1784,14 +1665,7 @@ def test_anthropic_tools_history_with_events_with_no_content(
             tool_result_message,
         ],
     )
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -1862,18 +1736,11 @@ def test_anthropic_tools_streaming_legacy(
         stream=True,
     )
 
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     # consume the streaming iterator
     for _ in response:
         pass
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -1978,13 +1845,7 @@ def test_anthropic_tools_streaming_with_events_with_content(
     for _ in response:
         pass
 
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -2090,13 +1951,7 @@ def test_anthropic_tools_streaming_with_events_with_no_content(
     for _ in response:
         pass
 
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -2343,14 +2198,7 @@ def test_anthropic_message_stream_manager_legacy(
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2403,14 +2251,7 @@ def test_anthropic_message_stream_manager_with_events_with_content(
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2467,14 +2308,7 @@ def test_anthropic_message_stream_manager_with_events_with_no_content(
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2527,14 +2361,7 @@ async def test_async_anthropic_message_stream_manager_legacy(
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2572,13 +2399,6 @@ async def test_async_anthropic_message_stream_manager_legacy(
 async def test_async_anthropic_message_stream_manager_with_events_with_content(
     instrument_with_content, async_anthropic_client, span_exporter, log_exporter, reader
 ):
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     user_message = {
         "role": "user",
         "content": "Tell me a joke about OpenTelemetry",
@@ -2594,7 +2414,7 @@ async def test_async_anthropic_message_stream_manager_with_events_with_content(
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2635,13 +2455,6 @@ async def test_async_anthropic_message_stream_manager_with_events_with_no_conten
     log_exporter,
     reader,
 ):
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     response_content = ""
     async with async_anthropic_client.messages.stream(
         max_tokens=1024,
@@ -2657,7 +2470,7 @@ async def test_async_anthropic_message_stream_manager_with_events_with_no_conten
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_messages.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_messages.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 from opentelemetry.sdk._logs import ReadableLogRecord
+from opentelemetry.trace.status import StatusCode
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
@@ -85,7 +86,7 @@ def test_anthropic_message_create_legacy(
     except Exception:
         pass
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert all(span.name == "anthropic.chat" for span in spans)
 
     anthropic_span = spans[0]
@@ -139,7 +140,7 @@ def test_anthropic_message_create_with_events_with_content(
     except Exception:
         pass
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert all(span.name == "anthropic.chat" for span in spans)
 
     anthropic_span = spans[0]
@@ -204,7 +205,7 @@ def test_anthropic_message_create_with_events_with_no_content(
     except Exception:
         pass
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert all(span.name == "anthropic.chat" for span in spans)
 
     anthropic_span = spans[0]
@@ -257,7 +258,7 @@ def test_anthropic_multi_modal_legacy(
         model="claude-3-opus-20240229",
     )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -321,7 +322,7 @@ def test_anthropic_multi_modal_with_events_with_content(
         model="claude-3-opus-20240229",
     )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -382,7 +383,7 @@ def test_anthropic_multi_modal_with_events_with_no_content(
         model="claude-3-opus-20240229",
     )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -448,7 +449,7 @@ def test_anthropic_image_with_history(
         ],
     )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert all(span.name == "anthropic.chat" for span in spans)
 
     # span 0: system + first user message
@@ -513,7 +514,7 @@ async def test_anthropic_async_multi_modal_legacy(
         model="claude-3-opus-20240229",
     )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -578,7 +579,7 @@ async def test_anthropic_async_multi_modal_with_events_with_content(
         model="claude-3-opus-20240229",
     )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -640,7 +641,7 @@ async def test_anthropic_async_multi_modal_with_events_with_no_content(
         model="claude-3-opus-20240229",
     )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -695,7 +696,7 @@ def test_anthropic_message_streaming_legacy(
         if event.type == "content_block_delta" and event.delta.type == "text_delta":
             response_content += event.delta.text
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -756,7 +757,7 @@ def test_anthropic_message_streaming_with_events_with_content(
         if event.type == "content_block_delta" and event.delta.type == "text_delta":
             response_content += event.delta.text
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -821,7 +822,7 @@ def test_anthropic_message_streaming_with_events_with_no_content(
         if event.type == "content_block_delta" and event.delta.type == "text_delta":
             response_content += event.delta.text
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -876,7 +877,7 @@ async def test_async_anthropic_message_create_legacy(
     except Exception:
         pass
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -930,7 +931,7 @@ async def test_async_anthropic_message_create_with_events_with_content(
     except Exception:
         pass
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -988,7 +989,7 @@ async def test_async_anthropic_message_create_with_events_with_no_content(
     except Exception:
         pass
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -1048,7 +1049,7 @@ async def test_async_anthropic_message_streaming_legacy(
         if event.type == "content_block_delta" and event.delta.type == "text_delta":
             response_content += event.delta.text
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -1109,7 +1110,7 @@ async def test_async_anthropic_message_streaming_with_events_with_content(
         if event.type == "content_block_delta" and event.delta.type == "text_delta":
             response_content += event.delta.text
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -1173,7 +1174,7 @@ async def test_async_anthropic_message_streaming_with_events_with_no_content(
         if event.type == "content_block_delta" and event.delta.type == "text_delta":
             response_content += event.delta.text
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -1227,7 +1228,7 @@ def test_anthropic_tools_legacy(
     except Exception:
         pass
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -1330,7 +1331,7 @@ def test_anthropic_tools_with_events_with_content(
         )
     except Exception:
         pass
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -1432,7 +1433,7 @@ def test_anthropic_tools_with_events_with_no_content(
     except Exception:
         pass
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -1554,7 +1555,7 @@ def test_anthropic_tools_history_legacy(
     except Exception:
         pass
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -1688,7 +1689,7 @@ def test_anthropic_tools_history_with_events_with_content(
     except Exception:
         pass
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -1790,7 +1791,7 @@ def test_anthropic_tools_history_with_events_with_no_content(
     except Exception:
         pass
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -1872,7 +1873,7 @@ def test_anthropic_tools_streaming_legacy(
     for _ in response:
         pass
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -1983,7 +1984,7 @@ def test_anthropic_tools_streaming_with_events_with_content(
         )
     except Exception:
         pass
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -2095,7 +2096,7 @@ def test_anthropic_tools_streaming_with_events_with_no_content(
         )
     except Exception:
         pass
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 1
@@ -2192,7 +2193,7 @@ def test_with_asyncio_run_legacy(
         )
     )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2226,7 +2227,7 @@ def test_with_asyncio_run_with_events_with_content(
         )
     )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2284,7 +2285,7 @@ def test_with_asyncio_run_with_events_with_no_content(
         )
     )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2349,7 +2350,7 @@ def test_anthropic_message_stream_manager_legacy(
     except Exception:
         pass
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2409,7 +2410,7 @@ def test_anthropic_message_stream_manager_with_events_with_content(
     except Exception:
         pass
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2473,7 +2474,7 @@ def test_anthropic_message_stream_manager_with_events_with_no_content(
     except Exception:
         pass
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2533,7 +2534,7 @@ async def test_async_anthropic_message_stream_manager_legacy(
     except Exception:
         pass
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2593,7 +2594,7 @@ async def test_async_anthropic_message_stream_manager_with_events_with_content(
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2656,7 +2657,7 @@ async def test_async_anthropic_message_stream_manager_with_events_with_no_conten
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]
@@ -2714,7 +2715,7 @@ async def test_anthropic_streaming_helper_methods_legacy(
         assert hasattr(stream, 'text_stream')
         assert hasattr(stream, 'until_done')
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert len(spans) == 1, f"Expected 1 span, got {len(spans)}"
     assert spans[0].name == "anthropic.chat"
 
@@ -2740,7 +2741,7 @@ async def test_anthropic_text_stream_helper_method_legacy(
         async for text in stream.text_stream:
             text_content += text
         assert len(text_content) > 0
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     print(f"Number of spans created: {len(spans)}")
     assert len(spans) == 1, f"Expected 1 span, got {len(spans)}"
     assert spans[0].name == "anthropic.chat"
@@ -2767,7 +2768,7 @@ def test_anthropic_sync_streaming_helper_methods_legacy(
         for event in stream:
             events.append(event)
         assert len(events) > 0
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert len(spans) == 1
     assert spans[0].name == "anthropic.chat"
 
@@ -2794,7 +2795,7 @@ async def test_async_anthropic_beta_message_stream_manager_legacy(
 
     assert response_content != ""
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     assert [span.name for span in spans] == [
         "anthropic.chat",
     ]

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_prompt_caching.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_prompt_caching.py
@@ -4,7 +4,6 @@ import json
 import pytest
 from opentelemetry.sdk._logs import ReadableLogRecord
 from opentelemetry.sdk.trace import ReadableSpan
-from opentelemetry.trace.status import StatusCode
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
@@ -60,13 +59,6 @@ def test_anthropic_prompt_caching_legacy(
             + f.read()
         )
 
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     system_message = "You help generate concise summaries of news articles and blog posts that user sends you."
 
     for _ in range(2):
@@ -93,7 +85,7 @@ def test_anthropic_prompt_caching_legacy(
             ],
         )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -152,13 +144,6 @@ def test_anthropic_prompt_caching_with_events_with_content(
             + f.read()
         )
 
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     system_message = "You help generate concise summaries of news articles and blog posts that user sends you."
 
     for _ in range(2):
@@ -185,7 +170,7 @@ def test_anthropic_prompt_caching_with_events_with_content(
             ],
         )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -314,13 +299,6 @@ def test_anthropic_prompt_caching_with_events_with_no_content(
             + f.read()
         )
 
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     system_message = "You help generate concise summaries of news articles and blog posts that user sends you."
 
     for _ in range(2):
@@ -347,7 +325,7 @@ def test_anthropic_prompt_caching_with_events_with_no_content(
             ],
         )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -398,13 +376,6 @@ async def test_anthropic_prompt_caching_async_legacy(
             + f.read()
         )
 
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     system_message = "You help generate concise summaries of news articles and blog posts that user sends you."
 
     for _ in range(2):
@@ -431,7 +402,7 @@ async def test_anthropic_prompt_caching_async_legacy(
             ],
         )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -486,13 +457,6 @@ async def test_anthropic_prompt_caching_async_with_events_with_content(
             + f.read()
         )
 
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     system_message = "You help generate concise summaries of news articles and blog posts that user sends you."
 
     for _ in range(2):
@@ -519,7 +483,7 @@ async def test_anthropic_prompt_caching_async_with_events_with_content(
             ],
         )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -654,13 +618,6 @@ async def test_anthropic_prompt_caching_async_with_events_with_no_content(
             + f.read()
         )
 
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     system_message = "You help generate concise summaries of news articles and blog posts that user sends you."
 
     for _ in range(2):
@@ -687,7 +644,7 @@ async def test_anthropic_prompt_caching_async_with_events_with_no_content(
             ],
         )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -741,13 +698,6 @@ def test_anthropic_prompt_caching_stream_legacy(
             "test_anthropic_prompt_caching_stream <- IGNORE THIS. ARTICLES START ON THE NEXT LINE\n"
             + f.read()
         )
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     system_message = "You help generate concise summaries of news articles and blog posts that user sends you."
 
     for _ in range(2):
@@ -779,7 +729,7 @@ def test_anthropic_prompt_caching_stream_legacy(
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -832,13 +782,6 @@ def test_anthropic_prompt_caching_stream_with_events_with_content(
             "test_anthropic_prompt_caching_stream <- IGNORE THIS. ARTICLES START ON THE NEXT LINE\n"
             + f.read()
         )
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     system_message = "You help generate concise summaries of news articles and blog posts that user sends you."
 
     for _ in range(2):
@@ -870,7 +813,7 @@ def test_anthropic_prompt_caching_stream_with_events_with_content(
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -1005,13 +948,6 @@ def test_anthropic_prompt_caching_stream_with_events_with_no_content(
             "test_anthropic_prompt_caching_stream <- IGNORE THIS. ARTICLES START ON THE NEXT LINE\n"
             + f.read()
         )
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     system_message = "You help generate concise summaries of news articles and blog posts that user sends you."
 
     for _ in range(2):
@@ -1043,7 +979,7 @@ def test_anthropic_prompt_caching_stream_with_events_with_no_content(
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -1093,13 +1029,6 @@ async def test_anthropic_prompt_caching_async_stream_legacy(
             "test_anthropic_prompt_caching_async_stream <- IGNORE THIS. ARTICLES START ON THE NEXT LINE\n"
             + f.read()
         )
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     system_message = "You help generate concise summaries of news articles and blog posts that user sends you."
 
     for _ in range(2):
@@ -1131,7 +1060,7 @@ async def test_anthropic_prompt_caching_async_stream_legacy(
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -1184,13 +1113,6 @@ async def test_anthropic_prompt_caching_async_stream_with_events_with_content(
             "test_anthropic_prompt_caching_async_stream <- IGNORE THIS. ARTICLES START ON THE NEXT LINE\n"
             + f.read()
         )
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     system_message = "You help generate concise summaries of news articles and blog posts that user sends you."
 
     for _ in range(2):
@@ -1222,7 +1144,7 @@ async def test_anthropic_prompt_caching_async_stream_with_events_with_content(
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -1368,13 +1290,6 @@ async def test_anthropic_prompt_caching_async_stream_with_events_with_no_content
             "test_anthropic_prompt_caching_async_stream <- IGNORE THIS. ARTICLES START ON THE NEXT LINE\n"
             + f.read()
         )
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     system_message = "You help generate concise summaries of news articles and blog posts that user sends you."
 
     for _ in range(2):
@@ -1406,7 +1321,7 @@ async def test_anthropic_prompt_caching_async_stream_with_events_with_no_content
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_prompt_caching.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_prompt_caching.py
@@ -4,6 +4,7 @@ import json
 import pytest
 from opentelemetry.sdk._logs import ReadableLogRecord
 from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.trace.status import StatusCode
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
@@ -92,7 +93,7 @@ def test_anthropic_prompt_caching_legacy(
             ],
         )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -184,7 +185,7 @@ def test_anthropic_prompt_caching_with_events_with_content(
             ],
         )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -346,7 +347,7 @@ def test_anthropic_prompt_caching_with_events_with_no_content(
             ],
         )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -430,7 +431,7 @@ async def test_anthropic_prompt_caching_async_legacy(
             ],
         )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -518,7 +519,7 @@ async def test_anthropic_prompt_caching_async_with_events_with_content(
             ],
         )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -686,7 +687,7 @@ async def test_anthropic_prompt_caching_async_with_events_with_no_content(
             ],
         )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -778,7 +779,7 @@ def test_anthropic_prompt_caching_stream_legacy(
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -869,7 +870,7 @@ def test_anthropic_prompt_caching_stream_with_events_with_content(
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -1042,7 +1043,7 @@ def test_anthropic_prompt_caching_stream_with_events_with_no_content(
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -1130,7 +1131,7 @@ async def test_anthropic_prompt_caching_async_stream_legacy(
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -1221,7 +1222,7 @@ async def test_anthropic_prompt_caching_async_stream_with_events_with_content(
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2
@@ -1405,7 +1406,7 @@ async def test_anthropic_prompt_caching_async_stream_with_events_with_no_content
             if event.type == "content_block_delta" and event.delta.type == "text_delta":
                 response_content += event.delta.text
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     # verify overall shape
     assert all(span.name == "anthropic.chat" for span in spans)
     assert len(spans) == 2

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_thinking.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_thinking.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 from opentelemetry.sdk._logs import ReadableLogRecord
+from opentelemetry.trace.status import StatusCode
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
@@ -41,7 +42,7 @@ def test_anthropic_thinking_legacy(
         ],
     )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -100,7 +101,7 @@ def test_anthropic_thinking_with_events_with_content(
         messages=[user_message],
     )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -174,7 +175,7 @@ def test_anthropic_thinking_with_events_with_no_content(
         ],
     )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -241,7 +242,7 @@ async def test_async_anthropic_thinking_legacy(
         ],
     )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -301,7 +302,7 @@ async def test_async_anthropic_thinking_with_events_with_content(
         messages=[user_message],
     )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -379,7 +380,7 @@ async def test_async_anthropic_thinking_with_events_with_no_content(
         ],
     )
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -457,7 +458,7 @@ def test_anthropic_thinking_streaming_legacy(
         ):
             thinking += event.delta.thinking
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -527,7 +528,7 @@ def test_anthropic_thinking_streaming_with_events_with_content(
         ):
             thinking += event.delta.thinking
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -619,7 +620,7 @@ def test_anthropic_thinking_streaming_with_events_with_no_content(
         ):
             thinking += event.delta.thinking
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -698,7 +699,7 @@ async def test_async_anthropic_thinking_streaming_legacy(
         ):
             thinking += event.delta.thinking
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -769,7 +770,7 @@ async def test_async_anthropic_thinking_streaming_with_events_with_content(
         ):
             thinking += event.delta.thinking
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -867,7 +868,7 @@ async def test_async_anthropic_thinking_streaming_with_events_with_no_content(
         ):
             thinking += event.delta.thinking
 
-    spans = span_exporter.get_finished_spans()
+    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_thinking.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_thinking.py
@@ -1,7 +1,6 @@
 import json
 import pytest
 from opentelemetry.sdk._logs import ReadableLogRecord
-from opentelemetry.trace.status import StatusCode
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
@@ -14,13 +13,6 @@ def test_anthropic_thinking_legacy(
     instrument_legacy, anthropic_client, span_exporter, log_exporter, reader
 ):
     prompt = "How many times does the letter 'r' appear in the word strawberry?"
-
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
 
     response = anthropic_client.messages.create(
         model="claude-3-7-sonnet-20250219",
@@ -42,7 +34,7 @@ def test_anthropic_thinking_legacy(
         ],
     )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -74,13 +66,6 @@ def test_anthropic_thinking_with_events_with_content(
 ):
     prompt = "How many times does the letter 'r' appear in the word strawberry?"
 
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     user_message = {
         "role": "user",
         "content": [
@@ -101,7 +86,7 @@ def test_anthropic_thinking_with_events_with_content(
         messages=[user_message],
     )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -148,13 +133,6 @@ def test_anthropic_thinking_with_events_with_no_content(
 ):
     prompt = "How many times does the letter 'r' appear in the word strawberry?"
 
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     anthropic_client.messages.create(
         model="claude-3-7-sonnet-20250219",
         max_tokens=2048,
@@ -175,7 +153,7 @@ def test_anthropic_thinking_with_events_with_no_content(
         ],
     )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -215,13 +193,6 @@ async def test_async_anthropic_thinking_legacy(
 ):
     prompt = "How many times does the letter 'r' appear in the word strawberry?"
 
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     response = await async_anthropic_client.messages.create(
         model="claude-3-7-sonnet-20250219",
         max_tokens=2048,
@@ -242,7 +213,7 @@ async def test_async_anthropic_thinking_legacy(
         ],
     )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -275,13 +246,6 @@ async def test_async_anthropic_thinking_with_events_with_content(
 ):
     prompt = "How many times does the letter 'r' appear in the word strawberry?"
 
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     user_message = {
         "role": "user",
         "content": [
@@ -302,7 +266,7 @@ async def test_async_anthropic_thinking_with_events_with_content(
         messages=[user_message],
     )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -353,13 +317,6 @@ async def test_async_anthropic_thinking_with_events_with_no_content(
 ):
     prompt = "How many times does the letter 'r' appear in the word strawberry?"
 
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     await async_anthropic_client.messages.create(
         model="claude-3-7-sonnet-20250219",
         max_tokens=2048,
@@ -380,7 +337,7 @@ async def test_async_anthropic_thinking_with_events_with_no_content(
         ],
     )
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -419,13 +376,6 @@ def test_anthropic_thinking_streaming_legacy(
 ):
     prompt = "How many times does the letter 'r' appear in the word strawberry?"
 
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     response = anthropic_client.messages.create(
         model="claude-3-7-sonnet-20250219",
         stream=True,
@@ -458,7 +408,7 @@ def test_anthropic_thinking_streaming_legacy(
         ):
             thinking += event.delta.thinking
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -488,13 +438,6 @@ def test_anthropic_thinking_streaming_with_events_with_content(
     instrument_with_content, anthropic_client, span_exporter, log_exporter, reader
 ):
     prompt = "How many times does the letter 'r' appear in the word strawberry?"
-
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
 
     user_message = {
         "role": "user",
@@ -528,7 +471,7 @@ def test_anthropic_thinking_streaming_with_events_with_content(
         ):
             thinking += event.delta.thinking
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -581,13 +524,6 @@ def test_anthropic_thinking_streaming_with_events_with_no_content(
 ):
     prompt = "How many times does the letter 'r' appear in the word strawberry?"
 
-    try:
-        anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     response = anthropic_client.messages.create(
         model="claude-3-7-sonnet-20250219",
         stream=True,
@@ -620,7 +556,7 @@ def test_anthropic_thinking_streaming_with_events_with_no_content(
         ):
             thinking += event.delta.thinking
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -660,13 +596,6 @@ async def test_async_anthropic_thinking_streaming_legacy(
 ):
     prompt = "How many times does the letter 'r' appear in the word strawberry?"
 
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     response = await async_anthropic_client.messages.create(
         model="claude-3-7-sonnet-20250219",
         stream=True,
@@ -699,7 +628,7 @@ async def test_async_anthropic_thinking_streaming_legacy(
         ):
             thinking += event.delta.thinking
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -730,13 +659,6 @@ async def test_async_anthropic_thinking_streaming_with_events_with_content(
     instrument_with_content, async_anthropic_client, span_exporter, log_exporter, reader
 ):
     prompt = "How many times does the letter 'r' appear in the word strawberry?"
-
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
 
     user_message = {
         "role": "user",
@@ -770,7 +692,7 @@ async def test_async_anthropic_thinking_streaming_with_events_with_content(
         ):
             thinking += event.delta.thinking
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"
@@ -829,13 +751,6 @@ async def test_async_anthropic_thinking_streaming_with_events_with_no_content(
 ):
     prompt = "How many times does the letter 'r' appear in the word strawberry?"
 
-    try:
-        await async_anthropic_client.messages.create(
-            unknown_parameter="unknown",
-        )
-    except Exception:
-        pass
-
     response = await async_anthropic_client.messages.create(
         model="claude-3-7-sonnet-20250219",
         stream=True,
@@ -868,7 +783,7 @@ async def test_async_anthropic_thinking_streaming_with_events_with_no_content(
         ):
             thinking += event.delta.thinking
 
-    spans = [s for s in span_exporter.get_finished_spans() if s.status.status_code != StatusCode.ERROR]
+    spans = span_exporter.get_finished_spans()
     anthropic_span = spans[0]
 
     assert anthropic_span.name == "anthropic.chat"

--- a/packages/opentelemetry-instrumentation-anthropic/tests/utils.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/utils.py
@@ -11,7 +11,6 @@ def verify_metrics(
     found_token_metric = False
     found_choice_metric = False
     found_duration_metric = False
-    found_exception_metric = False
 
     for rm in resource_metrics:
         for sm in rm.scope_metrics:
@@ -50,15 +49,8 @@ def verify_metrics(
                     assert all(
                         data_point.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_MODEL)
                         == model_name
-                        or data_point.attributes.get("error.type") == "TypeError"
                         for data_point in metric.data.data_points
                     )
-
-                if metric.name == Meters.LLM_ANTHROPIC_COMPLETION_EXCEPTIONS:
-                    found_exception_metric = True
-                    for data_point in metric.data.data_points:
-                        assert data_point.value == 1
-                        assert data_point.attributes["error.type"] == "TypeError"
 
                 assert all(
                     data_point.attributes.get("gen_ai.provider.name") == "anthropic"
@@ -68,4 +60,3 @@ def verify_metrics(
     assert found_token_metric is True
     assert found_choice_metric is True
     assert found_duration_metric is True
-    assert found_exception_metric is True

--- a/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/__init__.py
+++ b/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/__init__.py
@@ -62,6 +62,7 @@ from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
     GenAiOperationNameValues,
     GenAiSystemValues,
 )
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from opentelemetry.semconv_ai import (
     SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY,
     Meters,
@@ -211,7 +212,7 @@ def _wrap(
             if metric_params.exception_counter:
                 metric_params.exception_counter.add(1, attributes=attributes)
 
-            raise e
+            raise
 
     return wrapped(*args, **kwargs)
 
@@ -236,6 +237,7 @@ def _instrumented_model_invoke(fn, tracer, metric_params, event_logger):
             try:
                 response = fn(*args, **kwargs)
             except Exception as e:
+                span.set_attribute(ERROR_TYPE, e.__class__.__name__)
                 span.record_exception(e)
                 span.set_status(Status(StatusCode.ERROR, str(e)))
                 raise
@@ -269,6 +271,7 @@ def _instrumented_model_invoke_with_response_stream(
         try:
             response = fn(*args, **kwargs)
         except Exception as e:
+            span.set_attribute(ERROR_TYPE, e.__class__.__name__)
             span.record_exception(e)
             span.set_status(Status(StatusCode.ERROR, str(e)))
             span.end()
@@ -304,6 +307,7 @@ def _instrumented_converse(fn, tracer, metric_params, event_logger):
             try:
                 response = fn(*args, **kwargs)
             except Exception as e:
+                span.set_attribute(ERROR_TYPE, e.__class__.__name__)
                 span.record_exception(e)
                 span.set_status(Status(StatusCode.ERROR, str(e)))
                 raise
@@ -334,6 +338,7 @@ def _instrumented_converse_stream(fn, tracer, metric_params, event_logger):
         try:
             response = fn(*args, **kwargs)
         except Exception as e:
+            span.set_attribute(ERROR_TYPE, e.__class__.__name__)
             span.record_exception(e)
             span.set_status(Status(StatusCode.ERROR, str(e)))
             span.end()

--- a/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/__init__.py
+++ b/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/__init__.py
@@ -67,6 +67,7 @@ from opentelemetry.semconv_ai import (
     Meters,
 )
 from opentelemetry.trace import Span, SpanKind, get_tracer
+from opentelemetry.trace.status import Status, StatusCode
 from wrapt import wrap_function_wrapper
 
 
@@ -229,9 +230,15 @@ def _instrumented_model_invoke(fn, tracer, metric_params, event_logger):
             GenAIAttributes.GEN_AI_REQUEST_MODEL: _model,
         }
         with tracer.start_as_current_span(
-            _span_name(operation_name, _model), kind=SpanKind.CLIENT, attributes=span_attributes
+            _span_name(operation_name, _model), kind=SpanKind.CLIENT, attributes=span_attributes,
+            record_exception=False, set_status_on_exception=False,
         ) as span:
-            response = fn(*args, **kwargs)
+            try:
+                response = fn(*args, **kwargs)
+            except Exception as e:
+                span.record_exception(e)
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                raise
             _handle_call(span, kwargs, response, metric_params, event_logger)
             return response
 
@@ -259,7 +266,13 @@ def _instrumented_model_invoke_with_response_stream(
             attributes=span_attributes,
         )
 
-        response = fn(*args, **kwargs)
+        try:
+            response = fn(*args, **kwargs)
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            span.end()
+            raise
         _handle_stream_call(span, kwargs, response, metric_params, event_logger)
 
         return response
@@ -286,8 +299,14 @@ def _instrumented_converse(fn, tracer, metric_params, event_logger):
             _span_name(GenAiOperationNameValues.CHAT.value, _model),
             kind=SpanKind.CLIENT,
             attributes=span_attributes,
+            record_exception=False, set_status_on_exception=False,
         ) as span:
-            response = fn(*args, **kwargs)
+            try:
+                response = fn(*args, **kwargs)
+            except Exception as e:
+                span.record_exception(e)
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                raise
             _handle_converse(span, kwargs, response, metric_params, event_logger)
 
             return response
@@ -312,7 +331,13 @@ def _instrumented_converse_stream(fn, tracer, metric_params, event_logger):
             kind=SpanKind.CLIENT,
             attributes=span_attributes,
         )
-        response = fn(*args, **kwargs)
+        try:
+            response = fn(*args, **kwargs)
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            span.end()
+            raise
         if span.is_recording():
             _handle_converse_stream(span, kwargs, response, metric_params, event_logger)
 

--- a/packages/opentelemetry-instrumentation-bedrock/tests/traces/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-bedrock/tests/traces/test_error_handling.py
@@ -1,0 +1,46 @@
+from unittest.mock import patch
+from botocore.exceptions import ClientError
+
+import pytest
+from opentelemetry.trace.status import StatusCode
+
+
+def _make_client_error(operation="InvokeModel"):
+    return ClientError(
+        {"Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"}},
+        operation,
+    )
+
+
+def test_bedrock_invoke_model_error_sets_span_status(instrument_legacy, brt, span_exporter):
+    with patch("botocore.endpoint.URLLib3Session.send", side_effect=_make_client_error("InvokeModel")):
+        with pytest.raises(ClientError):
+            brt.invoke_model(
+                body=b'{"prompt": "test", "max_tokens_to_sample": 10}',
+                modelId="anthropic.claude-v2:1",
+                accept="application/json",
+                contentType="application/json",
+            )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1
+
+
+def test_bedrock_converse_error_sets_span_status(instrument_legacy, brt, span_exporter):
+    with patch("botocore.endpoint.URLLib3Session.send", side_effect=_make_client_error("Converse")):
+        with pytest.raises(ClientError):
+            brt.converse(
+                modelId="anthropic.claude-3-sonnet-20240229-v1:0",
+                messages=[{"role": "user", "content": [{"text": "Tell me a joke"}]}],
+            )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1

--- a/packages/opentelemetry-instrumentation-bedrock/tests/traces/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-bedrock/tests/traces/test_error_handling.py
@@ -26,6 +26,7 @@ def test_bedrock_invoke_model_error_sets_span_status(instrument_legacy, brt, spa
     assert len(spans) == 1
     span = spans[0]
     assert span.status.status_code == StatusCode.ERROR
+    assert span.attributes.get("error.type") == "ClientError"
     events = [e for e in span.events if e.name == "exception"]
     assert len(events) == 1
 
@@ -42,5 +43,6 @@ def test_bedrock_converse_error_sets_span_status(instrument_legacy, brt, span_ex
     assert len(spans) == 1
     span = spans[0]
     assert span.status.status_code == StatusCode.ERROR
+    assert span.attributes.get("error.type") == "ClientError"
     events = [e for e in span.events if e.name == "exception"]
     assert len(events) == 1

--- a/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/__init__.py
+++ b/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/__init__.py
@@ -304,10 +304,9 @@ def _wrap(
 
         span.set_attribute(ERROR_TYPE, e.__class__.__name__)
         span.record_exception(e)
-        if span.is_recording():
-            span.set_status(Status(StatusCode.ERROR, str(e)))
+        span.set_status(Status(StatusCode.ERROR, str(e)))
         span.end()
-        raise e
+        raise
 
     end_time = time.time()
 
@@ -393,10 +392,9 @@ async def _awrap(
 
         span.set_attribute(ERROR_TYPE, e.__class__.__name__)
         span.record_exception(e)
-        if span.is_recording():
-            span.set_status(Status(StatusCode.ERROR, str(e)))
+        span.set_status(Status(StatusCode.ERROR, str(e)))
         span.end()
-        raise e
+        raise
 
     end_time = time.time()
 

--- a/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/__init__.py
+++ b/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/__init__.py
@@ -39,6 +39,7 @@ from opentelemetry.semconv_ai import (
 )
 from opentelemetry.trace import Span, SpanKind, Tracer, get_tracer
 from opentelemetry.trace.status import Status, StatusCode
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from wrapt import wrap_function_wrapper
 
 from groq._streaming import AsyncStream, Stream
@@ -301,8 +302,10 @@ def _wrap(
             duration = end_time - start_time
             duration_histogram.record(duration, attributes=attributes)
 
+        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+        span.record_exception(e)
         if span.is_recording():
-            span.set_status(Status(StatusCode.ERROR))
+            span.set_status(Status(StatusCode.ERROR, str(e)))
         span.end()
         raise e
 
@@ -388,8 +391,10 @@ async def _awrap(
             duration = end_time - start_time
             duration_histogram.record(duration, attributes=attributes)
 
+        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+        span.record_exception(e)
         if span.is_recording():
-            span.set_status(Status(StatusCode.ERROR))
+            span.set_status(Status(StatusCode.ERROR, str(e)))
         span.end()
         raise e
 

--- a/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/__init__.py
+++ b/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/__init__.py
@@ -214,7 +214,9 @@ def _create_stream_processor(response, span, event_logger):
         raise
     else:
         tool_calls = [accumulated_tool_calls[i] for i in sorted(accumulated_tool_calls)] or None
-        _handle_streaming_response(span, accumulated_content, tool_calls, accumulated_finish_reasons, usage, event_logger)
+        _handle_streaming_response(
+            span, accumulated_content, tool_calls, accumulated_finish_reasons, usage, event_logger
+        )
         if span.is_recording():
             span.set_status(Status(StatusCode.OK))
     finally:
@@ -246,7 +248,9 @@ async def _create_async_stream_processor(response, span, event_logger):
         raise
     else:
         tool_calls = [accumulated_tool_calls[i] for i in sorted(accumulated_tool_calls)] or None
-        _handle_streaming_response(span, accumulated_content, tool_calls, accumulated_finish_reasons, usage, event_logger)
+        _handle_streaming_response(
+            span, accumulated_content, tool_calls, accumulated_finish_reasons, usage, event_logger
+        )
         if span.is_recording():
             span.set_status(Status(StatusCode.OK))
     finally:

--- a/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/__init__.py
+++ b/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/__init__.py
@@ -196,24 +196,29 @@ def _create_stream_processor(response, span, event_logger):
     accumulated_finish_reasons: list = []
     usage = None
 
-    for chunk in response:
-        content, tool_calls_delta, chunk_finish_reasons, chunk_usage = _process_streaming_chunk(chunk)
-        if content:
-            accumulated_content += content
-        if tool_calls_delta:
-            _accumulate_tool_calls(accumulated_tool_calls, tool_calls_delta)
-        accumulated_finish_reasons.extend(chunk_finish_reasons)
-        if chunk_usage:
-            usage = chunk_usage
-        yield chunk
-
-    tool_calls = [accumulated_tool_calls[i] for i in sorted(accumulated_tool_calls)] or None
-    _handle_streaming_response(span, accumulated_content, tool_calls, accumulated_finish_reasons, usage, event_logger)
-
-    if span.is_recording():
-        span.set_status(Status(StatusCode.OK))
-
-    span.end()
+    try:
+        for chunk in response:
+            content, tool_calls_delta, chunk_finish_reasons, chunk_usage = _process_streaming_chunk(chunk)
+            if content:
+                accumulated_content += content
+            if tool_calls_delta:
+                _accumulate_tool_calls(accumulated_tool_calls, tool_calls_delta)
+            accumulated_finish_reasons.extend(chunk_finish_reasons)
+            if chunk_usage:
+                usage = chunk_usage
+            yield chunk
+    except Exception as e:
+        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+        span.record_exception(e)
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        raise
+    else:
+        tool_calls = [accumulated_tool_calls[i] for i in sorted(accumulated_tool_calls)] or None
+        _handle_streaming_response(span, accumulated_content, tool_calls, accumulated_finish_reasons, usage, event_logger)
+        if span.is_recording():
+            span.set_status(Status(StatusCode.OK))
+    finally:
+        span.end()
 
 
 async def _create_async_stream_processor(response, span, event_logger):
@@ -223,24 +228,29 @@ async def _create_async_stream_processor(response, span, event_logger):
     accumulated_finish_reasons: list = []
     usage = None
 
-    async for chunk in response:
-        content, tool_calls_delta, chunk_finish_reasons, chunk_usage = _process_streaming_chunk(chunk)
-        if content:
-            accumulated_content += content
-        if tool_calls_delta:
-            _accumulate_tool_calls(accumulated_tool_calls, tool_calls_delta)
-        accumulated_finish_reasons.extend(chunk_finish_reasons)
-        if chunk_usage:
-            usage = chunk_usage
-        yield chunk
-
-    tool_calls = [accumulated_tool_calls[i] for i in sorted(accumulated_tool_calls)] or None
-    _handle_streaming_response(span, accumulated_content, tool_calls, accumulated_finish_reasons, usage, event_logger)
-
-    if span.is_recording():
-        span.set_status(Status(StatusCode.OK))
-
-    span.end()
+    try:
+        async for chunk in response:
+            content, tool_calls_delta, chunk_finish_reasons, chunk_usage = _process_streaming_chunk(chunk)
+            if content:
+                accumulated_content += content
+            if tool_calls_delta:
+                _accumulate_tool_calls(accumulated_tool_calls, tool_calls_delta)
+            accumulated_finish_reasons.extend(chunk_finish_reasons)
+            if chunk_usage:
+                usage = chunk_usage
+            yield chunk
+    except Exception as e:
+        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+        span.record_exception(e)
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        raise
+    else:
+        tool_calls = [accumulated_tool_calls[i] for i in sorted(accumulated_tool_calls)] or None
+        _handle_streaming_response(span, accumulated_content, tool_calls, accumulated_finish_reasons, usage, event_logger)
+        if span.is_recording():
+            span.set_status(Status(StatusCode.OK))
+    finally:
+        span.end()
 
 
 def _handle_input(span, kwargs, event_logger):

--- a/packages/opentelemetry-instrumentation-groq/tests/traces/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-groq/tests/traces/test_error_handling.py
@@ -1,0 +1,39 @@
+from unittest.mock import patch
+
+import pytest
+from opentelemetry.trace.status import StatusCode
+
+
+def test_groq_error_sets_span_status(instrument_legacy, groq_client, span_exporter):
+    with patch("httpx.Client.send", side_effect=Exception("API connection error")):
+        with pytest.raises(Exception):
+            groq_client.chat.completions.create(
+                model="llama3-8b-8192",
+                messages=[{"role": "user", "content": "Tell me a joke"}],
+            )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    assert span.attributes.get("error.type") is not None
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_groq_error_sets_span_status(instrument_legacy, async_groq_client, span_exporter):
+    with patch("httpx.AsyncClient.send", side_effect=Exception("Async API error")):
+        with pytest.raises(Exception):
+            await async_groq_client.chat.completions.create(
+                model="llama3-8b-8192",
+                messages=[{"role": "user", "content": "Tell me a joke"}],
+            )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    assert span.attributes.get("error.type") is not None
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1

--- a/packages/opentelemetry-instrumentation-groq/tests/traces/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-groq/tests/traces/test_error_handling.py
@@ -37,3 +37,61 @@ async def test_async_groq_error_sets_span_status(instrument_legacy, async_groq_c
     assert span.attributes.get("error.type") is not None
     events = [e for e in span.events if e.name == "exception"]
     assert len(events) == 1
+
+
+def test_groq_streaming_iteration_error_sets_span_status(
+    instrument_legacy, tracer_provider, span_exporter
+):
+    """Errors raised during stream iteration must still finalize the span
+    with ERROR status, error.type, and an exception event."""
+    from opentelemetry.instrumentation.groq import _create_stream_processor
+
+    span = tracer_provider.get_tracer(__name__).start_span("groq.chat")
+
+    def failing_stream():
+        raise Exception("Mid-stream failure")
+        yield  # unreachable, makes this a generator
+
+    gen = _create_stream_processor(failing_stream(), span, None)
+    with pytest.raises(Exception, match="Mid-stream failure"):
+        for _ in gen:
+            pass
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    assert "Mid-stream failure" in span.status.description
+    assert span.attributes.get("error.type") == "Exception"
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1
+    assert "Mid-stream failure" in events[0].attributes["exception.message"]
+
+
+@pytest.mark.asyncio
+async def test_async_groq_streaming_iteration_error_sets_span_status(
+    instrument_legacy, tracer_provider, span_exporter
+):
+    """Same as the sync test but for the async stream processor."""
+    from opentelemetry.instrumentation.groq import _create_async_stream_processor
+
+    span = tracer_provider.get_tracer(__name__).start_span("groq.chat")
+
+    async def failing_stream():
+        raise Exception("Async mid-stream failure")
+        yield  # unreachable, makes this an async generator
+
+    gen = _create_async_stream_processor(failing_stream(), span, None)
+    with pytest.raises(Exception, match="Async mid-stream failure"):
+        async for _ in gen:
+            pass
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    assert "Async mid-stream failure" in span.status.description
+    assert span.attributes.get("error.type") == "Exception"
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1
+    assert "Async mid-stream failure" in events[0].attributes["exception.message"]

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
@@ -1055,6 +1055,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         span = self._get_span(run_id)
         # Set task status to failure
         _set_span_attribute(span, SpanAttributes.GEN_AI_TASK_STATUS, "failure")
+        span.set_attribute(ERROR_TYPE, type(error).__name__)
         span.set_status(Status(StatusCode.ERROR, str(error)))
         span.record_exception(error)
         self._end_span(span, run_id)
@@ -1093,8 +1094,6 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         **kwargs: Any,
     ) -> None:
         """Run when tool errors."""
-        span = self._get_span(run_id)
-        span.set_attribute(ERROR_TYPE, type(error).__name__)
         self._handle_error(error, run_id, parent_run_id, **kwargs)
 
     @dont_throw

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/callback_handler.py
@@ -1055,7 +1055,7 @@ class TraceloopCallbackHandler(BaseCallbackHandler):
         span = self._get_span(run_id)
         # Set task status to failure
         _set_span_attribute(span, SpanAttributes.GEN_AI_TASK_STATUS, "failure")
-        span.set_status(Status(StatusCode.ERROR), str(error))
+        span.set_status(Status(StatusCode.ERROR, str(error)))
         span.record_exception(error)
         self._end_span(span, run_id)
 

--- a/packages/opentelemetry-instrumentation-mistralai/opentelemetry/instrumentation/mistralai/__init__.py
+++ b/packages/opentelemetry-instrumentation-mistralai/opentelemetry/instrumentation/mistralai/__init__.py
@@ -208,36 +208,42 @@ def _accumulate_streaming_response(span, event_logger, llm_request_type, respons
         usage=UsageInfo(prompt_tokens=0, total_tokens=0, completion_tokens=0),
     )
 
-    for res in response:
-        yield res
+    try:
+        for res in response:
+            yield res
 
-        # Handle new CompletionEvent structure with .data attribute
-        chunk_data = res.data if hasattr(res, 'data') else res
-        if chunk_data.model:
-            accumulated_response.model = chunk_data.model
-        if chunk_data.usage:
-            accumulated_response.usage = chunk_data.usage
-        # Id is the same for all chunks, so it's safe to overwrite it every time
-        if chunk_data.id:
-            accumulated_response.id = chunk_data.id
+            # Handle new CompletionEvent structure with .data attribute
+            chunk_data = res.data if hasattr(res, 'data') else res
+            if chunk_data.model:
+                accumulated_response.model = chunk_data.model
+            if chunk_data.usage:
+                accumulated_response.usage = chunk_data.usage
+            # Id is the same for all chunks, so it's safe to overwrite it every time
+            if chunk_data.id:
+                accumulated_response.id = chunk_data.id
 
-        for idx, choice in enumerate(chunk_data.choices):
-            if len(accumulated_response.choices) <= idx:
-                accumulated_response.choices.append(
-                    ChatCompletionChoice(
-                        index=idx,
-                        message=AssistantMessage(role="assistant", content=""),
-                        finish_reason=None,
+            for idx, choice in enumerate(chunk_data.choices):
+                if len(accumulated_response.choices) <= idx:
+                    accumulated_response.choices.append(
+                        ChatCompletionChoice(
+                            index=idx,
+                            message=AssistantMessage(role="assistant", content=""),
+                            finish_reason=None,
+                        )
                     )
-                )
 
-            accumulated_response.choices[idx].finish_reason = choice.finish_reason
-            accumulated_response.choices[idx].message.content += choice.delta.content
-            accumulated_response.choices[idx].message.role = choice.delta.role
-
-    _handle_response(span, event_logger, llm_request_type, accumulated_response)
-
-    span.end()
+                accumulated_response.choices[idx].finish_reason = choice.finish_reason
+                accumulated_response.choices[idx].message.content += choice.delta.content
+                accumulated_response.choices[idx].message.role = choice.delta.role
+    except Exception as e:
+        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+        span.record_exception(e)
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        raise
+    else:
+        _handle_response(span, event_logger, llm_request_type, accumulated_response)
+    finally:
+        span.end()
 
 
 async def _aaccumulate_streaming_response(
@@ -252,36 +258,42 @@ async def _aaccumulate_streaming_response(
         usage=UsageInfo(prompt_tokens=0, total_tokens=0, completion_tokens=0),
     )
 
-    async for res in response:
-        yield res
+    try:
+        async for res in response:
+            yield res
 
-        # Handle new CompletionEvent structure with .data attribute
-        chunk_data = res.data if hasattr(res, 'data') else res
-        if chunk_data.model:
-            accumulated_response.model = chunk_data.model
-        if chunk_data.usage:
-            accumulated_response.usage = chunk_data.usage
-        # Id is the same for all chunks, so it's safe to overwrite it every time
-        if chunk_data.id:
-            accumulated_response.id = chunk_data.id
+            # Handle new CompletionEvent structure with .data attribute
+            chunk_data = res.data if hasattr(res, 'data') else res
+            if chunk_data.model:
+                accumulated_response.model = chunk_data.model
+            if chunk_data.usage:
+                accumulated_response.usage = chunk_data.usage
+            # Id is the same for all chunks, so it's safe to overwrite it every time
+            if chunk_data.id:
+                accumulated_response.id = chunk_data.id
 
-        for idx, choice in enumerate(chunk_data.choices):
-            if len(accumulated_response.choices) <= idx:
-                accumulated_response.choices.append(
-                    ChatCompletionChoice(
-                        index=idx,
-                        message=AssistantMessage(role="assistant", content=""),
-                        finish_reason=None,
+            for idx, choice in enumerate(chunk_data.choices):
+                if len(accumulated_response.choices) <= idx:
+                    accumulated_response.choices.append(
+                        ChatCompletionChoice(
+                            index=idx,
+                            message=AssistantMessage(role="assistant", content=""),
+                            finish_reason=None,
+                        )
                     )
-                )
 
-            accumulated_response.choices[idx].finish_reason = choice.finish_reason
-            accumulated_response.choices[idx].message.content += choice.delta.content
-            accumulated_response.choices[idx].message.role = choice.delta.role
-
-    _handle_response(span, event_logger, llm_request_type, accumulated_response)
-
-    span.end()
+                accumulated_response.choices[idx].finish_reason = choice.finish_reason
+                accumulated_response.choices[idx].message.content += choice.delta.content
+                accumulated_response.choices[idx].message.role = choice.delta.role
+    except Exception as e:
+        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+        span.record_exception(e)
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        raise
+    else:
+        _handle_response(span, event_logger, llm_request_type, accumulated_response)
+    finally:
+        span.end()
 
 
 def _with_tracer_wrapper(func):

--- a/packages/opentelemetry-instrumentation-mistralai/opentelemetry/instrumentation/mistralai/__init__.py
+++ b/packages/opentelemetry-instrumentation-mistralai/opentelemetry/instrumentation/mistralai/__init__.py
@@ -208,42 +208,36 @@ def _accumulate_streaming_response(span, event_logger, llm_request_type, respons
         usage=UsageInfo(prompt_tokens=0, total_tokens=0, completion_tokens=0),
     )
 
-    try:
-        for res in response:
-            yield res
+    for res in response:
+        yield res
 
-            # Handle new CompletionEvent structure with .data attribute
-            chunk_data = res.data if hasattr(res, 'data') else res
-            if chunk_data.model:
-                accumulated_response.model = chunk_data.model
-            if chunk_data.usage:
-                accumulated_response.usage = chunk_data.usage
-            # Id is the same for all chunks, so it's safe to overwrite it every time
-            if chunk_data.id:
-                accumulated_response.id = chunk_data.id
+        # Handle new CompletionEvent structure with .data attribute
+        chunk_data = res.data if hasattr(res, 'data') else res
+        if chunk_data.model:
+            accumulated_response.model = chunk_data.model
+        if chunk_data.usage:
+            accumulated_response.usage = chunk_data.usage
+        # Id is the same for all chunks, so it's safe to overwrite it every time
+        if chunk_data.id:
+            accumulated_response.id = chunk_data.id
 
-            for idx, choice in enumerate(chunk_data.choices):
-                if len(accumulated_response.choices) <= idx:
-                    accumulated_response.choices.append(
-                        ChatCompletionChoice(
-                            index=idx,
-                            message=AssistantMessage(role="assistant", content=""),
-                            finish_reason=None,
-                        )
+        for idx, choice in enumerate(chunk_data.choices):
+            if len(accumulated_response.choices) <= idx:
+                accumulated_response.choices.append(
+                    ChatCompletionChoice(
+                        index=idx,
+                        message=AssistantMessage(role="assistant", content=""),
+                        finish_reason=None,
                     )
+                )
 
-                accumulated_response.choices[idx].finish_reason = choice.finish_reason
-                accumulated_response.choices[idx].message.content += choice.delta.content
-                accumulated_response.choices[idx].message.role = choice.delta.role
-    except Exception as e:
-        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
-        span.record_exception(e)
-        span.set_status(Status(StatusCode.ERROR, str(e)))
-        raise
-    else:
-        _handle_response(span, event_logger, llm_request_type, accumulated_response)
-    finally:
-        span.end()
+            accumulated_response.choices[idx].finish_reason = choice.finish_reason
+            accumulated_response.choices[idx].message.content += choice.delta.content
+            accumulated_response.choices[idx].message.role = choice.delta.role
+
+    _handle_response(span, event_logger, llm_request_type, accumulated_response)
+
+    span.end()
 
 
 async def _aaccumulate_streaming_response(
@@ -258,42 +252,36 @@ async def _aaccumulate_streaming_response(
         usage=UsageInfo(prompt_tokens=0, total_tokens=0, completion_tokens=0),
     )
 
-    try:
-        async for res in response:
-            yield res
+    async for res in response:
+        yield res
 
-            # Handle new CompletionEvent structure with .data attribute
-            chunk_data = res.data if hasattr(res, 'data') else res
-            if chunk_data.model:
-                accumulated_response.model = chunk_data.model
-            if chunk_data.usage:
-                accumulated_response.usage = chunk_data.usage
-            # Id is the same for all chunks, so it's safe to overwrite it every time
-            if chunk_data.id:
-                accumulated_response.id = chunk_data.id
+        # Handle new CompletionEvent structure with .data attribute
+        chunk_data = res.data if hasattr(res, 'data') else res
+        if chunk_data.model:
+            accumulated_response.model = chunk_data.model
+        if chunk_data.usage:
+            accumulated_response.usage = chunk_data.usage
+        # Id is the same for all chunks, so it's safe to overwrite it every time
+        if chunk_data.id:
+            accumulated_response.id = chunk_data.id
 
-            for idx, choice in enumerate(chunk_data.choices):
-                if len(accumulated_response.choices) <= idx:
-                    accumulated_response.choices.append(
-                        ChatCompletionChoice(
-                            index=idx,
-                            message=AssistantMessage(role="assistant", content=""),
-                            finish_reason=None,
-                        )
+        for idx, choice in enumerate(chunk_data.choices):
+            if len(accumulated_response.choices) <= idx:
+                accumulated_response.choices.append(
+                    ChatCompletionChoice(
+                        index=idx,
+                        message=AssistantMessage(role="assistant", content=""),
+                        finish_reason=None,
                     )
+                )
 
-                accumulated_response.choices[idx].finish_reason = choice.finish_reason
-                accumulated_response.choices[idx].message.content += choice.delta.content
-                accumulated_response.choices[idx].message.role = choice.delta.role
-    except Exception as e:
-        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
-        span.record_exception(e)
-        span.set_status(Status(StatusCode.ERROR, str(e)))
-        raise
-    else:
-        _handle_response(span, event_logger, llm_request_type, accumulated_response)
-    finally:
-        span.end()
+            accumulated_response.choices[idx].finish_reason = choice.finish_reason
+            accumulated_response.choices[idx].message.content += choice.delta.content
+            accumulated_response.choices[idx].message.role = choice.delta.role
+
+    _handle_response(span, event_logger, llm_request_type, accumulated_response)
+
+    span.end()
 
 
 def _with_tracer_wrapper(func):

--- a/packages/opentelemetry-instrumentation-mistralai/opentelemetry/instrumentation/mistralai/__init__.py
+++ b/packages/opentelemetry-instrumentation-mistralai/opentelemetry/instrumentation/mistralai/__init__.py
@@ -33,6 +33,7 @@ from opentelemetry.semconv_ai import (
 )
 from opentelemetry.trace import SpanKind, get_tracer
 from opentelemetry.trace.status import Status, StatusCode
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from wrapt import wrap_function_wrapper
 
 from mistralai.models import (
@@ -414,7 +415,14 @@ def _wrap(
 
     _handle_input(span, event_logger, args, kwargs, to_wrap)
 
-    response = wrapped(*args, **kwargs)
+    try:
+        response = wrapped(*args, **kwargs)
+    except Exception as e:
+        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+        span.record_exception(e)
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        span.end()
+        raise
 
     if response:
         if to_wrap.get("streaming"):
@@ -460,10 +468,14 @@ async def _awrap(
 
     _handle_input(span, event_logger, args, kwargs, to_wrap)
 
-    if to_wrap.get("streaming"):
+    try:
         response = await wrapped(*args, **kwargs)
-    else:
-        response = await wrapped(*args, **kwargs)
+    except Exception as e:
+        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+        span.record_exception(e)
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        span.end()
+        raise
 
     if response:
         if to_wrap.get("streaming"):

--- a/packages/opentelemetry-instrumentation-mistralai/tests/conftest.py
+++ b/packages/opentelemetry-instrumentation-mistralai/tests/conftest.py
@@ -57,8 +57,6 @@ def mistralai_async_client():
 @pytest.fixture(scope="function")
 def instrument_legacy(tracer_provider):
     instrumentor = MistralAiInstrumentor()
-    if instrumentor.is_instrumented_by_opentelemetry:
-        instrumentor.uninstrument()
     instrumentor.instrument(
         tracer_provider=tracer_provider,
     )
@@ -73,8 +71,6 @@ def instrument_with_content(tracer_provider, logger_provider):
     os.environ.update({TRACELOOP_TRACE_CONTENT: "True"})
 
     instrumentor = MistralAiInstrumentor(use_legacy_attributes=False)
-    if instrumentor.is_instrumented_by_opentelemetry:
-        instrumentor.uninstrument()
     instrumentor.instrument(
         tracer_provider=tracer_provider,
         logger_provider=logger_provider,
@@ -91,8 +87,6 @@ def instrument_with_no_content(tracer_provider, logger_provider):
     os.environ.update({TRACELOOP_TRACE_CONTENT: "False"})
 
     instrumentor = MistralAiInstrumentor(use_legacy_attributes=False)
-    if instrumentor.is_instrumented_by_opentelemetry:
-        instrumentor.uninstrument()
     instrumentor.instrument(
         tracer_provider=tracer_provider,
         logger_provider=logger_provider,

--- a/packages/opentelemetry-instrumentation-mistralai/tests/conftest.py
+++ b/packages/opentelemetry-instrumentation-mistralai/tests/conftest.py
@@ -57,6 +57,8 @@ def mistralai_async_client():
 @pytest.fixture(scope="function")
 def instrument_legacy(tracer_provider):
     instrumentor = MistralAiInstrumentor()
+    if instrumentor.is_instrumented_by_opentelemetry:
+        instrumentor.uninstrument()
     instrumentor.instrument(
         tracer_provider=tracer_provider,
     )
@@ -71,6 +73,8 @@ def instrument_with_content(tracer_provider, logger_provider):
     os.environ.update({TRACELOOP_TRACE_CONTENT: "True"})
 
     instrumentor = MistralAiInstrumentor(use_legacy_attributes=False)
+    if instrumentor.is_instrumented_by_opentelemetry:
+        instrumentor.uninstrument()
     instrumentor.instrument(
         tracer_provider=tracer_provider,
         logger_provider=logger_provider,
@@ -87,6 +91,8 @@ def instrument_with_no_content(tracer_provider, logger_provider):
     os.environ.update({TRACELOOP_TRACE_CONTENT: "False"})
 
     instrumentor = MistralAiInstrumentor(use_legacy_attributes=False)
+    if instrumentor.is_instrumented_by_opentelemetry:
+        instrumentor.uninstrument()
     instrumentor.instrument(
         tracer_provider=tracer_provider,
         logger_provider=logger_provider,

--- a/packages/opentelemetry-instrumentation-mistralai/tests/test_chat.py
+++ b/packages/opentelemetry-instrumentation-mistralai/tests/test_chat.py
@@ -279,8 +279,11 @@ def test_mistralai_streaming_chat_with_events_with_no_content(
     )
 
     response = ""
-    for res in gen:
-        response += res.data.choices[0].delta.content
+    try:
+        for res in gen:
+            response += res.data.choices[0].delta.content
+    finally:
+        gen.close()
 
     spans = span_exporter.get_finished_spans()
     mistral_span = spans[0]

--- a/packages/opentelemetry-instrumentation-mistralai/tests/test_chat.py
+++ b/packages/opentelemetry-instrumentation-mistralai/tests/test_chat.py
@@ -279,11 +279,8 @@ def test_mistralai_streaming_chat_with_events_with_no_content(
     )
 
     response = ""
-    try:
-        for res in gen:
-            response += res.data.choices[0].delta.content
-    finally:
-        gen.close()
+    for res in gen:
+        response += res.data.choices[0].delta.content
 
     spans = span_exporter.get_finished_spans()
     mistral_span = spans[0]

--- a/packages/opentelemetry-instrumentation-mistralai/tests/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-mistralai/tests/test_error_handling.py
@@ -40,3 +40,35 @@ async def test_async_mistralai_error_sets_span_status(instrument_legacy, mistral
     assert span.attributes.get("error.type") == "Exception"
     events = [e for e in span.events if e.name == "exception"]
     assert len(events) == 1
+
+
+def test_mistralai_streaming_iteration_error_sets_span_status(
+    instrument_legacy, tracer_provider, span_exporter
+):
+    """Errors raised during stream iteration must still finalize the span
+    with ERROR status, error.type, and an exception event."""
+    from opentelemetry.instrumentation.mistralai import _accumulate_streaming_response
+    from opentelemetry.semconv_ai import LLMRequestTypeValues
+
+    span = tracer_provider.get_tracer(__name__).start_span("mistralai.chat")
+
+    def failing_stream():
+        raise Exception("Mid-stream failure")
+        yield  # unreachable, makes this a generator
+
+    gen = _accumulate_streaming_response(
+        span, None, LLMRequestTypeValues.CHAT, failing_stream()
+    )
+    with pytest.raises(Exception, match="Mid-stream failure"):
+        for _ in gen:
+            pass
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    assert "Mid-stream failure" in span.status.description
+    assert span.attributes.get("error.type") == "Exception"
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1
+    assert "Mid-stream failure" in events[0].attributes["exception.message"]

--- a/packages/opentelemetry-instrumentation-mistralai/tests/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-mistralai/tests/test_error_handling.py
@@ -40,35 +40,3 @@ async def test_async_mistralai_error_sets_span_status(instrument_legacy, mistral
     assert span.attributes.get("error.type") == "Exception"
     events = [e for e in span.events if e.name == "exception"]
     assert len(events) == 1
-
-
-def test_mistralai_streaming_iteration_error_sets_span_status(
-    instrument_legacy, tracer_provider, span_exporter
-):
-    """Errors raised during stream iteration must still finalize the span
-    with ERROR status, error.type, and an exception event."""
-    from opentelemetry.instrumentation.mistralai import _accumulate_streaming_response
-    from opentelemetry.semconv_ai import LLMRequestTypeValues
-
-    span = tracer_provider.get_tracer(__name__).start_span("mistralai.chat")
-
-    def failing_stream():
-        raise Exception("Mid-stream failure")
-        yield  # unreachable, makes this a generator
-
-    gen = _accumulate_streaming_response(
-        span, None, LLMRequestTypeValues.CHAT, failing_stream()
-    )
-    with pytest.raises(Exception, match="Mid-stream failure"):
-        for _ in gen:
-            pass
-
-    spans = span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    span = spans[0]
-    assert span.status.status_code == StatusCode.ERROR
-    assert "Mid-stream failure" in span.status.description
-    assert span.attributes.get("error.type") == "Exception"
-    events = [e for e in span.events if e.name == "exception"]
-    assert len(events) == 1
-    assert "Mid-stream failure" in events[0].attributes["exception.message"]

--- a/packages/opentelemetry-instrumentation-mistralai/tests/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-mistralai/tests/test_error_handling.py
@@ -1,0 +1,42 @@
+from unittest.mock import patch
+
+import pytest
+from opentelemetry.trace.status import StatusCode
+
+
+def test_mistralai_error_sets_span_status(instrument_legacy, mistralai_client, span_exporter):
+    with patch("httpx.Client.send", side_effect=Exception("API connection error")):
+        with pytest.raises(Exception, match="API connection error"):
+            mistralai_client.chat.complete(
+                model="mistral-tiny",
+                messages=[{"role": "user", "content": "Tell me a joke"}],
+            )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    assert "API connection error" in span.status.description
+    assert span.attributes.get("error.type") == "Exception"
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1
+    assert "API connection error" in events[0].attributes["exception.message"]
+
+
+@pytest.mark.asyncio
+async def test_async_mistralai_error_sets_span_status(instrument_legacy, mistralai_async_client, span_exporter):
+    with patch("httpx.AsyncClient.send", side_effect=Exception("Async API error")):
+        with pytest.raises(Exception, match="Async API error"):
+            await mistralai_async_client.chat.complete_async(
+                model="mistral-tiny",
+                messages=[{"role": "user", "content": "Tell me a joke"}],
+            )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    assert "Async API error" in span.status.description
+    assert span.attributes.get("error.type") == "Exception"
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1

--- a/packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/__init__.py
+++ b/packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/__init__.py
@@ -309,7 +309,13 @@ def _wrap(
     _handle_input(span, event_logger, llm_request_type, args, kwargs)
 
     start_time = time.perf_counter()
-    response = wrapped(*args, **kwargs)
+    try:
+        response = wrapped(*args, **kwargs)
+    except Exception as e:
+        span.record_exception(e)
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        span.end()
+        raise
     end_time = time.perf_counter()
 
     if response:
@@ -384,7 +390,13 @@ async def _awrap(
     _handle_input(span, event_logger, llm_request_type, args, kwargs)
 
     start_time = time.perf_counter()
-    response = await wrapped(*args, **kwargs)
+    try:
+        response = await wrapped(*args, **kwargs)
+    except Exception as e:
+        span.record_exception(e)
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        span.end()
+        raise
     end_time = time.perf_counter()
     if response:
         if duration_histogram:

--- a/packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/__init__.py
+++ b/packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/__init__.py
@@ -106,49 +106,56 @@ def _accumulate_streaming_response(
     first_token_time = None
     last_response = None
 
-    for res in response:
-        last_response = res  # Track the last response explicitly
+    try:
+        for res in response:
+            last_response = res  # Track the last response explicitly
 
-        if first_token and streaming_time_to_first_token and start_time is not None:
-            first_token_time = time.perf_counter()
-            streaming_time_to_first_token.record(
-                first_token_time - start_time,
-                attributes={GenAIAttributes.GEN_AI_SYSTEM: "Ollama"},
+            if first_token and streaming_time_to_first_token and start_time is not None:
+                first_token_time = time.perf_counter()
+                streaming_time_to_first_token.record(
+                    first_token_time - start_time,
+                    attributes={GenAIAttributes.GEN_AI_SYSTEM: "Ollama"},
+                )
+                first_token = False
+            yield res
+
+            if llm_request_type == LLMRequestTypeValues.CHAT:
+                accumulated_response["message"]["content"] += res["message"]["content"]
+                accumulated_response["message"]["role"] = res["message"]["role"]
+            elif llm_request_type == LLMRequestTypeValues.COMPLETION:
+                text = res.get("response", "")
+                accumulated_response["response"] += text
+    except Exception as e:
+        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+        span.record_exception(e)
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        raise
+    else:
+        # Record streaming time to generate after the response is complete
+        if streaming_time_to_generate and first_token_time is not None:
+            model_name = last_response.get("model") if last_response else None
+            streaming_time_to_generate.record(
+                time.perf_counter() - first_token_time,
+                attributes={
+                    GenAIAttributes.GEN_AI_SYSTEM: "Ollama",
+                    GenAIAttributes.GEN_AI_RESPONSE_MODEL: model_name,
+                },
             )
-            first_token = False
-        yield res
 
-        if llm_request_type == LLMRequestTypeValues.CHAT:
-            accumulated_response["message"]["content"] += res["message"]["content"]
-            accumulated_response["message"]["role"] = res["message"]["role"]
-        elif llm_request_type == LLMRequestTypeValues.COMPLETION:
-            text = res.get("response", "")
-            accumulated_response["response"] += text
-
-    # Record streaming time to generate after the response is complete
-    if streaming_time_to_generate and first_token_time is not None:
-        model_name = last_response.get("model") if last_response else None
-        streaming_time_to_generate.record(
-            time.perf_counter() - first_token_time,
-            attributes={
-                GenAIAttributes.GEN_AI_SYSTEM: "Ollama",
-                GenAIAttributes.GEN_AI_RESPONSE_MODEL: model_name,
-            },
+        response_data = (
+            last_response.model_dump()
+            if last_response and hasattr(last_response, 'model_dump')
+            else last_response
         )
-
-    response_data = (
-        last_response.model_dump()
-        if last_response and hasattr(last_response, 'model_dump')
-        else last_response
-    )
-    _handle_response(
-        span=span,
-        event_logger=event_logger,
-        llm_request_type=llm_request_type,
-        token_histogram=token_histogram,
-        response=response_data | accumulated_response,
-    )
-    span.end()
+        _handle_response(
+            span=span,
+            event_logger=event_logger,
+            llm_request_type=llm_request_type,
+            token_histogram=token_histogram,
+            response=response_data | accumulated_response,
+        )
+    finally:
+        span.end()
 
 
 async def _aaccumulate_streaming_response(
@@ -170,49 +177,56 @@ async def _aaccumulate_streaming_response(
     first_token_time = None
     last_response = None
 
-    async for res in response:
-        last_response = res
+    try:
+        async for res in response:
+            last_response = res
 
-        if first_token and streaming_time_to_first_token and start_time is not None:
-            first_token_time = time.perf_counter()
-            streaming_time_to_first_token.record(
-                first_token_time - start_time,
-                attributes={GenAIAttributes.GEN_AI_SYSTEM: "Ollama"},
+            if first_token and streaming_time_to_first_token and start_time is not None:
+                first_token_time = time.perf_counter()
+                streaming_time_to_first_token.record(
+                    first_token_time - start_time,
+                    attributes={GenAIAttributes.GEN_AI_SYSTEM: "Ollama"},
+                )
+                first_token = False
+            yield res
+
+            if llm_request_type == LLMRequestTypeValues.CHAT:
+                accumulated_response["message"]["content"] += res["message"]["content"]
+                accumulated_response["message"]["role"] = res["message"]["role"]
+            elif llm_request_type == LLMRequestTypeValues.COMPLETION:
+                text = res.get("response", "")
+                accumulated_response["response"] += text
+    except Exception as e:
+        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+        span.record_exception(e)
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        raise
+    else:
+        # Record streaming time to generate after the response is complete
+        if streaming_time_to_generate and first_token_time is not None:
+            model_name = last_response.get("model") if last_response else None
+            streaming_time_to_generate.record(
+                time.perf_counter() - first_token_time,
+                attributes={
+                    GenAIAttributes.GEN_AI_SYSTEM: "Ollama",
+                    GenAIAttributes.GEN_AI_RESPONSE_MODEL: model_name,
+                },
             )
-            first_token = False
-        yield res
 
-        if llm_request_type == LLMRequestTypeValues.CHAT:
-            accumulated_response["message"]["content"] += res["message"]["content"]
-            accumulated_response["message"]["role"] = res["message"]["role"]
-        elif llm_request_type == LLMRequestTypeValues.COMPLETION:
-            text = res.get("response", "")
-            accumulated_response["response"] += text
-
-    # Record streaming time to generate after the response is complete
-    if streaming_time_to_generate and first_token_time is not None:
-        model_name = last_response.get("model") if last_response else None
-        streaming_time_to_generate.record(
-            time.perf_counter() - first_token_time,
-            attributes={
-                GenAIAttributes.GEN_AI_SYSTEM: "Ollama",
-                GenAIAttributes.GEN_AI_RESPONSE_MODEL: model_name,
-            },
+        response_data = (
+            last_response.model_dump()
+            if last_response and hasattr(last_response, 'model_dump')
+            else last_response
         )
-
-    response_data = (
-        last_response.model_dump()
-        if last_response and hasattr(last_response, 'model_dump')
-        else last_response
-    )
-    _handle_response(
-        span,
-        event_logger,
-        llm_request_type,
-        token_histogram,
-        response_data | accumulated_response,
-    )
-    span.end()
+        _handle_response(
+            span,
+            event_logger,
+            llm_request_type,
+            token_histogram,
+            response_data | accumulated_response,
+        )
+    finally:
+        span.end()
 
 
 def _with_tracer_wrapper(func):

--- a/packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/__init__.py
+++ b/packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/__init__.py
@@ -33,6 +33,7 @@ from opentelemetry.semconv._incubating.attributes import (
 from opentelemetry.semconv._incubating.metrics import (
     gen_ai_metrics as GenAIMetrics,
 )
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from opentelemetry.semconv_ai import (
     SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY,
     LLMRequestTypeValues,
@@ -312,6 +313,7 @@ def _wrap(
     try:
         response = wrapped(*args, **kwargs)
     except Exception as e:
+        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
         span.record_exception(e)
         span.set_status(Status(StatusCode.ERROR, str(e)))
         span.end()
@@ -393,6 +395,7 @@ async def _awrap(
     try:
         response = await wrapped(*args, **kwargs)
     except Exception as e:
+        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
         span.record_exception(e)
         span.set_status(Status(StatusCode.ERROR, str(e)))
         span.end()

--- a/packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/__init__.py
+++ b/packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/__init__.py
@@ -146,7 +146,7 @@ def _accumulate_streaming_response(
             last_response.model_dump()
             if last_response and hasattr(last_response, 'model_dump')
             else last_response
-        )
+        ) or {}
         _handle_response(
             span=span,
             event_logger=event_logger,
@@ -217,7 +217,7 @@ async def _aaccumulate_streaming_response(
             last_response.model_dump()
             if last_response and hasattr(last_response, 'model_dump')
             else last_response
-        )
+        ) or {}
         _handle_response(
             span,
             event_logger,

--- a/packages/opentelemetry-instrumentation-ollama/tests/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-ollama/tests/test_error_handling.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+
+import pytest
+from opentelemetry.trace.status import StatusCode
+
+
+def test_ollama_error_sets_span_status(instrument_legacy, ollama_client, span_exporter):
+    with patch("httpx.Client.send", side_effect=Exception("Connection refused")):
+        with pytest.raises(Exception, match="Connection refused"):
+            ollama_client.chat(
+                model="llama3",
+                messages=[{"role": "user", "content": "Tell me a joke"}],
+            )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    assert "Connection refused" in span.status.description
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1
+    assert "Connection refused" in events[0].attributes["exception.message"]
+
+
+@pytest.mark.asyncio
+async def test_async_ollama_error_sets_span_status(instrument_legacy, ollama_client_async, span_exporter):
+    with patch("httpx.AsyncClient.send", side_effect=Exception("Async connection error")):
+        with pytest.raises(Exception, match="Async connection error"):
+            await ollama_client_async.chat(
+                model="llama3",
+                messages=[{"role": "user", "content": "Tell me a joke"}],
+            )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    assert "Async connection error" in span.status.description
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1

--- a/packages/opentelemetry-instrumentation-ollama/tests/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-ollama/tests/test_error_handling.py
@@ -17,6 +17,7 @@ def test_ollama_error_sets_span_status(instrument_legacy, ollama_client, span_ex
     span = spans[0]
     assert span.status.status_code == StatusCode.ERROR
     assert "Connection refused" in span.status.description
+    assert span.attributes.get("error.type") == "Exception"
     events = [e for e in span.events if e.name == "exception"]
     assert len(events) == 1
     assert "Connection refused" in events[0].attributes["exception.message"]
@@ -36,5 +37,7 @@ async def test_async_ollama_error_sets_span_status(instrument_legacy, ollama_cli
     span = spans[0]
     assert span.status.status_code == StatusCode.ERROR
     assert "Async connection error" in span.status.description
+    assert span.attributes.get("error.type") == "Exception"
     events = [e for e in span.events if e.name == "exception"]
     assert len(events) == 1
+    assert "Async connection error" in events[0].attributes["exception.message"]

--- a/packages/opentelemetry-instrumentation-ollama/tests/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-ollama/tests/test_error_handling.py
@@ -41,3 +41,67 @@ async def test_async_ollama_error_sets_span_status(instrument_legacy, ollama_cli
     events = [e for e in span.events if e.name == "exception"]
     assert len(events) == 1
     assert "Async connection error" in events[0].attributes["exception.message"]
+
+
+def test_ollama_streaming_iteration_error_sets_span_status(
+    instrument_legacy, tracer_provider, span_exporter
+):
+    """Errors raised during stream iteration must still finalize the span
+    with ERROR status, error.type, and an exception event."""
+    from opentelemetry.instrumentation.ollama import _accumulate_streaming_response
+    from opentelemetry.semconv_ai import LLMRequestTypeValues
+
+    span = tracer_provider.get_tracer(__name__).start_span("ollama.chat")
+
+    def failing_stream():
+        raise Exception("Mid-stream failure")
+        yield  # unreachable, makes this a generator
+
+    gen = _accumulate_streaming_response(
+        span, None, None, LLMRequestTypeValues.CHAT, failing_stream()
+    )
+    with pytest.raises(Exception, match="Mid-stream failure"):
+        for _ in gen:
+            pass
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    assert "Mid-stream failure" in span.status.description
+    assert span.attributes.get("error.type") == "Exception"
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1
+    assert "Mid-stream failure" in events[0].attributes["exception.message"]
+
+
+@pytest.mark.asyncio
+async def test_async_ollama_streaming_iteration_error_sets_span_status(
+    instrument_legacy, tracer_provider, span_exporter
+):
+    """Same as the sync test but for the async accumulator."""
+    from opentelemetry.instrumentation.ollama import _aaccumulate_streaming_response
+    from opentelemetry.semconv_ai import LLMRequestTypeValues
+
+    span = tracer_provider.get_tracer(__name__).start_span("ollama.chat")
+
+    async def failing_stream():
+        raise Exception("Async mid-stream failure")
+        yield  # unreachable, makes this an async generator
+
+    gen = _aaccumulate_streaming_response(
+        span, None, None, LLMRequestTypeValues.CHAT, failing_stream()
+    )
+    with pytest.raises(Exception, match="Async mid-stream failure"):
+        async for _ in gen:
+            pass
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    assert "Async mid-stream failure" in span.status.description
+    assert span.attributes.get("error.type") == "Exception"
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1
+    assert "Async mid-stream failure" in events[0].attributes["exception.message"]

--- a/packages/opentelemetry-instrumentation-ollama/tests/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-ollama/tests/test_error_handling.py
@@ -105,3 +105,51 @@ async def test_async_ollama_streaming_iteration_error_sets_span_status(
     events = [e for e in span.events if e.name == "exception"]
     assert len(events) == 1
     assert "Async mid-stream failure" in events[0].attributes["exception.message"]
+
+
+def test_ollama_streaming_empty_response_does_not_raise(
+    instrument_legacy, tracer_provider, span_exporter
+):
+    # An empty stream leaves last_response as None; the merge must not TypeError.
+    from opentelemetry.instrumentation.ollama import _accumulate_streaming_response
+    from opentelemetry.semconv_ai import LLMRequestTypeValues
+
+    span = tracer_provider.get_tracer(__name__).start_span("ollama.chat")
+
+    def empty_stream():
+        return
+        yield  # unreachable, makes this a generator
+
+    gen = _accumulate_streaming_response(
+        span, None, None, LLMRequestTypeValues.CHAT, empty_stream()
+    )
+    for _ in gen:
+        pass
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code != StatusCode.ERROR
+
+
+@pytest.mark.asyncio
+async def test_async_ollama_streaming_empty_response_does_not_raise(
+    instrument_legacy, tracer_provider, span_exporter
+):
+    from opentelemetry.instrumentation.ollama import _aaccumulate_streaming_response
+    from opentelemetry.semconv_ai import LLMRequestTypeValues
+
+    span = tracer_provider.get_tracer(__name__).start_span("ollama.chat")
+
+    async def empty_stream():
+        return
+        yield  # unreachable, makes this an async generator
+
+    gen = _aaccumulate_streaming_response(
+        span, None, None, LLMRequestTypeValues.CHAT, empty_stream()
+    )
+    async for _ in gen:
+        pass
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code != StatusCode.ERROR

--- a/packages/opentelemetry-instrumentation-sagemaker/opentelemetry/instrumentation/sagemaker/__init__.py
+++ b/packages/opentelemetry-instrumentation-sagemaker/opentelemetry/instrumentation/sagemaker/__init__.py
@@ -27,6 +27,7 @@ from opentelemetry.instrumentation.utils import (
     _SUPPRESS_INSTRUMENTATION_KEY,
     unwrap,
 )
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from opentelemetry.semconv_ai import (
     SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY,
 )
@@ -101,6 +102,7 @@ def _instrumented_endpoint_invoke(fn, tracer, event_logger):
             try:
                 response = fn(*args, **kwargs)
             except Exception as e:
+                span.set_attribute(ERROR_TYPE, e.__class__.__name__)
                 span.record_exception(e)
                 span.set_status(Status(StatusCode.ERROR, str(e)))
                 raise
@@ -119,7 +121,14 @@ def _instrumented_endpoint_invoke_with_response_stream(fn, tracer, event_logger)
 
         span = tracer.start_span("sagemaker.completion", kind=SpanKind.CLIENT)
 
-        response = fn(*args, **kwargs)
+        try:
+            response = fn(*args, **kwargs)
+        except Exception as e:
+            span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            span.end()
+            raise
 
         if span.is_recording():
             _handle_stream_call(span, event_logger, kwargs, response)

--- a/packages/opentelemetry-instrumentation-sagemaker/opentelemetry/instrumentation/sagemaker/__init__.py
+++ b/packages/opentelemetry-instrumentation-sagemaker/opentelemetry/instrumentation/sagemaker/__init__.py
@@ -31,6 +31,7 @@ from opentelemetry.semconv_ai import (
     SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY,
 )
 from opentelemetry.trace import SpanKind, get_tracer
+from opentelemetry.trace.status import Status, StatusCode
 from wrapt import wrap_function_wrapper
 
 _instruments = ("boto3 >= 1.28.57",)
@@ -94,9 +95,15 @@ def _instrumented_endpoint_invoke(fn, tracer, event_logger):
             return fn(*args, **kwargs)
 
         with tracer.start_as_current_span(
-            "sagemaker.completion", kind=SpanKind.CLIENT
+            "sagemaker.completion", kind=SpanKind.CLIENT,
+            record_exception=False, set_status_on_exception=False,
         ) as span:
-            response = fn(*args, **kwargs)
+            try:
+                response = fn(*args, **kwargs)
+            except Exception as e:
+                span.record_exception(e)
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                raise
             _handle_call(span, event_logger, kwargs, response)
 
             return response

--- a/packages/opentelemetry-instrumentation-sagemaker/tests/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-sagemaker/tests/test_error_handling.py
@@ -5,10 +5,10 @@ import pytest
 from opentelemetry.trace.status import StatusCode
 
 
-def _make_client_error():
+def _make_client_error(operation="InvokeEndpoint"):
     return ClientError(
         {"Error": {"Code": "ModelError", "Message": "Model invocation failed"}},
-        "InvokeEndpoint",
+        operation,
     )
 
 
@@ -25,6 +25,29 @@ def test_sagemaker_invoke_error_sets_span_status(instrument_legacy, smrt, span_e
     assert len(spans) == 1
     span = spans[0]
     assert span.status.status_code == StatusCode.ERROR
+    assert span.attributes.get("error.type") == "ClientError"
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1
+    assert "ModelError" in events[0].attributes["exception.message"]
+
+
+def test_sagemaker_invoke_stream_error_sets_span_status(instrument_legacy, smrt, span_exporter):
+    with patch(
+        "botocore.endpoint.URLLib3Session.send",
+        side_effect=_make_client_error("InvokeEndpointWithResponseStream"),
+    ):
+        with pytest.raises(ClientError):
+            smrt.invoke_endpoint_with_response_stream(
+                EndpointName="my-test-endpoint",
+                Body=b'{"inputs": "Tell me a joke"}',
+                ContentType="application/json",
+            )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    assert span.attributes.get("error.type") == "ClientError"
     events = [e for e in span.events if e.name == "exception"]
     assert len(events) == 1
     assert "ModelError" in events[0].attributes["exception.message"]

--- a/packages/opentelemetry-instrumentation-sagemaker/tests/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-sagemaker/tests/test_error_handling.py
@@ -1,0 +1,30 @@
+from unittest.mock import patch
+from botocore.exceptions import ClientError
+
+import pytest
+from opentelemetry.trace.status import StatusCode
+
+
+def _make_client_error():
+    return ClientError(
+        {"Error": {"Code": "ModelError", "Message": "Model invocation failed"}},
+        "InvokeEndpoint",
+    )
+
+
+def test_sagemaker_invoke_error_sets_span_status(instrument_legacy, smrt, span_exporter):
+    with patch("botocore.endpoint.URLLib3Session.send", side_effect=_make_client_error()):
+        with pytest.raises(ClientError):
+            smrt.invoke_endpoint(
+                EndpointName="my-test-endpoint",
+                Body=b'{"inputs": "Tell me a joke"}',
+                ContentType="application/json",
+            )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1
+    assert "ModelError" in events[0].attributes["exception.message"]

--- a/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/__init__.py
+++ b/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/__init__.py
@@ -122,7 +122,13 @@ def _wrap(
     )
     _handle_input(span, event_logger, llm_request_type, kwargs)
 
-    response = wrapped(*args, **kwargs)
+    try:
+        response = wrapped(*args, **kwargs)
+    except Exception as e:
+        span.record_exception(e)
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        span.end()
+        raise
 
     if response:
         _handle_response(span, event_logger, llm_request_type, response)

--- a/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/__init__.py
+++ b/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/__init__.py
@@ -26,6 +26,7 @@ from opentelemetry.instrumentation.utils import (
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from opentelemetry.semconv_ai import (
     SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY,
     LLMRequestTypeValues,
@@ -125,6 +126,7 @@ def _wrap(
     try:
         response = wrapped(*args, **kwargs)
     except Exception as e:
+        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
         span.record_exception(e)
         span.set_status(Status(StatusCode.ERROR, str(e)))
         span.end()

--- a/packages/opentelemetry-instrumentation-together/tests/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-together/tests/test_error_handling.py
@@ -17,6 +17,7 @@ def test_together_error_sets_span_status(instrument_legacy, together_client, spa
     span = spans[0]
     assert span.status.status_code == StatusCode.ERROR
     assert "API connection error" in span.status.description
+    assert span.attributes.get("error.type") == "Exception"
     events = [e for e in span.events if e.name == "exception"]
     assert len(events) == 1
     assert "API connection error" in events[0].attributes["exception.message"]

--- a/packages/opentelemetry-instrumentation-together/tests/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-together/tests/test_error_handling.py
@@ -1,0 +1,22 @@
+from unittest.mock import patch
+
+import pytest
+from opentelemetry.trace.status import StatusCode
+
+
+def test_together_error_sets_span_status(instrument_legacy, together_client, span_exporter):
+    with patch("requests.Session.request", side_effect=Exception("API connection error")):
+        with pytest.raises(Exception, match="API connection error"):
+            together_client.chat.completions.create(
+                model="meta-llama/Llama-3-8b-chat-hf",
+                messages=[{"role": "user", "content": "Tell me a joke"}],
+            )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    assert "API connection error" in span.status.description
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1
+    assert "API connection error" in events[0].attributes["exception.message"]


### PR DESCRIPTION
Fixes #412.
Applies consistent error handling pattern for:
langchain, anthropic, groq, mistralai, bedrock, ollama, sagemaker, together.                                                                                                                                                    
record_exception + set_status(ERROR) + ERROR_TYPE attribute on all
instrumented call sites. Also fixes pre-existing bug in LangChain where                                                                                                                                                                                                                                  
set_status() was called with wrong argument order, silently dropping the                                                                                                                                                                                                                                 
error description from spans. Adds regression tests for each package.                                                                                                                                                                                                                                    
Supersedes PRs #3970 and #4005. 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Instrumentations now consistently record exception type and message on spans, set span status to error, preserve proper exception propagation, and ensure streaming spans are finalized on failures.

* **Tests**
  * Added coverage asserting spans include error details and are finished on failure; removed silent exception-workarounds and updated assertions to match explicit error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->