### PR TITLE
fix(sdk): warn when both `exporter` and `processor` are passed to `Traceloop.init()`

### DIFF
--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
@@ -941,9 +941,11 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
     def _end_generation_span(self, otel_span, span_data, trace_content):
         """Handle on_span_end logic for generation/response spans."""
         input_data = getattr(span_data, "input", [])
+        response = getattr(span_data, "response", None)
+        if trace_content and response and getattr(response, "instructions", None):
+            input_data = [{"role": "system", "content": response.instructions}] + (input_data if input_data else [])
         _extract_prompt_attributes(otel_span, input_data, trace_content)
 
-        response = getattr(span_data, "response", None)
         tools = getattr(span_data, "tools", None) or (
             getattr(response, "tools", None) if response else None
         )

--- a/packages/opentelemetry-instrumentation-openai-agents/tests/test_openai_agents.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/tests/test_openai_agents.py
@@ -105,11 +105,13 @@ def test_agent_spans(exporter, test_agent):
     assert response_span.attributes[GenAIAttributes.GEN_AI_PROVIDER_NAME] == "openai"
 
     # Test input messages (JSON array with parts-based schema)
+    # index 0 is the system message (agent instructions), index 1 is the user message
     input_messages = json.loads(response_span.attributes[GenAIAttributes.GEN_AI_INPUT_MESSAGES])
-    assert input_messages[0]["role"] == "user"
-    assert "parts" in input_messages[0], "Input messages must use parts-based schema"
-    assert input_messages[0]["parts"][0]["type"] == "text"
-    assert input_messages[0]["parts"][0]["content"] == "What is AI?"
+    assert input_messages[0]["role"] == "system"
+    user_message = next(m for m in input_messages if m["role"] == "user")
+    assert "parts" in user_message, "Input messages must use parts-based schema"
+    assert user_message["parts"][0]["type"] == "text"
+    assert user_message["parts"][0]["content"] == "What is AI?"
 
     # Test usage tokens
     assert response_span.attributes[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS] is not None

--- a/packages/opentelemetry-instrumentation-openai-agents/tests/test_tracing_processor.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/tests/test_tracing_processor.py
@@ -752,6 +752,69 @@ class TestEndGenerationSpan:
 
         otel_span.end()
 
+    def test_instructions_prepended_as_system_message(self, tracer_and_exporter, processor):
+        """response.instructions must appear as the first message with role=system."""
+        tracer, _ = tracer_and_exporter
+        otel_span = tracer.start_span("test-gen")
+
+        response = MagicMock()
+        response.instructions = "You are a helpful assistant."
+        response.tools = None
+        response.output = []
+        response.model = None
+        response.id = None
+        response.temperature = None
+        response.max_output_tokens = None
+        response.top_p = None
+        response.frequency_penalty = None
+        response.finish_reason = None
+        response.usage = None
+
+        span_data = MagicMock()
+        span_data.input = [{"role": "user", "content": "Hello"}]
+        span_data.response = response
+        span_data.tools = None
+
+        processor._end_generation_span(otel_span, span_data, trace_content=True)
+
+        raw = otel_span.attributes.get(GenAIAttributes.GEN_AI_INPUT_MESSAGES)
+        assert raw is not None
+        messages = json.loads(raw)
+        assert messages[0]["role"] == "system"
+        assert messages[0]["parts"][0]["content"] == "You are a helpful assistant."
+        assert messages[1]["role"] == "user"
+
+        otel_span.end()
+
+    def test_instructions_not_prepended_when_content_gated(self, tracer_and_exporter, processor):
+        """response.instructions must NOT appear when trace_content=False."""
+        tracer, _ = tracer_and_exporter
+        otel_span = tracer.start_span("test-gen")
+
+        response = MagicMock()
+        response.instructions = "You are a helpful assistant."
+        response.tools = None
+        response.output = []
+        response.model = None
+        response.id = None
+        response.temperature = None
+        response.max_output_tokens = None
+        response.top_p = None
+        response.frequency_penalty = None
+        response.finish_reason = None
+        response.usage = None
+
+        span_data = MagicMock()
+        span_data.input = [{"role": "user", "content": "Hello"}]
+        span_data.response = response
+        span_data.tools = None
+
+        processor._end_generation_span(otel_span, span_data, trace_content=False)
+
+        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in otel_span.attributes
+
+        otel_span.end()
+
     def test_extracts_response_attributes(self, tracer_and_exporter, processor):
         """Must extract response model, id, etc."""
         tracer, exporter = tracer_and_exporter

--- a/packages/opentelemetry-instrumentation-openai-agents/uv.lock
+++ b/packages/opentelemetry-instrumentation-openai-agents/uv.lock
@@ -1307,7 +1307,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-openai-agents"
-version = "0.59.2"
+version = "0.60.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },

--- a/packages/sample-app/uv.lock
+++ b/packages/sample-app/uv.lock
@@ -3654,7 +3654,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-agno"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-agno" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3694,7 +3694,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-alephalpha"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-alephalpha" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3732,7 +3732,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-anthropic"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-anthropic" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3770,7 +3770,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-bedrock"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-bedrock" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3803,7 +3803,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-chromadb"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-chromadb" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3838,7 +3838,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-cohere"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-cohere" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3876,7 +3876,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-crewai"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-crewai" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3912,7 +3912,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-google-generativeai"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-google-generativeai" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3934,23 +3934,22 @@ provides-extras = ["instruments"]
 [package.metadata.requires-dev]
 dev = [
     { name = "autopep8", specifier = ">=2.2.0,<3" },
-    { name = "pytest", specifier = ">=8.2.2,<9" },
-    { name = "pytest-sugar", specifier = "==1.0.0" },
+    { name = "pytest", specifier = ">=8.2.2,<10" },
     { name = "ruff", specifier = ">=0.4.0" },
 ]
 test = [
     { name = "google-genai", specifier = ">=1.0.0,<2" },
     { name = "opentelemetry-sdk", specifier = ">=1.38.0,<2" },
-    { name = "pytest", specifier = ">=8.2.2,<9" },
+    { name = "pytest", specifier = ">=8.2.2,<10" },
     { name = "pytest-asyncio", specifier = ">=1.2.0,<2" },
     { name = "pytest-recording", specifier = ">=0.13.1,<0.14.0" },
-    { name = "pytest-sugar", specifier = "==1.0.0" },
+    { name = "pytest-sugar", specifier = "==1.1.1" },
     { name = "vcrpy", specifier = ">=8.0.0,<9" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-groq"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-groq" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3977,7 +3976,7 @@ dev = [
     { name = "ruff", specifier = ">=0.4.0" },
 ]
 test = [
-    { name = "groq", specifier = ">=0.18.0" },
+    { name = "groq", specifier = ">=1.2.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.38.0,<2" },
     { name = "pytest", specifier = ">=8.2.2,<9" },
     { name = "pytest-asyncio", specifier = ">=0.23.7,<0.24.0" },
@@ -3988,7 +3987,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-haystack"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-haystack" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4025,7 +4024,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-lancedb"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-lancedb" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4065,7 +4064,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-langchain"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-langchain" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4119,7 +4118,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-llamaindex"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-llamaindex" }
 dependencies = [
     { name = "inflection" },
@@ -4182,7 +4181,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-marqo"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-marqo" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4220,7 +4219,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-mcp"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-mcp" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4260,7 +4259,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-milvus"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-milvus" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4296,7 +4295,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-mistralai"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-mistralai" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4333,7 +4332,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-ollama"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-ollama" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4371,7 +4370,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-openai"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-openai" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4408,7 +4407,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-openai-agents"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-openai-agents" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4436,7 +4435,7 @@ dev = [
 ]
 test = [
     { name = "litellm", specifier = ">=1.71.2,<2" },
-    { name = "openai-agents", specifier = ">=0.6.9" },
+    { name = "openai-agents", specifier = ">=0.14.2" },
     { name = "opentelemetry-sdk", specifier = ">=1.38.0,<2" },
     { name = "pytest", specifier = ">=8.2.2,<9" },
     { name = "pytest-asyncio", specifier = ">=1.0.0,<2" },
@@ -4447,7 +4446,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-pinecone"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-pinecone" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4486,7 +4485,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-qdrant"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-qdrant" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4534,7 +4533,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-replicate"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-replicate" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4586,7 +4585,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-sagemaker"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-sagemaker" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4651,7 +4650,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-together"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-together" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4689,7 +4688,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-transformers"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-transformers" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4736,7 +4735,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-vertexai"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-vertexai" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4774,7 +4773,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-voyageai"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-voyageai" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4812,7 +4811,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-watsonx"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-watsonx" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4850,7 +4849,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-weaviate"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-weaviate" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4889,7 +4888,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-writer"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../opentelemetry-instrumentation-writer" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -7030,7 +7029,7 @@ wheels = [
 
 [[package]]
 name = "traceloop-sdk"
-version = "0.58.1"
+version = "0.60.0"
 source = { editable = "../traceloop-sdk" }
 dependencies = [
     { name = "aiohttp" },

--- a/packages/traceloop-sdk/tests/conftest.py
+++ b/packages/traceloop-sdk/tests/conftest.py
@@ -64,7 +64,6 @@ def exporter_with_custom_span_processor():
 
     exporter = InMemorySpanExporter()
     Traceloop.init(
-        exporter=exporter,
         processor=CustomSpanProcessor(exporter),
     )
 

--- a/packages/traceloop-sdk/tests/test_sdk_initialization.py
+++ b/packages/traceloop-sdk/tests/test_sdk_initialization.py
@@ -2,7 +2,11 @@ import json
 import pytest
 from unittest.mock import patch
 from openai import OpenAI
+from traceloop.sdk import Traceloop
 from traceloop.sdk.decorators import workflow
+from traceloop.sdk.tracing.tracing import TracerWrapper
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 
 @pytest.fixture
@@ -223,3 +227,23 @@ def test_get_default_span_processor():
     assert isinstance(processor, BatchSpanProcessor)
     assert hasattr(processor, "_traceloop_processor")
     assert getattr(processor, "_traceloop_processor") is True
+
+
+def test_both_exporter_and_processor_warns():
+    """Passing both exporter and processor is a mistake — the processor already wraps
+    the exporter internally. We warn instead of silently dropping the exporter."""
+    if hasattr(TracerWrapper, "instance"):
+        _instance = TracerWrapper.instance
+        del TracerWrapper.instance
+
+    exporter = InMemorySpanExporter()
+    processor = SimpleSpanProcessor(exporter)
+
+    with pytest.warns(UserWarning, match="exporter.*ignored"):
+        Traceloop.init(
+            exporter=exporter,
+            processor=processor,
+        )
+
+    if "_instance" in dir():
+        TracerWrapper.instance = _instance

--- a/packages/traceloop-sdk/traceloop/sdk/__init__.py
+++ b/packages/traceloop-sdk/traceloop/sdk/__init__.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import warnings
 from pathlib import Path
 
 from typing import Callable, List, Optional, Set, Union
@@ -89,6 +90,14 @@ class Traceloop:
             return
 
         enable_content_tracing = is_content_tracing_enabled()
+
+        if exporter and processor:
+            warnings.warn(
+                "Both 'exporter' and 'processor' were provided to Traceloop.init(). "
+                "The 'exporter' will be ignored — your processor should already wrap the exporter.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         if exporter or processor:
             print(Fore.GREEN + "Traceloop exporting traces to a custom exporter")

--- a/packages/traceloop-sdk/uv.lock
+++ b/packages/traceloop-sdk/uv.lock
@@ -2296,7 +2296,7 @@ dev = [
 ]
 test = [
     { name = "litellm", specifier = ">=1.71.2,<2" },
-    { name = "openai-agents", specifier = ">=0.6.9" },
+    { name = "openai-agents", specifier = ">=0.14.2" },
     { name = "opentelemetry-sdk", specifier = ">=1.38.0,<2" },
     { name = "pytest", specifier = ">=8.2.2,<9" },
     { name = "pytest-asyncio", specifier = ">=1.0.0,<2" },


### PR DESCRIPTION
Fixes #3046
Problem: passing both exporter and processor is a mistake — the processor already wraps the exporter
internally. The exporter was silently ignored with no feedback to the user.

Fix: emit a `UserWarning` pointing at the caller's line. Also removes the redundant
`exporter=` from the `exporter_with_custom_span_processor` test fixture which had the same bug.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Response instructions are now automatically included in trace content for OpenAI agent spans when content tracing is enabled.

* **Improvements**
  * SDK now warns users when both exporter and processor are configured, clarifying that the exporter configuration will be ignored.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4132)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->