### PR TITLE
fix(chromadb): emit one result event per document across all queries

### DIFF
--- a/packages/opentelemetry-instrumentation-chromadb/opentelemetry/instrumentation/chromadb/wrapper.py
+++ b/packages/opentelemetry-instrumentation-chromadb/opentelemetry/instrumentation/chromadb/wrapper.py
@@ -223,68 +223,50 @@ def _add_segment_query_embeddings_events(span, kwargs, args=None):
 @dont_throw
 def _add_query_result_events(span, kwargs):
     """
-    There's a lot of logic here involved in converting the query result
-    format from ChromaDB into the canonical format (taken from Pinecone)
-
-    This is because Chroma query result looks like this:
+    ChromaDB query results have a nested structure — one inner list per query:
 
         {
-           ids: [1, 2, 3...],
-           distances: [0.3, 0.5, 0.6...],
-           metadata: ["some metadata text", "another metadata text",...],
-           documents: ["retrieved text", "retrieved text2", ...]
+            "ids":       [["id1", "id2", "id3"]],   <- outer: per query, inner: per result
+            "distances": [[0.1,   0.2,   0.3  ]],
+            "metadatas": [[{...}, {...}, {...} ]],
+            "documents": [["doc1","doc2","doc3"]],
         }
 
-    We'd like instead to log it like this:
+    We emit one db.query.result span event per result document:
 
-        [
-            {"id": 1, "distance": 0.3,  "document": "retrieved text", "metadata": "some metadata text",
-            {"id": 2, "distance" 0.5, , "document": "retrieved text2": "another metadata text",
-            {"id": 3, "distance": 0.6, "document": ..., "metadata": ...
-        ]
+        event: db.query.result { id: "id1", distance: 0.1, document: "doc1", metadata: "..." }
+        event: db.query.result { id: "id2", distance: 0.2, document: "doc2", metadata: "..." }
+        event: db.query.result { id: "id3", distance: 0.3, document: "doc3", metadata: "..." }
 
-    If you'd like to understand better why, please read the discussions on PR #370:
-    https://github.com/traceloop/openllmetry/pull/370
-
-    The goal is to set a canonical format which we call as a Semantic Convention.
+    For N queries with n_results=K, this produces N×K events total.
     """
-    zipped = itertools.zip_longest(
+    # Outer zip: one tuple per query (ChromaDB returns a list-of-lists)
+    for query_ids, query_distances, query_metadatas, query_documents in itertools.zip_longest(
         kwargs.get("ids", []) or [],
         kwargs.get("distances", []) or [],
         kwargs.get("metadatas", []) or [],
         kwargs.get("documents", []) or [],
-    )
-    for tuple_ in zipped:
-        attributes = {
-            EventAttributes.DB_QUERY_RESULT_ID.value: None,
-            EventAttributes.DB_QUERY_RESULT_DISTANCE.value: None,
-            EventAttributes.DB_QUERY_RESULT_METADATA.value: None,
-            EventAttributes.DB_QUERY_RESULT_DOCUMENT.value: None,
-        }
+    ):
+        # Inner zip: one event per result document within this query
+        for id_, distance, metadata, document in itertools.zip_longest(
+            query_ids or [],
+            query_distances or [],
+            query_metadatas or [],
+            query_documents or [],
+        ):
+            attributes = {}
+            if id_ is not None:
+                attributes[EventAttributes.DB_QUERY_RESULT_ID.value] = id_
+            if distance is not None:
+                attributes[EventAttributes.DB_QUERY_RESULT_DISTANCE.value] = distance
+            if metadata is not None:
+                attributes[EventAttributes.DB_QUERY_RESULT_METADATA.value] = (
+                    json.dumps(metadata) if isinstance(metadata, dict) else metadata
+                )
+            if document is not None:
+                attributes[EventAttributes.DB_QUERY_RESULT_DOCUMENT.value] = document
 
-        attributes_order = ["ids", "distances", "metadatas", "documents"]
-        attributes_mapping_to_canonical_format = {
-            "ids": EventAttributes.DB_QUERY_RESULT_ID.value,
-            "distances": EventAttributes.DB_QUERY_RESULT_DISTANCE.value,
-            "metadatas": EventAttributes.DB_QUERY_RESULT_METADATA.value,
-            "documents": EventAttributes.DB_QUERY_RESULT_DOCUMENT.value,
-        }
-        for j, attr in enumerate(tuple_):
-            original_attribute_name = attributes_order[j]
-            canonical_name = attributes_mapping_to_canonical_format[
-                original_attribute_name
-            ]
-            try:
-                value = attr[0]
-                if isinstance(value, dict):
-                    value = json.dumps(value)
-
-                attributes[canonical_name] = value
-            except (IndexError, TypeError):
-                # Don't send missing values as nulls, OpenTelemetry dislikes them!
-                del attributes[canonical_name]
-
-        span.add_event(name=Events.DB_QUERY_RESULT.value, attributes=attributes)
+            span.add_event(name=Events.DB_QUERY_RESULT.value, attributes=attributes)
 
 
 @dont_throw

--- a/packages/opentelemetry-instrumentation-chromadb/tests/test_query.py
+++ b/packages/opentelemetry-instrumentation-chromadb/tests/test_query.py
@@ -81,7 +81,7 @@ def test_chroma_query(exporter, collection):
     assert span.attributes.get(SpanAttributes.CHROMADB_QUERY_N_RESULTS) == 2
 
     events = span.events
-    assert len(events) == 1
+    assert len(events) == 2  # n_results=2 → one event per result
     for event in events:
         assert event.name == Events.DB_QUERY_RESULT.value
         ids_ = event.attributes.get(f"{event.name}.id")

--- a/packages/opentelemetry-instrumentation-chromadb/tests/test_query_results.py
+++ b/packages/opentelemetry-instrumentation-chromadb/tests/test_query_results.py
@@ -1,0 +1,76 @@
+"""Tests for ChromaDB query result events — issue #1870."""
+import chromadb
+import pytest
+
+chroma = chromadb.EphemeralClient()
+
+
+@pytest.fixture
+def collection(exporter):
+    col = chroma.create_collection(name="test_results")
+    yield col
+    chroma.delete_collection(name="test_results")
+
+
+def test_chromadb_query_returns_all_chunks(exporter, collection):
+    """query() with n_results=2 should produce 2 result events, not 1."""
+    collection.add(
+        ids=["1", "2", "3"],
+        documents=["doc one", "doc two", "doc three"],
+        embeddings=[[1.0, 0.0], [0.0, 1.0], [0.5, 0.5]],
+    )
+    collection.query(query_embeddings=[[1.0, 0.0]], n_results=2)
+
+    spans = exporter.get_finished_spans()
+    query_span = next(s for s in spans if s.name == "chroma.query")
+    result_events = [e for e in query_span.events if e.name == "db.query.result"]
+
+    assert len(result_events) == 2, (
+        f"Expected 2 result events, got {len(result_events)}"
+    )
+
+
+def test_chromadb_multi_query_returns_all_chunks(exporter, collection):
+    """2 query embeddings × n_results=2 should produce 4 events total."""
+    collection.add(
+        ids=["1", "2", "3", "4"],
+        documents=["doc one", "doc two", "doc three", "doc four"],
+        embeddings=[[1.0, 0.0], [0.0, 1.0], [0.5, 0.5], [0.3, 0.7]],
+    )
+    collection.query(
+        query_embeddings=[[1.0, 0.0], [0.0, 1.0]],
+        n_results=2,
+    )
+
+    spans = exporter.get_finished_spans()
+    query_span = next(s for s in spans if s.name == "chroma.query")
+    result_events = [e for e in query_span.events if e.name == "db.query.result"]
+
+    assert len(result_events) == 4, (
+        f"Expected 4 result events (2 queries × 2 results), got {len(result_events)}"
+    )
+
+
+def test_chromadb_query_result_events_contain_correct_data(exporter, collection):
+    """Each result event should contain id, distance, document and metadata."""
+    collection.add(
+        ids=["1", "2"],
+        documents=["doc one", "doc two"],
+        metadatas=[{"source": "fileA"}, {"source": "fileB"}],
+        embeddings=[[1.0, 0.0], [0.0, 1.0]],
+    )
+    collection.query(query_embeddings=[[1.0, 0.0]], n_results=2)
+
+    spans = exporter.get_finished_spans()
+    query_span = next(s for s in spans if s.name == "chroma.query")
+    result_events = [e for e in query_span.events if e.name == "db.query.result"]
+
+    assert len(result_events) == 2
+    for event in result_events:
+        assert "db.query.result.id" in event.attributes
+        assert "db.query.result.distance" in event.attributes
+        assert "db.query.result.document" in event.attributes
+        assert "db.query.result.metadata" in event.attributes
+
+    ids_recorded = {e.attributes["db.query.result.id"] for e in result_events}
+    assert ids_recorded == {"1", "2"}

--- a/packages/opentelemetry-instrumentation-chromadb/tests/test_query_results.py
+++ b/packages/opentelemetry-instrumentation-chromadb/tests/test_query_results.py
@@ -54,7 +54,7 @@ def test_chromadb_multi_query_returns_all_chunks(exporter, collection):
 def test_chromadb_query_result_events_contain_correct_data(exporter, collection):
     """Each result event should contain id, distance, document and metadata."""
     collection.add(
-        ids=["1", "2"],
+        ids=["doc-id-aaa", "doc-id-bbb"],
         documents=["doc one", "doc two"],
         metadatas=[{"source": "fileA"}, {"source": "fileB"}],
         embeddings=[[1.0, 0.0], [0.0, 1.0]],
@@ -73,4 +73,4 @@ def test_chromadb_query_result_events_contain_correct_data(exporter, collection)
         assert "db.query.result.metadata" in event.attributes
 
     ids_recorded = {e.attributes["db.query.result.id"] for e in result_events}
-    assert ids_recorded == {"1", "2"}
+    assert ids_recorded == {"doc-id-aaa", "doc-id-bbb"}


### PR DESCRIPTION
Related to #1870

problem:                                                                                                                                                                        
ChromaDB's query() returns results as a list-of-lists (one inner list per query embedding). The instrumentation only unzipped the outer list, producing one db.query.result     
event per query instead of one per result document. A second bug also indexed into each attribute value with [0], so string IDs were silently truncated to their first          
character.                                                                                                                                                                      
                                                                                                                                                                                  
fix:                                                                                                                                                                            
Added an inner loop over each query's result list so every document gets its own span event. Removed the erroneous [0] indexing so attribute values are used as-is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Query telemetry now emits one event per returned document (N×K for multi-query), with event attributes included only when present and metadata serialized when it's a dictionary.

* **Tests**
  * Added and updated tests to assert per-result event counts and validate each event's attributes for single and multi-embedding queries.

* **Documentation**
  * Clarified the nested query-result structure and the resulting per-result event behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->