### PR TITLE
fix(openai-agents): capture response.instructions as system prompt in generation spans

### DIFF
--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
@@ -959,7 +959,8 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
         input_data = getattr(span_data, "input", [])
         response = getattr(span_data, "response", None)
         if trace_content and response and getattr(response, "instructions", None):
-            input_data = [{"role": "system", "content": response.instructions}] + (input_data if input_data else [])
+            existing = input_data if isinstance(input_data, list) else []
+            input_data = [{"role": "system", "content": response.instructions}] + existing
         _extract_prompt_attributes(otel_span, input_data, trace_content)
 
         tools = getattr(span_data, "tools", None) or (

--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
@@ -957,9 +957,11 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
     def _end_generation_span(self, otel_span, span_data, trace_content):
         """Handle on_span_end logic for generation/response spans."""
         input_data = getattr(span_data, "input", [])
+        response = getattr(span_data, "response", None)
+        if trace_content and response and getattr(response, "instructions", None):
+            input_data = [{"role": "system", "content": response.instructions}] + (input_data if input_data else [])
         _extract_prompt_attributes(otel_span, input_data, trace_content)
 
-        response = getattr(span_data, "response", None)
         tools = getattr(span_data, "tools", None) or (
             getattr(response, "tools", None) if response else None
         )

--- a/packages/opentelemetry-instrumentation-openai-agents/tests/test_openai_agents.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/tests/test_openai_agents.py
@@ -109,11 +109,13 @@ def test_agent_spans(exporter, test_agent):
     assert response_span.attributes[GenAIAttributes.GEN_AI_PROVIDER_NAME] == "openai"
 
     # Test input messages (JSON array with parts-based schema)
+    # index 0 is the system message (agent instructions), index 1 is the user message
     input_messages = json.loads(response_span.attributes[GenAIAttributes.GEN_AI_INPUT_MESSAGES])
-    assert input_messages[0]["role"] == "user"
-    assert "parts" in input_messages[0], "Input messages must use parts-based schema"
-    assert input_messages[0]["parts"][0]["type"] == "text"
-    assert input_messages[0]["parts"][0]["content"] == "What is AI?"
+    assert input_messages[0]["role"] == "system"
+    user_message = next(m for m in input_messages if m["role"] == "user")
+    assert "parts" in user_message, "Input messages must use parts-based schema"
+    assert user_message["parts"][0]["type"] == "text"
+    assert user_message["parts"][0]["content"] == "What is AI?"
 
     # Test usage tokens
     assert response_span.attributes[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS] is not None

--- a/packages/opentelemetry-instrumentation-openai-agents/tests/test_tracing_processor.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/tests/test_tracing_processor.py
@@ -752,6 +752,69 @@ class TestEndGenerationSpan:
 
         otel_span.end()
 
+    def test_instructions_prepended_as_system_message(self, tracer_and_exporter, processor):
+        """response.instructions must appear as the first message with role=system."""
+        tracer, _ = tracer_and_exporter
+        otel_span = tracer.start_span("test-gen")
+
+        response = MagicMock()
+        response.instructions = "You are a helpful assistant."
+        response.tools = None
+        response.output = []
+        response.model = None
+        response.id = None
+        response.temperature = None
+        response.max_output_tokens = None
+        response.top_p = None
+        response.frequency_penalty = None
+        response.finish_reason = None
+        response.usage = None
+
+        span_data = MagicMock()
+        span_data.input = [{"role": "user", "content": "Hello"}]
+        span_data.response = response
+        span_data.tools = None
+
+        processor._end_generation_span(otel_span, span_data, trace_content=True)
+
+        raw = otel_span.attributes.get(GenAIAttributes.GEN_AI_INPUT_MESSAGES)
+        assert raw is not None
+        messages = json.loads(raw)
+        assert messages[0]["role"] == "system"
+        assert messages[0]["parts"][0]["content"] == "You are a helpful assistant."
+        assert messages[1]["role"] == "user"
+
+        otel_span.end()
+
+    def test_instructions_not_prepended_when_content_gated(self, tracer_and_exporter, processor):
+        """response.instructions must NOT appear when trace_content=False."""
+        tracer, _ = tracer_and_exporter
+        otel_span = tracer.start_span("test-gen")
+
+        response = MagicMock()
+        response.instructions = "You are a helpful assistant."
+        response.tools = None
+        response.output = []
+        response.model = None
+        response.id = None
+        response.temperature = None
+        response.max_output_tokens = None
+        response.top_p = None
+        response.frequency_penalty = None
+        response.finish_reason = None
+        response.usage = None
+
+        span_data = MagicMock()
+        span_data.input = [{"role": "user", "content": "Hello"}]
+        span_data.response = response
+        span_data.tools = None
+
+        processor._end_generation_span(otel_span, span_data, trace_content=False)
+
+        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in otel_span.attributes
+
+        otel_span.end()
+
     def test_extracts_response_attributes(self, tracer_and_exporter, processor):
         """Must extract response model, id, etc."""
         tracer, exporter = tracer_and_exporter

--- a/packages/opentelemetry-instrumentation-openai-agents/tests/test_tracing_processor.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/tests/test_tracing_processor.py
@@ -815,6 +815,73 @@ class TestEndGenerationSpan:
 
         otel_span.end()
 
+    def test_instructions_only_with_empty_input(self, tracer_and_exporter, processor):
+        """Empty input + instructions → single system message in output."""
+        tracer, _ = tracer_and_exporter
+        otel_span = tracer.start_span("test-gen")
+
+        response = MagicMock()
+        response.instructions = "You are a helpful assistant."
+        response.tools = None
+        response.output = []
+        response.model = None
+        response.id = None
+        response.temperature = None
+        response.max_output_tokens = None
+        response.top_p = None
+        response.frequency_penalty = None
+        response.finish_reason = None
+        response.usage = None
+
+        span_data = MagicMock()
+        span_data.input = []
+        span_data.response = response
+        span_data.tools = None
+
+        processor._end_generation_span(otel_span, span_data, trace_content=True)
+
+        raw = otel_span.attributes.get(GenAIAttributes.GEN_AI_INPUT_MESSAGES)
+        assert raw is not None
+        messages = json.loads(raw)
+        assert len(messages) == 1
+        assert messages[0]["role"] == "system"
+        assert messages[0]["parts"][0]["content"] == "You are a helpful assistant."
+
+        otel_span.end()
+
+    def test_empty_instructions_skipped(self, tracer_and_exporter, processor):
+        """instructions == "" is falsy and must be skipped — no system message prepended."""
+        tracer, _ = tracer_and_exporter
+        otel_span = tracer.start_span("test-gen")
+
+        response = MagicMock()
+        response.instructions = ""
+        response.tools = None
+        response.output = []
+        response.model = None
+        response.id = None
+        response.temperature = None
+        response.max_output_tokens = None
+        response.top_p = None
+        response.frequency_penalty = None
+        response.finish_reason = None
+        response.usage = None
+
+        span_data = MagicMock()
+        span_data.input = [{"role": "user", "content": "Hello"}]
+        span_data.response = response
+        span_data.tools = None
+
+        processor._end_generation_span(otel_span, span_data, trace_content=True)
+
+        raw = otel_span.attributes.get(GenAIAttributes.GEN_AI_INPUT_MESSAGES)
+        assert raw is not None
+        messages = json.loads(raw)
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+
+        otel_span.end()
+
     def test_extracts_response_attributes(self, tracer_and_exporter, processor):
         """Must extract response model, id, etc."""
         tracer, exporter = tracer_and_exporter


### PR DESCRIPTION
Fixes #3738.

Problem:
When an OpenAI Agent had instructions set, the system prompt was silently dropped from generation spans — only the conversation history was recorded, with no role: system message.

Fix:
Prepend response.instructions as a role: system message to the input messages array in _end_generation_span() before passing to _extract_prompt_attributes(). Consistent with how responses_wrappers.py handles it in the plain openai instrumentation.

  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tracing now includes agent instructions as a leading system message in traced input when content tracing is enabled, ensuring prompt context is captured correctly.

* **Tests**
  * Updated assertions to reflect new message ordering and role-based lookup.
  * Added tests covering instruction handling: enabled/disabled tracing, empty input, and empty or missing instruction cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->