### PR TITLE
fix(chromadb,lancedb,weaviate,pinecone): record exceptions and set ERROR status on failed span

### DIFF
--- a/packages/opentelemetry-instrumentation-chromadb/opentelemetry/instrumentation/chromadb/wrapper.py
+++ b/packages/opentelemetry-instrumentation-chromadb/opentelemetry/instrumentation/chromadb/wrapper.py
@@ -1,5 +1,7 @@
 from opentelemetry.instrumentation.chromadb.utils import dont_throw
 from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
+from opentelemetry.trace.status import Status, StatusCode
 
 from opentelemetry import context as context_api
 from opentelemetry.instrumentation.utils import (
@@ -37,7 +39,9 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
 
     name = to_wrap.get("span_name")
-    with tracer.start_as_current_span(name) as span:
+    with tracer.start_as_current_span(
+        name, record_exception=False, set_status_on_exception=False
+    ) as span:
         span.set_attribute(SpanAttributes.DB_SYSTEM, "chroma")
         span.set_attribute(SpanAttributes.DB_OPERATION, to_wrap.get("method"))
 
@@ -61,7 +65,13 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         elif to_wrap.get("method") == "delete":
             _set_delete_attributes(span, kwargs)
 
-        return_value = wrapped(*args, **kwargs)
+        try:
+            return_value = wrapped(*args, **kwargs)
+        except Exception as e:
+            span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            raise
         if to_wrap.get("method") == "query":
             _add_query_result_events(span, return_value)
 

--- a/packages/opentelemetry-instrumentation-chromadb/tests/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-chromadb/tests/test_error_handling.py
@@ -1,0 +1,55 @@
+from unittest.mock import patch
+
+import chromadb
+import pytest
+from opentelemetry.trace.status import StatusCode
+
+
+chroma = chromadb.EphemeralClient()
+
+
+@pytest.fixture
+def collection(exporter):
+    col = chroma.create_collection(name="test_errors")
+    yield col
+    chroma.delete_collection(name="test_errors")
+
+
+def test_chromadb_add_error_sets_span_status_and_error_type(exporter, collection):
+    # Patch the internal client method so the wrapt wrapper (and thus the span) still fires
+    with patch.object(
+        type(collection._client), "_add", side_effect=Exception("DB write error")
+    ):
+        with pytest.raises(Exception, match="DB write error"):
+            collection.add(ids=["id1"], documents=["some document"])
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+
+    assert span.status.status_code == StatusCode.ERROR
+    assert "DB write error" in span.status.description
+    assert span.attributes.get("error.type") == "Exception"
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1
+    assert "DB write error" in events[0].attributes["exception.message"]
+
+
+def test_chromadb_query_error_sets_span_status_and_error_type(exporter, collection):
+    collection.add(ids=["id1"], documents=["some document"])
+
+    with patch.object(
+        type(collection._client), "_query", side_effect=Exception("Query failed")
+    ):
+        with pytest.raises(Exception, match="Query failed"):
+            collection.query(query_texts=["test query"], n_results=1)
+
+    spans = exporter.get_finished_spans()
+    error_spans = [s for s in spans if s.status.status_code == StatusCode.ERROR]
+    assert len(error_spans) == 1
+    span = error_spans[0]
+
+    assert "Query failed" in span.status.description
+    assert span.attributes.get("error.type") == "Exception"
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) == 1

--- a/packages/opentelemetry-instrumentation-chromadb/uv.lock
+++ b/packages/opentelemetry-instrumentation-chromadb/uv.lock
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-chromadb"
-version = "0.53.3"
+version = "0.60.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },

--- a/packages/opentelemetry-instrumentation-lancedb/opentelemetry/instrumentation/lancedb/wrapper.py
+++ b/packages/opentelemetry-instrumentation-lancedb/opentelemetry/instrumentation/lancedb/wrapper.py
@@ -1,5 +1,7 @@
 from opentelemetry.instrumentation.lancedb.utils import dont_throw
 from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
+from opentelemetry.trace.status import Status, StatusCode
 
 from opentelemetry import context as context_api
 from opentelemetry.instrumentation.utils import (
@@ -34,7 +36,9 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
 
     name = to_wrap.get("span_name")
-    with tracer.start_as_current_span(name) as span:
+    with tracer.start_as_current_span(
+        name, record_exception=False, set_status_on_exception=False
+    ) as span:
         span.set_attribute(SpanAttributes.DB_SYSTEM, "lancedb")
         span.set_attribute(SpanAttributes.DB_OPERATION, to_wrap.get("method"))
 
@@ -45,7 +49,13 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         elif to_wrap.get("method") == "delete":
             _set_delete_attributes(span, kwargs)
 
-        return_value = wrapped(*args, **kwargs)
+        try:
+            return_value = wrapped(*args, **kwargs)
+        except Exception as e:
+            span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            raise
 
     return return_value
 

--- a/packages/opentelemetry-instrumentation-lancedb/uv.lock
+++ b/packages/opentelemetry-instrumentation-lancedb/uv.lock
@@ -201,7 +201,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-lancedb"
-version = "0.53.3"
+version = "0.60.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },

--- a/packages/opentelemetry-instrumentation-pinecone/opentelemetry/instrumentation/pinecone/__init__.py
+++ b/packages/opentelemetry-instrumentation-pinecone/opentelemetry/instrumentation/pinecone/__init__.py
@@ -11,6 +11,7 @@ from opentelemetry import context as context_api
 from opentelemetry.metrics import get_meter
 from opentelemetry.trace import get_tracer, SpanKind
 from opentelemetry.trace.status import Status, StatusCode
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import (
@@ -143,6 +144,8 @@ def _wrap(
         attributes={
             AISpanAttributes.VECTOR_DB_VENDOR: "Pinecone",
         },
+        record_exception=False,
+        set_status_on_exception=False,
     ) as span:
         if span.is_recording():
             _set_input_attributes(span, instance, kwargs)
@@ -154,7 +157,13 @@ def _wrap(
             shared_attributes["server.address"] = instance._config.host
 
         start_time = time.time()
-        response = wrapped(*args, **kwargs)
+        try:
+            response = wrapped(*args, **kwargs)
+        except Exception as e:
+            span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            raise
         end_time = time.time()
 
         duration = end_time - start_time

--- a/packages/opentelemetry-instrumentation-pinecone/tests/conftest.py
+++ b/packages/opentelemetry-instrumentation-pinecone/tests/conftest.py
@@ -47,6 +47,11 @@ def instrument(traces_exporter, metrics_reader):
 
 
 @pytest.fixture(autouse=True)
+def clear_exporter(traces_exporter):
+    traces_exporter.clear()
+
+
+@pytest.fixture(autouse=True)
 def environment():
     if "OPENAI_API_KEY" not in os.environ:
         os.environ["OPENAI_API_KEY"] = "test_api_key"

--- a/packages/opentelemetry-instrumentation-pinecone/tests/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-pinecone/tests/test_error_handling.py
@@ -1,0 +1,22 @@
+from unittest.mock import patch
+
+import pytest
+from opentelemetry.trace.status import StatusCode
+from pinecone import Pinecone
+
+
+def test_pinecone_query_error_sets_span_status_and_error_type(traces_exporter):
+    with patch("httpx.Client.send", side_effect=Exception("Connection error")):
+        with pytest.raises(Exception):
+            pc = Pinecone(api_key="bad-key")
+            index = pc.Index(host="https://test-index.pinecone.io")
+            index.query(vector=[0.1] * 1536, top_k=1)
+
+    spans = traces_exporter.get_finished_spans()
+    error_spans = [s for s in spans if s.status.status_code == StatusCode.ERROR]
+    assert len(error_spans) >= 1
+    span = error_spans[0]
+
+    assert span.attributes.get("error.type") is not None
+    events = [e for e in span.events if e.name == "exception"]
+    assert len(events) >= 1

--- a/packages/opentelemetry-instrumentation-pinecone/tests/test_error_handling.py
+++ b/packages/opentelemetry-instrumentation-pinecone/tests/test_error_handling.py
@@ -6,17 +6,24 @@ from pinecone import Pinecone
 
 
 def test_pinecone_query_error_sets_span_status_and_error_type(traces_exporter):
-    with patch("httpx.Client.send", side_effect=Exception("Connection error")):
+    with patch(
+        "urllib3.connectionpool.HTTPSConnectionPool.urlopen",
+        side_effect=Exception("Connection error"),
+    ):
         with pytest.raises(Exception):
             pc = Pinecone(api_key="bad-key")
             index = pc.Index(host="https://test-index.pinecone.io")
             index.query(vector=[0.1] * 1536, top_k=1)
 
     spans = traces_exporter.get_finished_spans()
-    error_spans = [s for s in spans if s.status.status_code == StatusCode.ERROR]
-    assert len(error_spans) >= 1
-    span = error_spans[0]
+    query_spans = [
+        s for s in spans
+        if s.name == "pinecone.query" and s.status.status_code == StatusCode.ERROR
+    ]
+    assert len(query_spans) == 1
+    span = query_spans[0]
 
-    assert span.attributes.get("error.type") is not None
+    assert span.attributes.get("error.type") == "Exception"
     events = [e for e in span.events if e.name == "exception"]
-    assert len(events) >= 1
+    assert len(events) == 1
+    assert "Connection error" in events[0].attributes["exception.message"]

--- a/packages/opentelemetry-instrumentation-pinecone/uv.lock
+++ b/packages/opentelemetry-instrumentation-pinecone/uv.lock
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-openai"
-version = "0.53.3"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-openai" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -583,7 +583,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-pinecone"
-version = "0.53.3"
+version = "0.60.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },

--- a/packages/opentelemetry-instrumentation-weaviate/opentelemetry/instrumentation/weaviate/wrapper.py
+++ b/packages/opentelemetry-instrumentation-weaviate/opentelemetry/instrumentation/weaviate/wrapper.py
@@ -6,6 +6,8 @@ from opentelemetry import context as context_api
 from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.instrumentation.weaviate.utils import dont_throw
 from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
+from opentelemetry.trace.status import Status, StatusCode
 
 
 logger = logging.getLogger(__name__)
@@ -37,7 +39,9 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
 
     name = to_wrap.get("span_name")
-    with tracer.start_as_current_span(name) as span:
+    with tracer.start_as_current_span(
+        name, record_exception=False, set_status_on_exception=False
+    ) as span:
         span.set_attribute(SpanAttributes.DB_SYSTEM, "weaviate")
         span.set_attribute(SpanAttributes.DB_OPERATION, to_wrap.get("method"))
 
@@ -46,7 +50,13 @@ def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
         if instrumentor:
             instrumentor.instrument(to_wrap.get("method"), span, args, kwargs)
 
-        return_value = wrapped(*args, **kwargs)
+        try:
+            return_value = wrapped(*args, **kwargs)
+        except Exception as e:
+            span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            raise
 
     return return_value
 


### PR DESCRIPTION
Fixes #412.
Applies consistent error handling pattern for vector DB packages:                                                                                                                                                                                                                      
record_exception + set_status(ERROR) + ERROR_TYPE attribute on all instrumented
call sites. Supersedes PR #4006 which was missing ERROR_TYPE. Adds regression                                                                                                                                                                                                                            
tests for chromadb and pinecone. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instrumentation now explicitly records exception events, sets error-type attributes, and marks spans as errored when operations fail, improving trace clarity.

* **Tests**
  * Added tests validating span error reporting across instrumentations and a session-scoped fixture to ensure a clean in-memory span exporter between test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4102)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->