### PR TITLE
 fix(langchain): handle non-copyable dataclass fields in JSON encoder

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/utils.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/utils.py
@@ -26,8 +26,17 @@ class CallbackFilteredJSONEncoder(json.JSONEncoder):
                 del o["callbacks"]
                 return o
 
-        if dataclasses.is_dataclass(o):
-            return dataclasses.asdict(o)
+        if dataclasses.is_dataclass(o) and not isinstance(o, type):
+            try:
+                return dataclasses.asdict(o)
+            except TypeError:
+                # asdict() deep-copies every field, which fails when an
+                # attribute holds a non-copyable object such as a threading
+                # lock (seen with langchain HTTP-client wrappers). Fall back
+                # to a shallow field map and let the encoder recurse / stringify.
+                return {
+                    f.name: getattr(o, f.name) for f in dataclasses.fields(o)
+                }
 
         if hasattr(o, "to_json"):
             return o.to_json()

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_utils.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_utils.py
@@ -1,0 +1,68 @@
+"""Unit tests for langchain instrumentation utilities."""
+
+import dataclasses
+import json
+import threading
+
+from opentelemetry.instrumentation.langchain.utils import (
+    CallbackFilteredJSONEncoder,
+)
+
+
+def test_encoder_serializes_plain_dataclass():
+    @dataclasses.dataclass
+    class Plain:
+        name: str
+        count: int
+
+    result = json.loads(json.dumps(Plain(name="x", count=1), cls=CallbackFilteredJSONEncoder))
+
+    assert result == {"name": "x", "count": 1}
+
+
+def test_encoder_serializes_dataclass_with_rlock():
+    @dataclasses.dataclass
+    class WithLock:
+        name: str
+        lock: threading.RLock = dataclasses.field(default_factory=threading.RLock)
+
+    encoded = json.dumps(WithLock(name="x"), cls=CallbackFilteredJSONEncoder)
+    result = json.loads(encoded)
+
+    assert result["name"] == "x"
+    assert isinstance(result["lock"], str)
+
+
+def test_encoder_serializes_nested_dataclass_with_rlock():
+    @dataclasses.dataclass
+    class Inner:
+        lock: threading.RLock = dataclasses.field(default_factory=threading.RLock)
+
+    @dataclasses.dataclass
+    class Outer:
+        name: str
+        inner: Inner = dataclasses.field(default_factory=Inner)
+
+    encoded = json.dumps(Outer(name="x"), cls=CallbackFilteredJSONEncoder)
+    result = json.loads(encoded)
+
+    assert result["name"] == "x"
+    assert "lock" in result["inner"]
+
+
+def test_encoder_serializes_list_of_dataclasses_under_fallback():
+    @dataclasses.dataclass
+    class Item:
+        value: int
+
+    @dataclasses.dataclass
+    class Container:
+        items: list
+        lock: threading.RLock = dataclasses.field(default_factory=threading.RLock)
+
+    encoded = json.dumps(
+        Container(items=[Item(1), Item(2)]), cls=CallbackFilteredJSONEncoder
+    )
+    result = json.loads(encoded)
+
+    assert result["items"] == [{"value": 1}, {"value": 2}]


### PR DESCRIPTION
asdict() deep-copies every field, which fails when a dataclass holds an RLock or other non-copyable attribute. Fallback to a shallow field map in that case so the encoder can recurse / stringify per field.
 Fixes #3518

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [X] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [X] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced telemetry data serialization to safely handle complex data structures containing non-serializable components, with improved fallback behavior for conversion errors.

* **Tests**
  * Added comprehensive test coverage for telemetry serialization with various dataclass scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4104)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->