### PR TITLE
Fix coroutine warning in JSONEncoder

### DIFF
--- a/packages/traceloop-sdk/traceloop/sdk/utils/json_encoder.py
+++ b/packages/traceloop-sdk/traceloop/sdk/utils/json_encoder.py
@@ -10,7 +10,7 @@ class JSONEncoder(json.JSONEncoder):
                 del o["callbacks"]
                 return o
 
-        if dataclasses.is_dataclass(o):
+        if dataclasses.is_dataclass(o) and not isinstance(o, type):
             return dataclasses.asdict(o)
 
         to_json_method = getattr(o, "to_json", None)
@@ -26,7 +26,7 @@ class JSONEncoder(json.JSONEncoder):
 
                 if inspect.iscoroutine(result):
                     result.close()
-                    return o.__class__.__name__
+                    return type(o).__name__
 
                 return result
 
@@ -34,6 +34,7 @@ class JSONEncoder(json.JSONEncoder):
                 pass
 
         if hasattr(o, "__class__"):
-            return o.__class__.__name__
+            return type(o).__name__
 
         return super().default(o)
+    

--- a/packages/traceloop-sdk/traceloop/sdk/utils/json_encoder.py
+++ b/packages/traceloop-sdk/traceloop/sdk/utils/json_encoder.py
@@ -9,19 +9,29 @@ class JSONEncoder(json.JSONEncoder):
             if "callbacks" in o:
                 del o["callbacks"]
                 return o
+
         if dataclasses.is_dataclass(o):
             return dataclasses.asdict(o)
 
-        if hasattr(o, "to_json"):
-            return o.to_json()
+        to_json_method = getattr(o, "to_json", None)
 
-        if hasattr(o, "json"):
-            json_method = o.json
-            if callable(json_method) and not inspect.iscoroutinefunction(json_method):
+        if callable(to_json_method):
+            return to_json_method()
+
+        json_method = getattr(o, "json", None)
+
+        if callable(json_method):
+            try:
                 result = json_method()
-                if not inspect.iscoroutine(result):
-                    return result
-                result.close()
+
+                if inspect.iscoroutine(result):
+                    result.close()
+                    return o.__class__.__name__
+
+                return result
+
+            except Exception:
+                pass
 
         if hasattr(o, "__class__"):
             return o.__class__.__name__


### PR DESCRIPTION
Fixes #3967

## What changed

This updates `JSONEncoder` to handle objects with async `json()` methods more safely.

Previously, the encoder checked `inspect.iscoroutinefunction(json_method)` before calling `.json()`. In the case of `starlette.requests.Request`, this check did not reliably detect the async method, which caused the coroutine to be created without being awaited and produced:

`RuntimeWarning: coroutine 'Request.json' was never awaited`

The updated logic checks whether the returned value is a coroutine after calling the method and closes it safely before falling back to the class name.

## Verification

Tested locally using a FastAPI endpoint decorated with `@workflow` and passing a `Request` object. The warning no longer appears.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON serialization robustness: safer invocation of custom serializers, better handling and cleanup of asynchronous serialization results, suppressed serialization errors with a reliable fallback to type names, and more accurate handling of dataclass instances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4128)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->