### PR TITLE
fix(mcp): set error.type attribute on protocol-level tool errors

### DIFF
--- a/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
+++ b/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
@@ -341,6 +341,7 @@ class McpInstrumentor(BaseInstrumentor):
                 )
             # Handle errors
             if hasattr(result, "isError") and result.isError:
+                span.set_attribute(ERROR_TYPE, "tool_error")
                 if len(result.content) > 0:
                     span.set_status(
                         Status(StatusCode.ERROR, f"{result.content[0].text}")
@@ -569,6 +570,7 @@ class InstrumentedStreamWriter(ObjectProxy):  # type: ignore
                 )
                 if "isError" in request.result:
                     if request.result["isError"] is True:
+                        span.set_attribute(ERROR_TYPE, "tool_error")
                         span.set_status(
                             Status(
                                 StatusCode.ERROR,

--- a/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
+++ b/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
@@ -570,7 +570,6 @@ class InstrumentedStreamWriter(ObjectProxy):  # type: ignore
                 )
                 if "isError" in request.result:
                     if request.result["isError"] is True:
-                        span.set_attribute(ERROR_TYPE, "tool_error")
                         span.set_status(
                             Status(
                                 StatusCode.ERROR,

--- a/packages/opentelemetry-instrumentation-mcp/tests/conftest.py
+++ b/packages/opentelemetry-instrumentation-mcp/tests/conftest.py
@@ -21,12 +21,19 @@ def fixture_tracer_provider(span_exporter):
     provider.shutdown()
 
 
-@pytest.fixture(autouse=True)
-def instrument_mcp(tracer_provider, span_exporter):
+# Session-scoped: McpInstrumentor wraps process-level imports (BaseSession.send_request,
+# post-import hooks on fastmcp.client, etc.). Re-instrumenting per test stacks wrappers
+# because _uninstrument doesn't fully tear them down — that breaks tests whose assertions
+# depend on a single wrapping layer (e.g. trace-id sharing in test_fastmcp.py).
+@pytest.fixture(scope="session", autouse=True)
+def instrument_mcp(tracer_provider):
     instrumenter = McpInstrumentor()
     instrumenter.instrument(tracer_provider=tracer_provider)
-    try:
-        yield
-    finally:
-        instrumenter.uninstrument()
-        span_exporter.clear()
+    yield
+    instrumenter.uninstrument()
+
+
+@pytest.fixture(autouse=True)
+def clear_spans(span_exporter):
+    yield
+    span_exporter.clear()

--- a/packages/opentelemetry-instrumentation-mcp/tests/test_error_type.py
+++ b/packages/opentelemetry-instrumentation-mcp/tests/test_error_type.py
@@ -1,0 +1,52 @@
+"""Tests for error.type attribute on protocol-level MCP tool errors (issue #4037)."""
+import pytest
+from opentelemetry.trace.status import StatusCode
+
+
+@pytest.mark.asyncio
+async def test_tool_error_sets_error_type_on_server_span(span_exporter, tracer_provider):
+    """
+    When a FastMCP tool raises an exception, the server-side span must have
+    error.type set. The server-side span hits the isError=True code path in
+    _execute_and_handle_result — that's the bug location.
+    """
+    from fastmcp import FastMCP, Client
+
+    server = FastMCP("test-error-type")
+
+    @server.tool()
+    async def fail_tool(x: int) -> str:
+        raise ValueError("intentional tool error")
+
+    try:
+        async with Client(server) as client:
+            await client.call_tool("fail_tool", {"x": 1})
+    except Exception:
+        pass  # client raises ToolError or re-raises ValueError — expected
+
+    spans = span_exporter.get_finished_spans()
+
+    # The server-side tool span is the one that goes through _execute_and_handle_result
+    # with isError=True. It should have error.type set.
+    server_tool_spans = [
+        s for s in spans
+        if s.name == "fail_tool.tool" and s.status.status_code == StatusCode.ERROR
+    ]
+
+    assert len(server_tool_spans) >= 1, (
+        f"Expected at least 1 ERROR fail_tool.tool span, got: {[s.name for s in spans]}"
+    )
+
+    # All ERROR tool spans should have error.type set
+    for span in server_tool_spans:
+        assert span.attributes.get("error.type") is not None, (
+            f"error.type missing on ERROR span '{span.name}'"
+        )
+
+    # The server-side span specifically should have "tool_error" (isError=True path)
+    tool_error_values = [
+        s.attributes.get("error.type") for s in server_tool_spans
+    ]
+    assert "tool_error" in tool_error_values, (
+        f"Expected 'tool_error' in error.type values, got: {tool_error_values}"
+    )

--- a/packages/opentelemetry-instrumentation-mcp/tests/test_error_type.py
+++ b/packages/opentelemetry-instrumentation-mcp/tests/test_error_type.py
@@ -4,11 +4,12 @@ from opentelemetry.trace.status import StatusCode
 
 
 @pytest.mark.asyncio
-async def test_tool_error_sets_error_type_on_server_span(span_exporter, tracer_provider):
+async def test_tool_error_sets_error_type_on_client_span(span_exporter, tracer_provider):
     """
-    When a FastMCP tool raises an exception, the server-side span must have
-    error.type set. The server-side span hits the isError=True code path in
-    _execute_and_handle_result — that's the bug location.
+    When a FastMCP tool raises an exception, the client-side span must have
+    error.type set. The client-side span wraps BaseSession.send_request and
+    hits the isError=True branch in _execute_and_handle_result
+    (instrumentation.py:344) — that's the bug location this test pins.
     """
     from fastmcp import FastMCP, Client
 
@@ -26,26 +27,29 @@ async def test_tool_error_sets_error_type_on_server_span(span_exporter, tracer_p
 
     spans = span_exporter.get_finished_spans()
 
-    # The server-side tool span is the one that goes through _execute_and_handle_result
-    # with isError=True. It should have error.type set.
-    server_tool_spans = [
+    # Both client- and server-side produce a fail_tool.tool ERROR span (same name,
+    # different code paths). The client-side one — created by _execute_and_handle_result
+    # on isError=True — is the path this PR fixes.
+    error_tool_spans = [
         s for s in spans
         if s.name == "fail_tool.tool" and s.status.status_code == StatusCode.ERROR
     ]
 
-    assert len(server_tool_spans) >= 1, (
+    assert len(error_tool_spans) >= 1, (
         f"Expected at least 1 ERROR fail_tool.tool span, got: {[s.name for s in spans]}"
     )
 
-    # All ERROR tool spans should have error.type set
-    for span in server_tool_spans:
+    # Every ERROR tool span should carry error.type
+    for span in error_tool_spans:
         assert span.attributes.get("error.type") is not None, (
             f"error.type missing on ERROR span '{span.name}'"
         )
 
-    # The server-side span specifically should have "tool_error" (isError=True path)
+    # The client-side span specifically carries "tool_error" (isError=True path).
+    # The server-side span carries type(e).__name__ (e.g. "ValueError") from
+    # fastmcp_instrumentation.py's exception handler.
     tool_error_values = [
-        s.attributes.get("error.type") for s in server_tool_spans
+        s.attributes.get("error.type") for s in error_tool_spans
     ]
     assert "tool_error" in tool_error_values, (
         f"Expected 'tool_error' in error.type values, got: {tool_error_values}"

--- a/packages/opentelemetry-instrumentation-mcp/uv.lock
+++ b/packages/opentelemetry-instrumentation-mcp/uv.lock
@@ -1008,7 +1008,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-mcp"
-version = "0.53.3"
+version = "0.60.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION
Fixes #4037.
When a tool returns isError=True, the span was marked ERROR but missing                                                                                                                       
the error.type attribute required by OTel semconv.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Classifies protocol-level tool-call failures in traces by setting the error type to "tool_error" while preserving exception-type reporting for raised exceptions.

* **Tests**
  * Added an async test to verify tool-call failures set error.type on client spans and that error.type is present for ERROR spans.
  * Adjusted test fixtures to enable instrumentation for the whole session and clear spans per-test for reliable span inspection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->