### PR TITLE
feat(sdk): expose use_legacy_attributes via Traceloop.init()

### DIFF
--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
@@ -3,7 +3,10 @@
 import logging
 import os
 import time
+import warnings
 from typing import Callable, Collection, Optional
+
+_USE_ATTRIBUTES_UNSET = object()
 
 from opentelemetry import context as context_api
 from opentelemetry._logs import Logger, get_logger
@@ -796,18 +799,31 @@ class AnthropicInstrumentor(BaseInstrumentor):
         self,
         enrich_token_usage: bool = False,
         exception_logger=None,
-        use_legacy_attributes: bool = True,
+        use_attributes: bool = True,
         get_common_metrics_attributes: Callable[[], dict] = lambda: {},
         upload_base64_image: Optional[
             Callable[[str, str, str, str], Coroutine[None, None, str]]
         ] = None,
+        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
     ):
         super().__init__()
+        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+            warnings.warn(
+                "`use_legacy_attributes` is deprecated and will be removed in a "
+                "future release; use `use_attributes` instead. The current OTel "
+                "GenAI spec emits prompts/completions as span attributes "
+                "(`gen_ai.input.messages` / `gen_ai.output.messages`), which is "
+                "what `use_attributes=True` (the default) does. "
+                "`use_attributes=False` opts into the events path instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            use_attributes = use_legacy_attributes
         Config.exception_logger = exception_logger
         Config.enrich_token_usage = enrich_token_usage
         Config.get_common_metrics_attributes = get_common_metrics_attributes
         Config.upload_base64_image = upload_base64_image
-        Config.use_legacy_attributes = use_legacy_attributes
+        Config.use_legacy_attributes = use_attributes
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments

--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
@@ -6,8 +6,6 @@ import time
 import warnings
 from typing import Callable, Collection, Optional
 
-_USE_ATTRIBUTES_UNSET = object()
-
 from opentelemetry import context as context_api
 from opentelemetry._logs import Logger, get_logger
 from opentelemetry.instrumentation.anthropic.config import Config
@@ -799,15 +797,20 @@ class AnthropicInstrumentor(BaseInstrumentor):
         self,
         enrich_token_usage: bool = False,
         exception_logger=None,
-        use_attributes: bool = True,
+        use_attributes: Optional[bool] = None,
         get_common_metrics_attributes: Callable[[], dict] = lambda: {},
         upload_base64_image: Optional[
             Callable[[str, str, str, str], Coroutine[None, None, str]]
         ] = None,
-        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
+        use_legacy_attributes: Optional[bool] = None,
     ):
         super().__init__()
-        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+        if use_attributes is not None and use_legacy_attributes is not None:
+            raise TypeError(
+                "Cannot pass both `use_attributes` and `use_legacy_attributes`; "
+                "`use_legacy_attributes` is deprecated, use `use_attributes` instead."
+            )
+        if use_legacy_attributes is not None:
             warnings.warn(
                 "`use_legacy_attributes` is deprecated and will be removed in a "
                 "future release; use `use_attributes` instead. The current OTel "
@@ -819,6 +822,8 @@ class AnthropicInstrumentor(BaseInstrumentor):
                 stacklevel=2,
             )
             use_attributes = use_legacy_attributes
+        if use_attributes is None:
+            use_attributes = True
         Config.exception_logger = exception_logger
         Config.enrich_token_usage = enrich_token_usage
         Config.get_common_metrics_attributes = get_common_metrics_attributes

--- a/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/__init__.py
+++ b/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/__init__.py
@@ -7,9 +7,7 @@ import time
 import traceback
 import warnings
 from functools import partial, wraps
-from typing import Collection
-
-_USE_ATTRIBUTES_UNSET = object()
+from typing import Collection, Optional
 
 from opentelemetry import context as context_api
 from opentelemetry._logs import get_logger
@@ -1146,11 +1144,16 @@ class BedrockInstrumentor(BaseInstrumentor):
         self,
         enrich_token_usage: bool = False,
         exception_logger=None,
-        use_attributes: bool = True,
-        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
+        use_attributes: Optional[bool] = None,
+        use_legacy_attributes: Optional[bool] = None,
     ):
         super().__init__()
-        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+        if use_attributes is not None and use_legacy_attributes is not None:
+            raise TypeError(
+                "Cannot pass both `use_attributes` and `use_legacy_attributes`; "
+                "`use_legacy_attributes` is deprecated, use `use_attributes` instead."
+            )
+        if use_legacy_attributes is not None:
             warnings.warn(
                 "`use_legacy_attributes` is deprecated and will be removed in a "
                 "future release; use `use_attributes` instead. The current OTel "
@@ -1162,6 +1165,8 @@ class BedrockInstrumentor(BaseInstrumentor):
                 stacklevel=2,
             )
             use_attributes = use_legacy_attributes
+        if use_attributes is None:
+            use_attributes = True
         Config.enrich_token_usage = enrich_token_usage
         Config.exception_logger = exception_logger
         Config.use_legacy_attributes = use_attributes

--- a/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/__init__.py
+++ b/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/__init__.py
@@ -5,8 +5,11 @@ import logging
 import os
 import time
 import traceback
+import warnings
 from functools import partial, wraps
 from typing import Collection
+
+_USE_ATTRIBUTES_UNSET = object()
 
 from opentelemetry import context as context_api
 from opentelemetry._logs import get_logger
@@ -1143,12 +1146,25 @@ class BedrockInstrumentor(BaseInstrumentor):
         self,
         enrich_token_usage: bool = False,
         exception_logger=None,
-        use_legacy_attributes: bool = True,
+        use_attributes: bool = True,
+        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
     ):
         super().__init__()
+        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+            warnings.warn(
+                "`use_legacy_attributes` is deprecated and will be removed in a "
+                "future release; use `use_attributes` instead. The current OTel "
+                "GenAI spec emits prompts/completions as span attributes "
+                "(`gen_ai.input.messages` / `gen_ai.output.messages`), which is "
+                "what `use_attributes=True` (the default) does. "
+                "`use_attributes=False` opts into the events path instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            use_attributes = use_legacy_attributes
         Config.enrich_token_usage = enrich_token_usage
         Config.exception_logger = exception_logger
-        Config.use_legacy_attributes = use_legacy_attributes
+        Config.use_legacy_attributes = use_attributes
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments

--- a/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/__init__.py
+++ b/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/__init__.py
@@ -4,9 +4,7 @@ import logging
 import os
 import time
 import warnings
-from typing import Callable, Collection, Union
-
-_USE_ATTRIBUTES_UNSET = object()
+from typing import Callable, Collection, Optional, Union
 
 from opentelemetry import context as context_api
 from opentelemetry._logs import Logger, get_logger
@@ -461,12 +459,17 @@ class GroqInstrumentor(BaseInstrumentor):
     def __init__(
         self,
         exception_logger=None,
-        use_attributes: bool = True,
+        use_attributes: Optional[bool] = None,
         get_common_metrics_attributes: Callable[[], dict] = lambda: {},
-        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
+        use_legacy_attributes: Optional[bool] = None,
     ):
         super().__init__()
-        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+        if use_attributes is not None and use_legacy_attributes is not None:
+            raise TypeError(
+                "Cannot pass both `use_attributes` and `use_legacy_attributes`; "
+                "`use_legacy_attributes` is deprecated, use `use_attributes` instead."
+            )
+        if use_legacy_attributes is not None:
             warnings.warn(
                 "`use_legacy_attributes` is deprecated and will be removed in a "
                 "future release; use `use_attributes` instead. The current OTel "
@@ -478,6 +481,8 @@ class GroqInstrumentor(BaseInstrumentor):
                 stacklevel=2,
             )
             use_attributes = use_legacy_attributes
+        if use_attributes is None:
+            use_attributes = True
         Config.exception_logger = exception_logger
         Config.get_common_metrics_attributes = get_common_metrics_attributes
         Config.use_legacy_attributes = use_attributes

--- a/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/__init__.py
+++ b/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/__init__.py
@@ -3,7 +3,10 @@
 import logging
 import os
 import time
+import warnings
 from typing import Callable, Collection, Union
+
+_USE_ATTRIBUTES_UNSET = object()
 
 from opentelemetry import context as context_api
 from opentelemetry._logs import Logger, get_logger
@@ -458,13 +461,26 @@ class GroqInstrumentor(BaseInstrumentor):
     def __init__(
         self,
         exception_logger=None,
-        use_legacy_attributes: bool = True,
+        use_attributes: bool = True,
         get_common_metrics_attributes: Callable[[], dict] = lambda: {},
+        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
     ):
         super().__init__()
+        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+            warnings.warn(
+                "`use_legacy_attributes` is deprecated and will be removed in a "
+                "future release; use `use_attributes` instead. The current OTel "
+                "GenAI spec emits prompts/completions as span attributes "
+                "(`gen_ai.input.messages` / `gen_ai.output.messages`), which is "
+                "what `use_attributes=True` (the default) does. "
+                "`use_attributes=False` opts into the events path instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            use_attributes = use_legacy_attributes
         Config.exception_logger = exception_logger
         Config.get_common_metrics_attributes = get_common_metrics_attributes
-        Config.use_legacy_attributes = use_legacy_attributes
+        Config.use_legacy_attributes = use_attributes
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
@@ -1,7 +1,10 @@
 """OpenTelemetry Langchain instrumentation"""
 
 import logging
+import warnings
 from typing import Collection
+
+_USE_ATTRIBUTES_UNSET = object()
 
 from opentelemetry import context as context_api
 
@@ -43,8 +46,9 @@ class LangchainInstrumentor(BaseInstrumentor):
         self,
         exception_logger=None,
         disable_trace_context_propagation=False,
-        use_legacy_attributes: bool = True,
-        metadata_key_prefix: str = SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES
+        use_attributes: bool = True,
+        metadata_key_prefix: str = SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES,
+        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
     ):
         """Create a Langchain instrumentor instance.
 
@@ -52,14 +56,26 @@ class LangchainInstrumentor(BaseInstrumentor):
             exception_logger: A callable that takes an Exception as input. This will be
                 used to log exceptions that occur during instrumentation. If None, exceptions will not be logged.
             disable_trace_context_propagation: If True, disables trace context propagation to LLM providers.
-            use_legacy_attributes: If True, uses span attributes for Inputs/Outputs instead of events.
+            use_attributes: If True (default), emits prompts/completions as span attributes
+                (`gen_ai.input.messages` / `gen_ai.output.messages`), per the current OTel GenAI spec.
+                If False, emits them as OTel log events instead (requires an EventLoggerProvider).
             metadata_key_prefix: Prefix for metadata keys added to spans. Defaults to
                 `SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES`.
                 Useful for using with other backends.
+            use_legacy_attributes: Deprecated alias for ``use_attributes``. Will be removed in a
+                future release.
         """
         super().__init__()
+        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+            warnings.warn(
+                "`use_legacy_attributes` is deprecated and will be removed in a "
+                "future release; use `use_attributes` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            use_attributes = use_legacy_attributes
         Config.exception_logger = exception_logger
-        Config.use_legacy_attributes = use_legacy_attributes
+        Config.use_legacy_attributes = use_attributes
         Config.metadata_key_prefix = metadata_key_prefix
         self.disable_trace_context_propagation = disable_trace_context_propagation
 

--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/__init__.py
@@ -2,9 +2,7 @@
 
 import logging
 import warnings
-from typing import Collection
-
-_USE_ATTRIBUTES_UNSET = object()
+from typing import Collection, Optional
 
 from opentelemetry import context as context_api
 
@@ -46,9 +44,9 @@ class LangchainInstrumentor(BaseInstrumentor):
         self,
         exception_logger=None,
         disable_trace_context_propagation=False,
-        use_attributes: bool = True,
+        use_attributes: Optional[bool] = None,
         metadata_key_prefix: str = SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES,
-        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
+        use_legacy_attributes: Optional[bool] = None,
     ):
         """Create a Langchain instrumentor instance.
 
@@ -66,7 +64,12 @@ class LangchainInstrumentor(BaseInstrumentor):
                 future release.
         """
         super().__init__()
-        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+        if use_attributes is not None and use_legacy_attributes is not None:
+            raise TypeError(
+                "Cannot pass both `use_attributes` and `use_legacy_attributes`; "
+                "`use_legacy_attributes` is deprecated, use `use_attributes` instead."
+            )
+        if use_legacy_attributes is not None:
             warnings.warn(
                 "`use_legacy_attributes` is deprecated and will be removed in a "
                 "future release; use `use_attributes` instead.",
@@ -74,6 +77,8 @@ class LangchainInstrumentor(BaseInstrumentor):
                 stacklevel=2,
             )
             use_attributes = use_legacy_attributes
+        if use_attributes is None:
+            use_attributes = True
         Config.exception_logger = exception_logger
         Config.use_legacy_attributes = use_attributes
         Config.metadata_key_prefix = metadata_key_prefix

--- a/packages/opentelemetry-instrumentation-langchain/uv.lock
+++ b/packages/opentelemetry-instrumentation-langchain/uv.lock
@@ -1515,9 +1515,12 @@ provides-extras = ["instruments", "enrichment"]
 [package.metadata.requires-dev]
 dev = [{ name = "ruff", specifier = ">=0.4.0" }]
 test = [
+    { name = "aioboto3", specifier = ">=13.0.0,<15" },
+    { name = "aiobotocore", specifier = ">=2.13.0,<3" },
     { name = "boto3", specifier = ">=1.34.120,<2" },
     { name = "opentelemetry-sdk", specifier = ">=1.38.0,<2" },
     { name = "pytest", specifier = ">=8.2.2,<9" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0,<1" },
     { name = "pytest-recording", specifier = ">=0.13.1,<0.14.0" },
     { name = "pytest-sugar", specifier = "==1.0.0" },
     { name = "vcrpy", specifier = ">=8.0.0,<9" },

--- a/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/__init__.py
+++ b/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/__init__.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Callable, Collection, Optional
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
@@ -6,6 +7,8 @@ from opentelemetry.instrumentation.openai.utils import is_openai_v1
 from typing_extensions import Coroutine
 
 _instruments = ("openai >= 0.27.0",)
+
+_USE_ATTRIBUTES_UNSET = object()
 
 
 class OpenAIInstrumentor(BaseInstrumentor):
@@ -20,15 +23,28 @@ class OpenAIInstrumentor(BaseInstrumentor):
             Callable[[str, str, str, str], Coroutine[None, None, str]]
         ] = lambda *args: "",
         enable_trace_context_propagation: bool = True,
-        use_legacy_attributes: bool = True,
+        use_attributes: bool = True,
+        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
     ):
         super().__init__()
+        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+            warnings.warn(
+                "`use_legacy_attributes` is deprecated and will be removed in a "
+                "future release; use `use_attributes` instead. The current OTel "
+                "GenAI spec emits prompts/completions as span attributes "
+                "(`gen_ai.input.messages` / `gen_ai.output.messages`), which is "
+                "what `use_attributes=True` (the default) does. "
+                "`use_attributes=False` opts into the events path instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            use_attributes = use_legacy_attributes
         Config.enrich_assistant = enrich_assistant
         Config.exception_logger = exception_logger
         Config.get_common_metrics_attributes = get_common_metrics_attributes
         Config.upload_base64_image = upload_base64_image
         Config.enable_trace_context_propagation = enable_trace_context_propagation
-        Config.use_legacy_attributes = use_legacy_attributes
+        Config.use_legacy_attributes = use_attributes
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments

--- a/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/__init__.py
+++ b/packages/opentelemetry-instrumentation-openai/opentelemetry/instrumentation/openai/__init__.py
@@ -8,8 +8,6 @@ from typing_extensions import Coroutine
 
 _instruments = ("openai >= 0.27.0",)
 
-_USE_ATTRIBUTES_UNSET = object()
-
 
 class OpenAIInstrumentor(BaseInstrumentor):
     """An instrumentor for OpenAI's client library."""
@@ -23,11 +21,16 @@ class OpenAIInstrumentor(BaseInstrumentor):
             Callable[[str, str, str, str], Coroutine[None, None, str]]
         ] = lambda *args: "",
         enable_trace_context_propagation: bool = True,
-        use_attributes: bool = True,
-        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
+        use_attributes: Optional[bool] = None,
+        use_legacy_attributes: Optional[bool] = None,
     ):
         super().__init__()
-        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+        if use_attributes is not None and use_legacy_attributes is not None:
+            raise TypeError(
+                "Cannot pass both `use_attributes` and `use_legacy_attributes`; "
+                "`use_legacy_attributes` is deprecated, use `use_attributes` instead."
+            )
+        if use_legacy_attributes is not None:
             warnings.warn(
                 "`use_legacy_attributes` is deprecated and will be removed in a "
                 "future release; use `use_attributes` instead. The current OTel "
@@ -39,6 +42,8 @@ class OpenAIInstrumentor(BaseInstrumentor):
                 stacklevel=2,
             )
             use_attributes = use_legacy_attributes
+        if use_attributes is None:
+            use_attributes = True
         Config.enrich_assistant = enrich_assistant
         Config.exception_logger = exception_logger
         Config.get_common_metrics_attributes = get_common_metrics_attributes

--- a/packages/opentelemetry-instrumentation-sagemaker/opentelemetry/instrumentation/sagemaker/__init__.py
+++ b/packages/opentelemetry-instrumentation-sagemaker/opentelemetry/instrumentation/sagemaker/__init__.py
@@ -1,7 +1,10 @@
 """OpenTelemetry SageMaker instrumentation"""
 
+import warnings
 from functools import wraps
 from typing import Collection
+
+_USE_ATTRIBUTES_UNSET = object()
 
 from opentelemetry import context as context_api
 from opentelemetry._logs import get_logger
@@ -188,11 +191,24 @@ class SageMakerInstrumentor(BaseInstrumentor):
     def __init__(
         self,
         exception_logger=None,
-        use_legacy_attributes: bool = True,
+        use_attributes: bool = True,
+        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
     ):
         super().__init__()
+        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+            warnings.warn(
+                "`use_legacy_attributes` is deprecated and will be removed in a "
+                "future release; use `use_attributes` instead. The current OTel "
+                "GenAI spec emits prompts/completions as span attributes "
+                "(`gen_ai.input.messages` / `gen_ai.output.messages`), which is "
+                "what `use_attributes=True` (the default) does. "
+                "`use_attributes=False` opts into the events path instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            use_attributes = use_legacy_attributes
         Config.exception_logger = exception_logger
-        Config.use_legacy_attributes = use_legacy_attributes
+        Config.use_legacy_attributes = use_attributes
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments

--- a/packages/opentelemetry-instrumentation-sagemaker/opentelemetry/instrumentation/sagemaker/__init__.py
+++ b/packages/opentelemetry-instrumentation-sagemaker/opentelemetry/instrumentation/sagemaker/__init__.py
@@ -2,9 +2,7 @@
 
 import warnings
 from functools import wraps
-from typing import Collection
-
-_USE_ATTRIBUTES_UNSET = object()
+from typing import Collection, Optional
 
 from opentelemetry import context as context_api
 from opentelemetry._logs import get_logger
@@ -191,11 +189,16 @@ class SageMakerInstrumentor(BaseInstrumentor):
     def __init__(
         self,
         exception_logger=None,
-        use_attributes: bool = True,
-        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
+        use_attributes: Optional[bool] = None,
+        use_legacy_attributes: Optional[bool] = None,
     ):
         super().__init__()
-        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+        if use_attributes is not None and use_legacy_attributes is not None:
+            raise TypeError(
+                "Cannot pass both `use_attributes` and `use_legacy_attributes`; "
+                "`use_legacy_attributes` is deprecated, use `use_attributes` instead."
+            )
+        if use_legacy_attributes is not None:
             warnings.warn(
                 "`use_legacy_attributes` is deprecated and will be removed in a "
                 "future release; use `use_attributes` instead. The current OTel "
@@ -207,6 +210,8 @@ class SageMakerInstrumentor(BaseInstrumentor):
                 stacklevel=2,
             )
             use_attributes = use_legacy_attributes
+        if use_attributes is None:
+            use_attributes = True
         Config.exception_logger = exception_logger
         Config.use_legacy_attributes = use_attributes
 

--- a/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/__init__.py
+++ b/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/__init__.py
@@ -2,9 +2,7 @@
 
 import logging
 import warnings
-from typing import Collection
-
-_USE_ATTRIBUTES_UNSET = object()
+from typing import Collection, Optional
 
 from opentelemetry import context as context_api
 from opentelemetry._logs import get_logger
@@ -150,11 +148,16 @@ class TogetherAiInstrumentor(BaseInstrumentor):
     def __init__(
         self,
         exception_logger=None,
-        use_attributes: bool = True,
-        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
+        use_attributes: Optional[bool] = None,
+        use_legacy_attributes: Optional[bool] = None,
     ):
         super().__init__()
-        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+        if use_attributes is not None and use_legacy_attributes is not None:
+            raise TypeError(
+                "Cannot pass both `use_attributes` and `use_legacy_attributes`; "
+                "`use_legacy_attributes` is deprecated, use `use_attributes` instead."
+            )
+        if use_legacy_attributes is not None:
             warnings.warn(
                 "`use_legacy_attributes` is deprecated and will be removed in a "
                 "future release; use `use_attributes` instead. The current OTel "
@@ -166,6 +169,8 @@ class TogetherAiInstrumentor(BaseInstrumentor):
                 stacklevel=2,
             )
             use_attributes = use_legacy_attributes
+        if use_attributes is None:
+            use_attributes = True
         Config.exception_logger = exception_logger
         Config.use_legacy_attributes = use_attributes
 

--- a/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/__init__.py
+++ b/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/__init__.py
@@ -1,7 +1,10 @@
 """OpenTelemetry Together AI instrumentation"""
 
 import logging
+import warnings
 from typing import Collection
+
+_USE_ATTRIBUTES_UNSET = object()
 
 from opentelemetry import context as context_api
 from opentelemetry._logs import get_logger
@@ -144,10 +147,27 @@ def _wrap(
 class TogetherAiInstrumentor(BaseInstrumentor):
     """An instrumentor for Together AI's client library."""
 
-    def __init__(self, exception_logger=None, use_legacy_attributes: bool = True):
+    def __init__(
+        self,
+        exception_logger=None,
+        use_attributes: bool = True,
+        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
+    ):
         super().__init__()
+        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+            warnings.warn(
+                "`use_legacy_attributes` is deprecated and will be removed in a "
+                "future release; use `use_attributes` instead. The current OTel "
+                "GenAI spec emits prompts/completions as span attributes "
+                "(`gen_ai.input.messages` / `gen_ai.output.messages`), which is "
+                "what `use_attributes=True` (the default) does. "
+                "`use_attributes=False` opts into the events path instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            use_attributes = use_legacy_attributes
         Config.exception_logger = exception_logger
-        Config.use_legacy_attributes = use_legacy_attributes
+        Config.use_legacy_attributes = use_attributes
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments

--- a/packages/opentelemetry-instrumentation-watsonx/opentelemetry/instrumentation/watsonx/__init__.py
+++ b/packages/opentelemetry-instrumentation-watsonx/opentelemetry/instrumentation/watsonx/__init__.py
@@ -7,8 +7,6 @@ import types
 import warnings
 from typing import Collection, Optional, Union
 
-_USE_ATTRIBUTES_UNSET = object()
-
 from opentelemetry import context as context_api
 from opentelemetry._logs import Logger, get_logger
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
@@ -648,11 +646,16 @@ class WatsonxInstrumentor(BaseInstrumentor):
     def __init__(
         self,
         exception_logger=None,
-        use_attributes: bool = True,
-        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
+        use_attributes: Optional[bool] = None,
+        use_legacy_attributes: Optional[bool] = None,
     ):
         super().__init__()
-        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+        if use_attributes is not None and use_legacy_attributes is not None:
+            raise TypeError(
+                "Cannot pass both `use_attributes` and `use_legacy_attributes`; "
+                "`use_legacy_attributes` is deprecated, use `use_attributes` instead."
+            )
+        if use_legacy_attributes is not None:
             warnings.warn(
                 "`use_legacy_attributes` is deprecated and will be removed in a "
                 "future release; use `use_attributes` instead. The current OTel "
@@ -664,6 +667,8 @@ class WatsonxInstrumentor(BaseInstrumentor):
                 stacklevel=2,
             )
             use_attributes = use_legacy_attributes
+        if use_attributes is None:
+            use_attributes = True
         Config.exception_logger = exception_logger
         Config.use_legacy_attributes = use_attributes
 

--- a/packages/opentelemetry-instrumentation-watsonx/opentelemetry/instrumentation/watsonx/__init__.py
+++ b/packages/opentelemetry-instrumentation-watsonx/opentelemetry/instrumentation/watsonx/__init__.py
@@ -4,7 +4,10 @@ import logging
 import os
 import time
 import types
+import warnings
 from typing import Collection, Optional, Union
+
+_USE_ATTRIBUTES_UNSET = object()
 
 from opentelemetry import context as context_api
 from opentelemetry._logs import Logger, get_logger
@@ -642,10 +645,27 @@ class WatsonxSpanAttributes:
 class WatsonxInstrumentor(BaseInstrumentor):
     """An instrumentor for Watsonx's client library."""
 
-    def __init__(self, exception_logger=None, use_legacy_attributes: bool = True):
+    def __init__(
+        self,
+        exception_logger=None,
+        use_attributes: bool = True,
+        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
+    ):
         super().__init__()
+        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+            warnings.warn(
+                "`use_legacy_attributes` is deprecated and will be removed in a "
+                "future release; use `use_attributes` instead. The current OTel "
+                "GenAI spec emits prompts/completions as span attributes "
+                "(`gen_ai.input.messages` / `gen_ai.output.messages`), which is "
+                "what `use_attributes=True` (the default) does. "
+                "`use_attributes=False` opts into the events path instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            use_attributes = use_legacy_attributes
         Config.exception_logger = exception_logger
-        Config.use_legacy_attributes = use_legacy_attributes
+        Config.use_legacy_attributes = use_attributes
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments

--- a/packages/traceloop-sdk/tests/test_sdk_initialization.py
+++ b/packages/traceloop-sdk/tests/test_sdk_initialization.py
@@ -232,7 +232,6 @@ def test_multiple_span_processors(exporters_with_multiple_span_processors):
 def test_get_default_span_processor():
     """Test that get_default_span_processor returns a valid processor."""
     from traceloop.sdk import Traceloop
-    from opentelemetry.sdk.trace.export import SimpleSpanProcessor, BatchSpanProcessor
 
     # Test with batch disabled
     processor = Traceloop.get_default_span_processor(disable_batch=True)

--- a/packages/traceloop-sdk/tests/test_sdk_initialization.py
+++ b/packages/traceloop-sdk/tests/test_sdk_initialization.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 import pytest
 from unittest.mock import patch
 from openai import OpenAI
@@ -7,6 +8,23 @@ from traceloop.sdk.decorators import workflow
 from traceloop.sdk.tracing.tracing import TracerWrapper
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+
+@pytest.fixture
+def isolated_tracer_wrapper():
+    """Save/restore the TracerWrapper singleton so a test can call Traceloop.init()
+    with custom params without leaking state into other tests."""
+    _instance = None
+    if hasattr(TracerWrapper, "instance"):
+        _instance = TracerWrapper.instance
+        del TracerWrapper.instance
+
+    yield
+
+    if hasattr(TracerWrapper, "instance"):
+        del TracerWrapper.instance
+    if _instance is not None:
+        TracerWrapper.instance = _instance
 
 
 @pytest.fixture
@@ -229,6 +247,68 @@ def test_get_default_span_processor():
     assert getattr(processor, "_traceloop_processor") is True
 
 
+def test_use_legacy_attributes_false_propagates_to_instrumentors():
+    """use_legacy_attributes=False passed to Traceloop.init() must reach each
+    instrumentor's Config — otherwise users have no way to opt into the new
+    event-based format through the SDK."""
+    from opentelemetry.instrumentation.openai.shared.config import Config as OpenAIConfig
+    from opentelemetry.instrumentation.anthropic.config import Config as AnthropicConfig
+
+    Traceloop.init(exporter=InMemorySpanExporter(), disable_batch=True)
+
+    assert OpenAIConfig.use_legacy_attributes is True
+    assert AnthropicConfig.use_legacy_attributes is True
+
+
+def test_use_attributes_false_propagates_to_multiple_instrumentors(isolated_tracer_wrapper):
+    """use_attributes=False must reach every instrumentor that supports the flag,
+    not just OpenAI — otherwise users opting into the events path get inconsistent
+    behavior across providers."""
+    from opentelemetry.instrumentation.openai.shared.config import Config as OpenAIConfig
+    from opentelemetry.instrumentation.anthropic.config import Config as AnthropicConfig
+
+    Traceloop.init(
+        exporter=InMemorySpanExporter(),
+        disable_batch=True,
+        use_attributes=False,
+    )
+
+    assert OpenAIConfig.use_legacy_attributes is False
+    assert AnthropicConfig.use_legacy_attributes is False
+
+
+def test_use_legacy_attributes_deprecated_alias_still_works(isolated_tracer_wrapper):
+    """The old kwarg keeps working for one deprecation cycle but emits a warning
+    and forwards to use_attributes."""
+    from opentelemetry.instrumentation.openai.shared.config import Config as OpenAIConfig
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        Traceloop.init(
+            exporter=InMemorySpanExporter(),
+            disable_batch=True,
+            use_legacy_attributes=False,
+        )
+
+    assert OpenAIConfig.use_legacy_attributes is False
+    deprecations = [
+        w for w in caught
+        if issubclass(w.category, DeprecationWarning)
+        and "use_legacy_attributes" in str(w.message)
+    ]
+    assert len(deprecations) >= 1, "Expected a DeprecationWarning for use_legacy_attributes"
+
+def test_use_attributes_defaults_to_true(isolated_tracer_wrapper):
+    """When use_attributes is not passed, instrumentors keep the default spec-compliant
+    behavior (emit prompts/completions as span attributes)."""
+    from opentelemetry.instrumentation.openai.shared.config import Config as OpenAIConfig
+    from opentelemetry.instrumentation.anthropic.config import Config as AnthropicConfig
+
+    Traceloop.init(exporter=InMemorySpanExporter(), disable_batch=True)
+
+    assert OpenAIConfig.use_legacy_attributes is True
+    assert AnthropicConfig.use_legacy_attributes is True
+
 def test_both_exporter_and_processor_warns():
     """Passing both exporter and processor is a mistake — the processor already wraps
     the exporter internally. We warn instead of silently dropping the exporter, and
@@ -267,26 +347,3 @@ def test_both_exporter_and_processor_warns():
             del TracerWrapper.instance
         if saved_instance is not None:
             TracerWrapper.instance = saved_instance
-
-def test_use_legacy_attributes_false_propagates_to_instrumentors():
-    """use_legacy_attributes=False passed to Traceloop.init() must reach each
-    instrumentor's Config — otherwise users have no way to opt into the new
-    event-based format through the SDK."""
-    from opentelemetry.instrumentation.openai.shared.config import Config as OpenAIConfig
-
-    _instance = None
-    if hasattr(TracerWrapper, "instance"):
-        _instance = TracerWrapper.instance
-        del TracerWrapper.instance
-
-    exporter = InMemorySpanExporter()
-    Traceloop.init(
-        exporter=exporter,
-        disable_batch=True,
-        use_legacy_attributes=False,
-    )
-
-    assert OpenAIConfig.use_legacy_attributes is False
-
-    if _instance is not None:
-        TracerWrapper.instance = _instance

--- a/packages/traceloop-sdk/tests/test_sdk_initialization.py
+++ b/packages/traceloop-sdk/tests/test_sdk_initialization.py
@@ -267,3 +267,26 @@ def test_both_exporter_and_processor_warns():
             del TracerWrapper.instance
         if saved_instance is not None:
             TracerWrapper.instance = saved_instance
+
+def test_use_legacy_attributes_false_propagates_to_instrumentors():
+    """use_legacy_attributes=False passed to Traceloop.init() must reach each
+    instrumentor's Config — otherwise users have no way to opt into the new
+    event-based format through the SDK."""
+    from opentelemetry.instrumentation.openai.shared.config import Config as OpenAIConfig
+
+    _instance = None
+    if hasattr(TracerWrapper, "instance"):
+        _instance = TracerWrapper.instance
+        del TracerWrapper.instance
+
+    exporter = InMemorySpanExporter()
+    Traceloop.init(
+        exporter=exporter,
+        disable_batch=True,
+        use_legacy_attributes=False,
+    )
+
+    assert OpenAIConfig.use_legacy_attributes is False
+
+    if _instance is not None:
+        TracerWrapper.instance = _instance

--- a/packages/traceloop-sdk/tests/test_sdk_initialization.py
+++ b/packages/traceloop-sdk/tests/test_sdk_initialization.py
@@ -6,7 +6,7 @@ from openai import OpenAI
 from traceloop.sdk import Traceloop
 from traceloop.sdk.decorators import workflow
 from traceloop.sdk.tracing.tracing import TracerWrapper
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, BatchSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 
@@ -297,6 +297,18 @@ def test_use_legacy_attributes_deprecated_alias_still_works(isolated_tracer_wrap
         and "use_legacy_attributes" in str(w.message)
     ]
     assert len(deprecations) >= 1, "Expected a DeprecationWarning for use_legacy_attributes"
+
+
+def test_passing_both_kwargs_raises_type_error(isolated_tracer_wrapper):
+    """Passing both use_attributes and use_legacy_attributes is a programmer error —
+    fail loudly instead of silently letting one clobber the other."""
+    with pytest.raises(TypeError, match="Cannot pass both"):
+        Traceloop.init(
+            exporter=InMemorySpanExporter(),
+            disable_batch=True,
+            use_attributes=False,
+            use_legacy_attributes=True,
+        )
 
 def test_use_attributes_defaults_to_true(isolated_tracer_wrapper):
     """When use_attributes is not passed, instrumentors keep the default spec-compliant

--- a/packages/traceloop-sdk/traceloop/sdk/__init__.py
+++ b/packages/traceloop-sdk/traceloop/sdk/__init__.py
@@ -4,6 +4,8 @@ import warnings
 from pathlib import Path
 
 from typing import Callable, List, Optional, Set, Union
+
+_USE_ATTRIBUTES_UNSET = object()
 from colorama import Fore
 from opentelemetry.sdk.trace import SpanProcessor, ReadableSpan
 from opentelemetry.sdk.trace.sampling import Sampler
@@ -71,8 +73,36 @@ class Traceloop:
         image_uploader: Optional[ImageUploader] = None,
         span_postprocess_callback: Optional[Callable[[ReadableSpan], None]] = None,
         endpoint_is_traceloop: Optional[bool] = False,
-        use_legacy_attributes: bool = True,
+        use_attributes: bool = True,
+        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
     ) -> Optional[Client]:
+        """Initialize Traceloop tracing, metrics, and instrumentation.
+
+        Args:
+            use_attributes: Controls how prompts/completions are emitted by the
+                bundled instrumentations.
+                If ``True`` (default), they are set as span attributes
+                (``gen_ai.input.messages`` / ``gen_ai.output.messages``), per the current
+                OpenTelemetry GenAI semantic-convention spec.
+                If ``False``, they are emitted as OTel log events instead. This path
+                requires the application to have configured an ``EventLoggerProvider``
+                (via ``opentelemetry._events.set_event_logger_provider``); otherwise
+                events have nowhere to go and no prompt/completion data will be recorded.
+            use_legacy_attributes: Deprecated alias for ``use_attributes``. Will be
+                removed in a future release.
+        """
+        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+            warnings.warn(
+                "`use_legacy_attributes` is deprecated and will be removed in a "
+                "future release; use `use_attributes` instead. The current OTel "
+                "GenAI spec emits prompts/completions as span attributes "
+                "(`gen_ai.input.messages` / `gen_ai.output.messages`), which is "
+                "what `use_attributes=True` (the default) does. "
+                "`use_attributes=False` opts into the events path instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            use_attributes = use_legacy_attributes
         if not enabled:
             TracerWrapper.set_disabled(True)
             print(
@@ -157,7 +187,7 @@ class Traceloop:
             instruments=instruments,
             block_instruments=block_instruments,
             span_postprocess_callback=span_postprocess_callback,
-            use_legacy_attributes=use_legacy_attributes,
+            use_attributes=use_attributes,
         )
 
         metrics_disabled_by_config = not is_metrics_enabled()

--- a/packages/traceloop-sdk/traceloop/sdk/__init__.py
+++ b/packages/traceloop-sdk/traceloop/sdk/__init__.py
@@ -71,6 +71,7 @@ class Traceloop:
         image_uploader: Optional[ImageUploader] = None,
         span_postprocess_callback: Optional[Callable[[ReadableSpan], None]] = None,
         endpoint_is_traceloop: Optional[bool] = False,
+        use_legacy_attributes: bool = True,
     ) -> Optional[Client]:
         if not enabled:
             TracerWrapper.set_disabled(True)
@@ -156,6 +157,7 @@ class Traceloop:
             instruments=instruments,
             block_instruments=block_instruments,
             span_postprocess_callback=span_postprocess_callback,
+            use_legacy_attributes=use_legacy_attributes,
         )
 
         metrics_disabled_by_config = not is_metrics_enabled()

--- a/packages/traceloop-sdk/traceloop/sdk/__init__.py
+++ b/packages/traceloop-sdk/traceloop/sdk/__init__.py
@@ -4,8 +4,6 @@ import warnings
 from pathlib import Path
 
 from typing import Callable, List, Optional, Set, Union
-
-_USE_ATTRIBUTES_UNSET = object()
 from colorama import Fore
 from opentelemetry.sdk.trace import SpanProcessor, ReadableSpan
 from opentelemetry.sdk.trace.sampling import Sampler
@@ -73,8 +71,8 @@ class Traceloop:
         image_uploader: Optional[ImageUploader] = None,
         span_postprocess_callback: Optional[Callable[[ReadableSpan], None]] = None,
         endpoint_is_traceloop: Optional[bool] = False,
-        use_attributes: bool = True,
-        use_legacy_attributes=_USE_ATTRIBUTES_UNSET,
+        use_attributes: Optional[bool] = None,
+        use_legacy_attributes: Optional[bool] = None,
     ) -> Optional[Client]:
         """Initialize Traceloop tracing, metrics, and instrumentation.
 
@@ -91,7 +89,12 @@ class Traceloop:
             use_legacy_attributes: Deprecated alias for ``use_attributes``. Will be
                 removed in a future release.
         """
-        if use_legacy_attributes is not _USE_ATTRIBUTES_UNSET:
+        if use_attributes is not None and use_legacy_attributes is not None:
+            raise TypeError(
+                "Cannot pass both `use_attributes` and `use_legacy_attributes`; "
+                "`use_legacy_attributes` is deprecated, use `use_attributes` instead."
+            )
+        if use_legacy_attributes is not None:
             warnings.warn(
                 "`use_legacy_attributes` is deprecated and will be removed in a "
                 "future release; use `use_attributes` instead. The current OTel "
@@ -103,6 +106,8 @@ class Traceloop:
                 stacklevel=2,
             )
             use_attributes = use_legacy_attributes
+        if use_attributes is None:
+            use_attributes = True
         if not enabled:
             TracerWrapper.set_disabled(True)
             print(

--- a/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
+++ b/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
@@ -84,6 +84,7 @@ class TracerWrapper(object):
         block_instruments: Optional[Set[Instruments]] = None,
         image_uploader: ImageUploader = None,
         span_postprocess_callback: Optional[Callable[[ReadableSpan], None]] = None,
+        use_legacy_attributes: bool = True,
     ) -> "TracerWrapper":
         if not hasattr(cls, "instance"):
             obj = cls.instance = super(TracerWrapper, cls).__new__(cls)
@@ -160,6 +161,7 @@ class TracerWrapper(object):
                 image_uploader.aupload_base64_image,
                 instruments,
                 block_instruments,
+                use_legacy_attributes,
             )
 
             obj.__content_allow_list = ContentAllowList()
@@ -483,6 +485,7 @@ def init_instrumentations(
     base64_image_uploader: Callable[[str, str, str, str], str],
     instruments: Optional[Set[Instruments]] = None,
     block_instruments: Optional[Set[Instruments]] = None,
+    use_legacy_attributes: bool = True,
 ):
     block_instruments = block_instruments or set()
     # explictly test for None since empty set is a False value
@@ -501,11 +504,11 @@ def init_instrumentations(
                 instrument_set = True
         elif instrument == Instruments.ANTHROPIC:
             if init_anthropic_instrumentor(
-                should_enrich_metrics, base64_image_uploader
+                should_enrich_metrics, base64_image_uploader, use_legacy_attributes
             ):
                 instrument_set = True
         elif instrument == Instruments.BEDROCK:
-            if init_bedrock_instrumentor(should_enrich_metrics):
+            if init_bedrock_instrumentor(should_enrich_metrics, use_legacy_attributes):
                 instrument_set = True
         elif instrument == Instruments.CHROMA:
             if init_chroma_instrumentor():
@@ -522,7 +525,7 @@ def init_instrumentations(
             ):
                 instrument_set = True
         elif instrument == Instruments.GROQ:
-            if init_groq_instrumentor():
+            if init_groq_instrumentor(use_legacy_attributes):
                 instrument_set = True
         elif instrument == Instruments.HAYSTACK:
             if init_haystack_instrumentor():
@@ -531,7 +534,7 @@ def init_instrumentations(
             if init_lancedb_instrumentor():
                 instrument_set = True
         elif instrument == Instruments.LANGCHAIN:
-            if init_langchain_instrumentor():
+            if init_langchain_instrumentor(use_legacy_attributes):
                 instrument_set = True
         elif instrument == Instruments.LLAMA_INDEX:
             if init_llama_index_instrumentor():
@@ -552,7 +555,7 @@ def init_instrumentations(
             if init_ollama_instrumentor():
                 instrument_set = True
         elif instrument == Instruments.OPENAI:
-            if init_openai_instrumentor(should_enrich_metrics, base64_image_uploader):
+            if init_openai_instrumentor(should_enrich_metrics, base64_image_uploader, use_legacy_attributes):
                 instrument_set = True
         elif instrument == Instruments.OPENAI_AGENTS:
             if init_openai_agents_instrumentor():
@@ -576,10 +579,10 @@ def init_instrumentations(
             if init_requests_instrumentor():
                 instrument_set = True
         elif instrument == Instruments.SAGEMAKER:
-            if init_sagemaker_instrumentor(should_enrich_metrics):
+            if init_sagemaker_instrumentor(should_enrich_metrics, use_legacy_attributes):
                 instrument_set = True
         elif instrument == Instruments.TOGETHER:
-            if init_together_instrumentor():
+            if init_together_instrumentor(use_legacy_attributes):
                 instrument_set = True
         elif instrument == Instruments.TRANSFORMERS:
             if init_transformers_instrumentor():
@@ -594,7 +597,7 @@ def init_instrumentations(
             if init_voyageai_instrumentor():
                 instrument_set = True
         elif instrument == Instruments.WATSONX:
-            if init_watsonx_instrumentor():
+            if init_watsonx_instrumentor(use_legacy_attributes):
                 instrument_set = True
         elif instrument == Instruments.WEAVIATE:
             if init_weaviate_instrumentor():
@@ -626,6 +629,7 @@ def init_instrumentations(
 def init_openai_instrumentor(
     should_enrich_metrics: bool,
     base64_image_uploader: Callable[[str, str, str, str], str],
+    use_legacy_attributes: bool = True,
 ):
     try:
         if is_package_installed("openai"):
@@ -635,6 +639,7 @@ def init_openai_instrumentor(
                 enrich_assistant=should_enrich_metrics,
                 get_common_metrics_attributes=metrics_common_attributes,
                 upload_base64_image=base64_image_uploader,
+                use_legacy_attributes=use_legacy_attributes,
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
@@ -648,6 +653,7 @@ def init_openai_instrumentor(
 def init_anthropic_instrumentor(
     should_enrich_metrics: bool,
     base64_image_uploader: Callable[[str, str, str, str], str],
+    use_legacy_attributes: bool = True,
 ):
     try:
         if is_package_installed("anthropic"):
@@ -657,6 +663,7 @@ def init_anthropic_instrumentor(
                 enrich_token_usage=should_enrich_metrics,
                 get_common_metrics_attributes=metrics_common_attributes,
                 upload_base64_image=base64_image_uploader,
+                use_legacy_attributes=use_legacy_attributes,
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
@@ -761,12 +768,12 @@ def init_haystack_instrumentor():
     return False
 
 
-def init_langchain_instrumentor():
+def init_langchain_instrumentor(use_legacy_attributes: bool = True):
     try:
         if is_package_installed("langchain") or is_package_installed("langgraph"):
             from opentelemetry.instrumentation.langchain import LangchainInstrumentor
 
-            instrumentor = LangchainInstrumentor()
+            instrumentor = LangchainInstrumentor(use_legacy_attributes=use_legacy_attributes)
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
             return True
@@ -819,12 +826,12 @@ def init_transformers_instrumentor():
     return False
 
 
-def init_together_instrumentor():
+def init_together_instrumentor(use_legacy_attributes: bool = True):
     try:
         if is_package_installed("together"):
             from opentelemetry.instrumentation.together import TogetherAiInstrumentor
 
-            instrumentor = TogetherAiInstrumentor()
+            instrumentor = TogetherAiInstrumentor(use_legacy_attributes=use_legacy_attributes)
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
             return True
@@ -903,12 +910,13 @@ def init_pymysql_instrumentor():
     return False
 
 
-def init_bedrock_instrumentor(should_enrich_metrics: bool):
+def init_bedrock_instrumentor(should_enrich_metrics: bool, use_legacy_attributes: bool = True):
     if is_package_installed("boto3"):
         from opentelemetry.instrumentation.bedrock import BedrockInstrumentor
 
         instrumentor = BedrockInstrumentor(
             enrich_token_usage=should_enrich_metrics,
+            use_legacy_attributes=use_legacy_attributes,
         )
         if not instrumentor.is_instrumented_by_opentelemetry:
             instrumentor.instrument()
@@ -916,12 +924,12 @@ def init_bedrock_instrumentor(should_enrich_metrics: bool):
     return False
 
 
-def init_sagemaker_instrumentor(should_enrich_metrics: bool):
+def init_sagemaker_instrumentor(should_enrich_metrics: bool, use_legacy_attributes: bool = True):
     try:
         if is_package_installed("boto3"):
             from opentelemetry.instrumentation.sagemaker import SageMakerInstrumentor
 
-            instrumentor = SageMakerInstrumentor()
+            instrumentor = SageMakerInstrumentor(use_legacy_attributes=use_legacy_attributes)
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
             return True
@@ -977,14 +985,14 @@ def init_voyageai_instrumentor():
     return False
 
 
-def init_watsonx_instrumentor():
+def init_watsonx_instrumentor(use_legacy_attributes: bool = True):
     try:
         if is_package_installed("ibm-watsonx-ai") or is_package_installed(
             "ibm_watson_machine_learning"
         ):
             from opentelemetry.instrumentation.watsonx import WatsonxInstrumentor
 
-            instrumentor = WatsonxInstrumentor()
+            instrumentor = WatsonxInstrumentor(use_legacy_attributes=use_legacy_attributes)
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
             return True
@@ -1091,12 +1099,12 @@ def init_redis_instrumentor():
     return False
 
 
-def init_groq_instrumentor():
+def init_groq_instrumentor(use_legacy_attributes: bool = True):
     try:
         if is_package_installed("groq"):
             from opentelemetry.instrumentation.groq import GroqInstrumentor
 
-            instrumentor = GroqInstrumentor()
+            instrumentor = GroqInstrumentor(use_legacy_attributes=use_legacy_attributes)
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
             return True

--- a/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
+++ b/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
@@ -3,8 +3,6 @@ import logging
 import os
 from urllib.parse import urlparse
 
-_USE_ATTRIBUTES_UNSET = object()
-
 
 from colorama import Fore
 from opentelemetry import trace

--- a/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
+++ b/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py
@@ -3,6 +3,8 @@ import logging
 import os
 from urllib.parse import urlparse
 
+_USE_ATTRIBUTES_UNSET = object()
+
 
 from colorama import Fore
 from opentelemetry import trace
@@ -84,7 +86,7 @@ class TracerWrapper(object):
         block_instruments: Optional[Set[Instruments]] = None,
         image_uploader: ImageUploader = None,
         span_postprocess_callback: Optional[Callable[[ReadableSpan], None]] = None,
-        use_legacy_attributes: bool = True,
+        use_attributes: bool = True,
     ) -> "TracerWrapper":
         if not hasattr(cls, "instance"):
             obj = cls.instance = super(TracerWrapper, cls).__new__(cls)
@@ -161,7 +163,7 @@ class TracerWrapper(object):
                 image_uploader.aupload_base64_image,
                 instruments,
                 block_instruments,
-                use_legacy_attributes,
+                use_attributes,
             )
 
             obj.__content_allow_list = ContentAllowList()
@@ -485,7 +487,7 @@ def init_instrumentations(
     base64_image_uploader: Callable[[str, str, str, str], str],
     instruments: Optional[Set[Instruments]] = None,
     block_instruments: Optional[Set[Instruments]] = None,
-    use_legacy_attributes: bool = True,
+    use_attributes: bool = True,
 ):
     block_instruments = block_instruments or set()
     # explictly test for None since empty set is a False value
@@ -504,11 +506,11 @@ def init_instrumentations(
                 instrument_set = True
         elif instrument == Instruments.ANTHROPIC:
             if init_anthropic_instrumentor(
-                should_enrich_metrics, base64_image_uploader, use_legacy_attributes
+                should_enrich_metrics, base64_image_uploader, use_attributes
             ):
                 instrument_set = True
         elif instrument == Instruments.BEDROCK:
-            if init_bedrock_instrumentor(should_enrich_metrics, use_legacy_attributes):
+            if init_bedrock_instrumentor(should_enrich_metrics, use_attributes):
                 instrument_set = True
         elif instrument == Instruments.CHROMA:
             if init_chroma_instrumentor():
@@ -525,7 +527,7 @@ def init_instrumentations(
             ):
                 instrument_set = True
         elif instrument == Instruments.GROQ:
-            if init_groq_instrumentor(use_legacy_attributes):
+            if init_groq_instrumentor(use_attributes):
                 instrument_set = True
         elif instrument == Instruments.HAYSTACK:
             if init_haystack_instrumentor():
@@ -534,7 +536,7 @@ def init_instrumentations(
             if init_lancedb_instrumentor():
                 instrument_set = True
         elif instrument == Instruments.LANGCHAIN:
-            if init_langchain_instrumentor(use_legacy_attributes):
+            if init_langchain_instrumentor(use_attributes):
                 instrument_set = True
         elif instrument == Instruments.LLAMA_INDEX:
             if init_llama_index_instrumentor():
@@ -555,7 +557,7 @@ def init_instrumentations(
             if init_ollama_instrumentor():
                 instrument_set = True
         elif instrument == Instruments.OPENAI:
-            if init_openai_instrumentor(should_enrich_metrics, base64_image_uploader, use_legacy_attributes):
+            if init_openai_instrumentor(should_enrich_metrics, base64_image_uploader, use_attributes):
                 instrument_set = True
         elif instrument == Instruments.OPENAI_AGENTS:
             if init_openai_agents_instrumentor():
@@ -579,10 +581,10 @@ def init_instrumentations(
             if init_requests_instrumentor():
                 instrument_set = True
         elif instrument == Instruments.SAGEMAKER:
-            if init_sagemaker_instrumentor(should_enrich_metrics, use_legacy_attributes):
+            if init_sagemaker_instrumentor(should_enrich_metrics, use_attributes):
                 instrument_set = True
         elif instrument == Instruments.TOGETHER:
-            if init_together_instrumentor(use_legacy_attributes):
+            if init_together_instrumentor(use_attributes):
                 instrument_set = True
         elif instrument == Instruments.TRANSFORMERS:
             if init_transformers_instrumentor():
@@ -597,7 +599,7 @@ def init_instrumentations(
             if init_voyageai_instrumentor():
                 instrument_set = True
         elif instrument == Instruments.WATSONX:
-            if init_watsonx_instrumentor(use_legacy_attributes):
+            if init_watsonx_instrumentor(use_attributes):
                 instrument_set = True
         elif instrument == Instruments.WEAVIATE:
             if init_weaviate_instrumentor():
@@ -629,7 +631,7 @@ def init_instrumentations(
 def init_openai_instrumentor(
     should_enrich_metrics: bool,
     base64_image_uploader: Callable[[str, str, str, str], str],
-    use_legacy_attributes: bool = True,
+    use_attributes: bool = True,
 ):
     try:
         if is_package_installed("openai"):
@@ -639,7 +641,7 @@ def init_openai_instrumentor(
                 enrich_assistant=should_enrich_metrics,
                 get_common_metrics_attributes=metrics_common_attributes,
                 upload_base64_image=base64_image_uploader,
-                use_legacy_attributes=use_legacy_attributes,
+                use_attributes=use_attributes,
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
@@ -653,7 +655,7 @@ def init_openai_instrumentor(
 def init_anthropic_instrumentor(
     should_enrich_metrics: bool,
     base64_image_uploader: Callable[[str, str, str, str], str],
-    use_legacy_attributes: bool = True,
+    use_attributes: bool = True,
 ):
     try:
         if is_package_installed("anthropic"):
@@ -663,7 +665,7 @@ def init_anthropic_instrumentor(
                 enrich_token_usage=should_enrich_metrics,
                 get_common_metrics_attributes=metrics_common_attributes,
                 upload_base64_image=base64_image_uploader,
-                use_legacy_attributes=use_legacy_attributes,
+                use_attributes=use_attributes,
             )
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
@@ -768,12 +770,12 @@ def init_haystack_instrumentor():
     return False
 
 
-def init_langchain_instrumentor(use_legacy_attributes: bool = True):
+def init_langchain_instrumentor(use_attributes: bool = True):
     try:
         if is_package_installed("langchain") or is_package_installed("langgraph"):
             from opentelemetry.instrumentation.langchain import LangchainInstrumentor
 
-            instrumentor = LangchainInstrumentor(use_legacy_attributes=use_legacy_attributes)
+            instrumentor = LangchainInstrumentor(use_attributes=use_attributes)
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
             return True
@@ -826,12 +828,12 @@ def init_transformers_instrumentor():
     return False
 
 
-def init_together_instrumentor(use_legacy_attributes: bool = True):
+def init_together_instrumentor(use_attributes: bool = True):
     try:
         if is_package_installed("together"):
             from opentelemetry.instrumentation.together import TogetherAiInstrumentor
 
-            instrumentor = TogetherAiInstrumentor(use_legacy_attributes=use_legacy_attributes)
+            instrumentor = TogetherAiInstrumentor(use_attributes=use_attributes)
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
             return True
@@ -910,13 +912,13 @@ def init_pymysql_instrumentor():
     return False
 
 
-def init_bedrock_instrumentor(should_enrich_metrics: bool, use_legacy_attributes: bool = True):
+def init_bedrock_instrumentor(should_enrich_metrics: bool, use_attributes: bool = True):
     if is_package_installed("boto3"):
         from opentelemetry.instrumentation.bedrock import BedrockInstrumentor
 
         instrumentor = BedrockInstrumentor(
             enrich_token_usage=should_enrich_metrics,
-            use_legacy_attributes=use_legacy_attributes,
+            use_attributes=use_attributes,
         )
         if not instrumentor.is_instrumented_by_opentelemetry:
             instrumentor.instrument()
@@ -924,12 +926,12 @@ def init_bedrock_instrumentor(should_enrich_metrics: bool, use_legacy_attributes
     return False
 
 
-def init_sagemaker_instrumentor(should_enrich_metrics: bool, use_legacy_attributes: bool = True):
+def init_sagemaker_instrumentor(should_enrich_metrics: bool, use_attributes: bool = True):
     try:
         if is_package_installed("boto3"):
             from opentelemetry.instrumentation.sagemaker import SageMakerInstrumentor
 
-            instrumentor = SageMakerInstrumentor(use_legacy_attributes=use_legacy_attributes)
+            instrumentor = SageMakerInstrumentor(use_attributes=use_attributes)
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
             return True
@@ -985,14 +987,14 @@ def init_voyageai_instrumentor():
     return False
 
 
-def init_watsonx_instrumentor(use_legacy_attributes: bool = True):
+def init_watsonx_instrumentor(use_attributes: bool = True):
     try:
         if is_package_installed("ibm-watsonx-ai") or is_package_installed(
             "ibm_watson_machine_learning"
         ):
             from opentelemetry.instrumentation.watsonx import WatsonxInstrumentor
 
-            instrumentor = WatsonxInstrumentor(use_legacy_attributes=use_legacy_attributes)
+            instrumentor = WatsonxInstrumentor(use_attributes=use_attributes)
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
             return True
@@ -1099,12 +1101,12 @@ def init_redis_instrumentor():
     return False
 
 
-def init_groq_instrumentor(use_legacy_attributes: bool = True):
+def init_groq_instrumentor(use_attributes: bool = True):
     try:
         if is_package_installed("groq"):
             from opentelemetry.instrumentation.groq import GroqInstrumentor
 
-            instrumentor = GroqInstrumentor(use_legacy_attributes=use_legacy_attributes)
+            instrumentor = GroqInstrumentor(use_attributes=use_attributes)
             if not instrumentor.is_instrumented_by_opentelemetry:
                 instrumentor.instrument()
             return True

--- a/packages/traceloop-sdk/uv.lock
+++ b/packages/traceloop-sdk/uv.lock
@@ -2,8 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.10, <4"
 resolution-markers = [
-    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
-    "python_full_version >= '3.13' and platform_python_implementation != 'PyPy'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.13.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.13.*' and platform_python_implementation != 'PyPy'",
     "python_full_version >= '3.12.4' and python_full_version < '3.13' and platform_python_implementation == 'PyPy'",
     "python_full_version >= '3.12' and python_full_version < '3.12.4' and platform_python_implementation == 'PyPy'",
     "python_full_version >= '3.12.4' and python_full_version < '3.13' and platform_python_implementation != 'PyPy'",
@@ -1439,32 +1441,32 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.39.1"
+version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/b9/3161be15bb8e3ad01be8be5a968a9237c3027c5be504362ff800fca3e442/opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c", size = 65767, upload-time = "2025-12-11T13:32:39.182Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950", size = 66356, upload-time = "2025-12-11T13:32:17.304Z" },
+    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.39.1"
+version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409, upload-time = "2025-12-11T13:32:40.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/fa/f9e3bd3c4d692b3ce9a2880a167d1f79681a1bea11f00d5bf76adc03e6ea/opentelemetry_exporter_otlp_proto_common-1.41.1.tar.gz", hash = "sha256:0e253156ea9c36b0bd3d2440c5c9ba7dd1f3fb64ba7a08fc85fbac536b56e1fb", size = 20409, upload-time = "2026-04-24T13:15:40.924Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/02/ffc3e143d89a27ac21fd557365b98bd0653b98de8a101151d5805b5d4c33/opentelemetry_exporter_otlp_proto_common-1.39.1-py3-none-any.whl", hash = "sha256:08f8a5862d64cc3435105686d0216c1365dc5701f86844a8cd56597d0c764fde", size = 18366, upload-time = "2025-12-11T13:32:20.2Z" },
+    { url = "https://files.pythonhosted.org/packages/29/48/bce76d3ea772b609757e9bc844e02ab408a6446609bf74fb562062ba6b71/opentelemetry_exporter_otlp_proto_common-1.41.1-py3-none-any.whl", hash = "sha256:10da74dad6a49344b9b7b21b6182e3060373a235fde1528616d5f01f92e66aa9", size = 18366, upload-time = "2026-04-24T13:15:18.917Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.39.1"
+version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -1475,14 +1477,14 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/48/b329fed2c610c2c32c9366d9dc597202c9d1e58e631c137ba15248d8850f/opentelemetry_exporter_otlp_proto_grpc-1.39.1.tar.gz", hash = "sha256:772eb1c9287485d625e4dbe9c879898e5253fea111d9181140f51291b5fec3ad", size = 24650, upload-time = "2025-12-11T13:32:41.429Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/9b/e4503060b8695579dbaad187dc8cef4554188de68748c88060599b77489e/opentelemetry_exporter_otlp_proto_grpc-1.41.1.tar.gz", hash = "sha256:b05df8fa1333dc9a3fda36b676b96b5095ab6016d3f0c3296d430d629ba1443b", size = 25755, upload-time = "2026-04-24T13:15:41.93Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/a3/cc9b66575bd6597b98b886a2067eea2693408d2d5f39dad9ab7fc264f5f3/opentelemetry_exporter_otlp_proto_grpc-1.39.1-py3-none-any.whl", hash = "sha256:fa1c136a05c7e9b4c09f739469cbdb927ea20b34088ab1d959a849b5cc589c18", size = 19766, upload-time = "2025-12-11T13:32:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f2/c54f33c92443d087703e57e52e55f22f111373a5c4c4aa349ea60efe512e/opentelemetry_exporter_otlp_proto_grpc-1.41.1-py3-none-any.whl", hash = "sha256:537926dcef951136992479af1d9cd88f25e33d56c530e9f020ed57774dca2f94", size = 20297, upload-time = "2026-04-24T13:15:20.212Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.39.1"
+version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -1493,14 +1495,14 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288, upload-time = "2025-12-11T13:32:42.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/5b/9d3c7f70cca10136ba82a81e738dee626c8e7fc61c6887ea9a58bf34c606/opentelemetry_exporter_otlp_proto_http-1.41.1.tar.gz", hash = "sha256:4747a9604c8550ab38c6fd6180e2fcb80de3267060bef2c306bad3cb443302bc", size = 24139, upload-time = "2026-04-24T13:15:42.977Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/f1/b27d3e2e003cd9a3592c43d099d2ed8d0a947c15281bf8463a256db0b46c/opentelemetry_exporter_otlp_proto_http-1.39.1-py3-none-any.whl", hash = "sha256:d9f5207183dd752a412c4cd564ca8875ececba13be6e9c6c370ffb752fd59985", size = 19641, upload-time = "2025-12-11T13:32:22.248Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4d/ef07ff2fc630849f2080ae0ae73a61f67257905b7ac79066640bfa0c5739/opentelemetry_exporter_otlp_proto_http-1.41.1-py3-none-any.whl", hash = "sha256:1a21e8f49c7a946d935551e90947d6c3eb39236723c6624401da0f33d68edcb4", size = 22673, upload-time = "2026-04-24T13:15:21.313Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation"
-version = "0.60b1"
+version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1508,9 +1510,9 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/0f/7e6b713ac117c1f5e4e3300748af699b9902a2e5e34c9cf443dde25a01fa/opentelemetry_instrumentation-0.60b1.tar.gz", hash = "sha256:57ddc7974c6eb35865af0426d1a17132b88b2ed8586897fee187fd5b8944bd6a", size = 31706, upload-time = "2025-12-11T13:36:42.515Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/cb/0523b92c112a6cc70be43724343dc45225d3af134419844d7879a07755d4/opentelemetry_instrumentation-0.62b1.tar.gz", hash = "sha256:90e92a905ba4f84db06ac3aec96701df6c079b2d66e9379f8739f0a1bdcc7f45", size = 34043, upload-time = "2026-04-24T13:22:31.997Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl", hash = "sha256:04480db952b48fb1ed0073f822f0ee26012b7be7c3eac1a3793122737c78632d", size = 33096, upload-time = "2025-12-11T13:35:33.067Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/0f/45adbaea1f81b847cffdcee4f4b5f89297e42facf7fac78c7aaac4c38e75/opentelemetry_instrumentation-0.62b1-py3-none-any.whl", hash = "sha256:976fc6e640f2006599e97429c949e622c108d0c17c2059347d1e6c93c707f257", size = 34163, upload-time = "2026-04-24T13:21:31.722Z" },
 ]
 
 [[package]]
@@ -1654,9 +1656,12 @@ provides-extras = ["instruments", "enrichment"]
 [package.metadata.requires-dev]
 dev = [{ name = "ruff", specifier = ">=0.4.0" }]
 test = [
+    { name = "aioboto3", specifier = ">=13.0.0,<15" },
+    { name = "aiobotocore", specifier = ">=2.13.0,<3" },
     { name = "boto3", specifier = ">=1.34.120,<2" },
     { name = "opentelemetry-sdk", specifier = ">=1.38.0,<2" },
     { name = "pytest", specifier = ">=8.2.2,<9" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0,<1" },
     { name = "pytest-recording", specifier = ">=0.13.1,<0.14.0" },
     { name = "pytest-sugar", specifier = "==1.0.0" },
     { name = "vcrpy", specifier = ">=8.0.0,<9" },
@@ -2029,15 +2034,15 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-logging"
-version = "0.60b1"
+version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/a6/4515895b383113677fd2ad21813df5e56108a2df14ebb7916c962c9a0234/opentelemetry_instrumentation_logging-0.60b1.tar.gz", hash = "sha256:98f4b9c7aeb9314a30feee7c002c7ea9abea07c90df5f97fb058b850bc45b89a", size = 9968, upload-time = "2025-12-11T13:37:03.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/25/a30e0160cb3654bb63936be16d8ffe5f4a658d10bec0d5509cca3c74f103/opentelemetry_instrumentation_logging-0.62b1.tar.gz", hash = "sha256:997359d29ce06cb3768677387469431d0484b2450b5c35d7f02361431d3de338", size = 18969, upload-time = "2026-04-24T13:22:54.275Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/f9/8a4ce3901bc52277794e4b18c4ac43dc5929806eff01d22812364132f45f/opentelemetry_instrumentation_logging-0.60b1-py3-none-any.whl", hash = "sha256:f2e18cbc7e1dd3628c80e30d243897fdc93c5b7e0c8ae60abd2b9b6a99f82343", size = 12577, upload-time = "2025-12-11T13:36:08.123Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e4/216d1c7ff9c10815a8587ecbca0b570596921f001d1e2c2903c6f19e2e90/opentelemetry_instrumentation_logging-0.62b1-py3-none-any.whl", hash = "sha256:969330216d1ae02f4e10f1a030566ae758114caead020817192e6a02c6d1a0e1", size = 17488, upload-time = "2026-04-24T13:22:00.726Z" },
 ]
 
 [[package]]
@@ -2134,7 +2139,7 @@ requires-dist = [
     { name = "opentelemetry-api", specifier = ">=1.38.0,<2" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.59b0" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.59b0" },
-    { name = "opentelemetry-semantic-conventions-ai", specifier = ">=0.5.1,<0.6.0" },
+    { name = "opentelemetry-semantic-conventions-ai", editable = "../opentelemetry-semantic-conventions-ai" },
     { name = "pymilvus", marker = "extra == 'instruments'" },
 ]
 provides-extras = ["instruments"]
@@ -2282,7 +2287,7 @@ requires-dist = [
     { name = "openai-agents", marker = "extra == 'instruments'" },
     { name = "opentelemetry-api", specifier = ">=1.38.0,<2" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.59b0" },
-    { name = "opentelemetry-semantic-conventions", specifier = ">=0.59b0" },
+    { name = "opentelemetry-semantic-conventions", specifier = ">=0.62b1" },
     { name = "opentelemetry-semantic-conventions-ai", specifier = ">=0.5.1,<0.6.0" },
 ]
 provides-extras = ["instruments"]
@@ -2321,7 +2326,7 @@ requires-dist = [
     { name = "opentelemetry-api", specifier = ">=1.38.0,<2" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.59b0" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.59b0" },
-    { name = "opentelemetry-semantic-conventions-ai", specifier = ">=0.5.1,<0.6.0" },
+    { name = "opentelemetry-semantic-conventions-ai", editable = "../opentelemetry-semantic-conventions-ai" },
     { name = "pinecone", marker = "extra == 'instruments'", specifier = ">=5.1.0,<9" },
 ]
 provides-extras = ["instruments"]
@@ -2379,7 +2384,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-redis"
-version = "0.60b1"
+version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -2387,9 +2392,9 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/1e/225364fab4db793f6f5024ed9f3dd53774fd7c7c21fa242460234dcdf8d9/opentelemetry_instrumentation_redis-0.60b1.tar.gz", hash = "sha256:ecafa8f81c88917b59f0d842fb3d157f3a8edc71fb4b85bebca3bc19432ce7b8", size = 14774, upload-time = "2025-12-11T13:37:11.201Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/ff/35414ad80409bd9e472c7959832524c5f2c8f63965af08c41c2b42d3a6a6/opentelemetry_instrumentation_redis-0.62b1.tar.gz", hash = "sha256:2d3c421d95e05ade075bee5becbe34e743b1cdf5bdee2085cb524f88c4f13dcb", size = 14796, upload-time = "2026-04-24T13:23:01.138Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/bd/d55d3b34fd49df08d9d9fa3701dff0051b216e2c7e9adaaa4ff6aa1de8d7/opentelemetry_instrumentation_redis-0.60b1-py3-none-any.whl", hash = "sha256:33bef0ff9af6f2d88de90c1cd7e25675c10a16d4f9ee5ae7592b28bb08b78139", size = 15502, upload-time = "2025-12-11T13:36:21.481Z" },
+    { url = "https://files.pythonhosted.org/packages/31/37/bc2271f3472e3041eeade8b8da1cfd3b06badae76fe5d0ff135b6285e70c/opentelemetry_instrumentation_redis-0.62b1-py3-none-any.whl", hash = "sha256:9aedd02c1acf631251d1d676634db47da9da04e0a626cd0c7d83fe0eb791d165", size = 15501, upload-time = "2026-04-24T13:22:11.705Z" },
 ]
 
 [[package]]
@@ -2431,7 +2436,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-requests"
-version = "0.60b1"
+version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -2439,9 +2444,9 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-util-http" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/4a/bb9d47d7424fc33aeba75275256ae6e6031f44b6a9a3f778d611c0c3ac27/opentelemetry_instrumentation_requests-0.60b1.tar.gz", hash = "sha256:9a1063c16c44a3ba6e81870c4fa42a0fac3ecef5a4d60a11d0976eec9046f3d4", size = 16366, upload-time = "2025-12-11T13:37:12.456Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/03/eb26e1c65fd776206b759955d33151ee39ee0e7ac8dd80c97385c321a8d0/opentelemetry_instrumentation_requests-0.62b1.tar.gz", hash = "sha256:67a79c4b67e2192445c1cf03d62126fa623065688d8bd1a9f87f858b0e5f0286", size = 18401, upload-time = "2026-04-24T13:23:02.291Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/7f/969b59a5acccb4c35317421843d63d7853ad7a18078ca3a9b80c248be448/opentelemetry_instrumentation_requests-0.60b1-py3-none-any.whl", hash = "sha256:eec9fac3fab84737f663a2e08b12cb095b4bd67643b24587a8ecfa3cf4d0ca4c", size = 13141, upload-time = "2025-12-11T13:36:23.696Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5a/cddb1f93bd17d6cfc99038a0aaa9af3d6bf455dedfe24d0ba4e13c1d83f7/opentelemetry_instrumentation_requests-0.62b1-py3-none-any.whl", hash = "sha256:ca348f2f51b715c21e86d82106d784f7069ae849c3e636ab37e34dc0ba510b8c", size = 14208, upload-time = "2026-04-24T13:22:13.89Z" },
 ]
 
 [[package]]
@@ -2481,7 +2486,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-sqlalchemy"
-version = "0.60b1"
+version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -2490,23 +2495,23 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/16/6a4cbff1b7cd86d1e58ffd100255f6da781a88f4a2affdcc3721880191c9/opentelemetry_instrumentation_sqlalchemy-0.60b1.tar.gz", hash = "sha256:b614e874a7c0a692838a0da613d1654e81a0612867836a1f0765e40e9c8cc49b", size = 15317, upload-time = "2025-12-11T13:37:13.089Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/53/fa511ab998dd66b4eb66a36d8c262d0604cc5bad7a9c82e923be038dda97/opentelemetry_instrumentation_sqlalchemy-0.62b1.tar.gz", hash = "sha256:bdeac015351a1de057e8ea39f1fe26c9e60ea6bedbf1d5ad6a8262a516b3dc7d", size = 18539, upload-time = "2026-04-24T13:23:03.169Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/b7/2234bc761c197c7f099f30cad5d50efd8286c59b5b8f45cfd6ba6ebe7d5e/opentelemetry_instrumentation_sqlalchemy-0.60b1-py3-none-any.whl", hash = "sha256:486a5f264d264c44e07e0320e33fd19d09cecd2fd4b99c1064046e77a27d9f9f", size = 14529, upload-time = "2025-12-11T13:36:24.964Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c5/aa2abcf8752a435536901636c5d540ba7a2c0ba2c4e98c7d119482e04262/opentelemetry_instrumentation_sqlalchemy-0.62b1-py3-none-any.whl", hash = "sha256:613542ecd52aabeec83d8813b5c287a3fb6c9ac3cd660694c94c0571f066e972", size = 15536, upload-time = "2026-04-24T13:22:14.767Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-threading"
-version = "0.60b1"
+version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/0a/e36123ec4c0910a3936b92982545a53e9bca5b26a28df06883751a783f84/opentelemetry_instrumentation_threading-0.60b1.tar.gz", hash = "sha256:20b18a68abe5801fa9474336b7c27487d4af3e00b66f6a8734e4fdd75c8b0b43", size = 8768, upload-time = "2025-12-11T13:37:16.29Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/2d/2537d5990fa341198cbc8ae70b2c3637037061b8ab1196af1d924a275f55/opentelemetry_instrumentation_threading-0.62b1.tar.gz", hash = "sha256:4b3c876907657e3b8b977bfe15d248f2c02db56302c51883724e7ac2f8ce26d2", size = 9180, upload-time = "2026-04-24T13:23:06.15Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/a3/448738b927bcc1843ace7d4ed55dd54441a71363075eeeee89c5944dd740/opentelemetry_instrumentation_threading-0.60b1-py3-none-any.whl", hash = "sha256:92a52a60fee5e32bc6aa8f5acd749b15691ad0bc4457a310f5736b76a6d9d1de", size = 9312, upload-time = "2025-12-11T13:36:28.434Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/37/a80fb13b76f85b4e433ff44b4ba177615823c36c28dca12e94d2c37de681/opentelemetry_instrumentation_threading-0.62b1-py3-none-any.whl", hash = "sha256:4596e79c47de122eb2e85877c1a8bfed1cd6ab06bd2c29d120ebcf8a708a433a", size = 9335, upload-time = "2026-04-24T13:22:19.419Z" },
 ]
 
 [[package]]
@@ -2580,7 +2585,7 @@ dev = [
 
 [[package]]
 name = "opentelemetry-instrumentation-urllib3"
-version = "0.60b1"
+version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -2589,9 +2594,9 @@ dependencies = [
     { name = "opentelemetry-util-http" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/0c/090ab43417f37b2e2044310de219a8913f4377c75a9f19b2fcaaaeccf0ec/opentelemetry_instrumentation_urllib3-0.60b1.tar.gz", hash = "sha256:1f01cdde3be155ab181fc4cf3363457ff0901f417ac8a102712ee7b7539c9f39", size = 15790, upload-time = "2025-12-11T13:37:19.172Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/e9/6329c1f3c803680e459c72cdabe4ac92f0328c9c225a884f3b32bbf2564f/opentelemetry_instrumentation_urllib3-0.62b1.tar.gz", hash = "sha256:1aff2f16292efd9b11eae5850cfb09ec5f7111ae2fe8c3ac223251ed468f13a1", size = 19337, upload-time = "2026-04-24T13:23:09.055Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/07/d3411ae68983a8e7ca7195dc0fc2333a4f83e75f6943a30e69ede4e5fe48/opentelemetry_instrumentation_urllib3-0.60b1-py3-none-any.whl", hash = "sha256:4f17b5d41b25cc1b318260ca32f5321afc65017e4be533b65cd804c52855fdf7", size = 13187, upload-time = "2025-12-11T13:36:32.265Z" },
+    { url = "https://files.pythonhosted.org/packages/08/28/fb3ffdad060c7995155eb0f1f71c611ad421f1cdf520a6cc5c07250948ab/opentelemetry_instrumentation_urllib3-0.62b1-py3-none-any.whl", hash = "sha256:26ee1760c08628167e3e7e7599314851ee3e4282461d3cd93d26976df35217c6", size = 14340, upload-time = "2026-04-24T13:22:22.987Z" },
 ]
 
 [[package]]
@@ -2788,63 +2793,73 @@ test = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.39.1"
+version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/1d/f25d76d8260c156c40c97c9ed4511ec0f9ce353f8108ca6e7561f82a06b2/opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8", size = 46152, upload-time = "2025-12-11T13:32:48.681Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/e8/633c6d8a9c8840338b105907e55c32d3da1983abab5e52f899f72a82c3d1/opentelemetry_proto-1.41.1.tar.gz", hash = "sha256:4b9d2eb631237ea43b80e16c073af438554e32bc7e9e3f8ca4a9582f900020e5", size = 45670, upload-time = "2026-04-24T13:15:49.768Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/95/b40c96a7b5203005a0b03d8ce8cd212ff23f1793d5ba289c87a097571b18/opentelemetry_proto-1.39.1-py3-none-any.whl", hash = "sha256:22cdc78efd3b3765d09e68bfbd010d4fc254c9818afd0b6b423387d9dee46007", size = 72535, upload-time = "2025-12-11T13:32:33.866Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/1e/5cd77035e3e82070e2265a63a760f715aacd3cb16dddc7efee913f297fcc/opentelemetry_proto-1.41.1-py3-none-any.whl", hash = "sha256:0496713b804d127a4147e32849fbaf5683fac8ee98550e8e7679cd706c289720", size = 72076, upload-time = "2026-04-24T13:15:32.542Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.39.1"
+version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/d0/54ee30dab82fb0acda23d144502771ff76ef8728459c83c3e89ef9fb1825/opentelemetry_sdk-1.41.1.tar.gz", hash = "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6", size = 230180, upload-time = "2026-04-24T13:15:50.991Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/98/e91cf858f203d86f4eccdf763dcf01cf03f1dae80c3750f7e635bfa206b6/opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c", size = 132565, upload-time = "2025-12-11T13:32:35.069Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e7/a1420b698aad018e1cf60fdbaaccbe49021fb415e2a0d81c242f4c518f54/opentelemetry_sdk-1.41.1-py3-none-any.whl", hash = "sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d", size = 180213, upload-time = "2026-04-24T13:15:33.767Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.60b1"
+version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/de/911ac9e309052aca1b20b2d5549d3db45d1011e1a610e552c6ccdd1b64f8/opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802", size = 145750, upload-time = "2026-04-24T13:15:52.236Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a6/83dc2ab6fa397ee66fba04fe2e74bdf7be3b3870005359ceb7689103c058/opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c", size = 231620, upload-time = "2026-04-24T13:15:35.454Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions-ai"
-version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
+version = "0.5.2"
+source = { editable = "../opentelemetry-semantic-conventions-ai" }
 dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "opentelemetry-semantic-conventions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/02/10aeacc37a38a3a8fa16ff67bec1ae3bf882539f6f9efb0f70acf802ca2d/opentelemetry_semantic_conventions_ai-0.5.1.tar.gz", hash = "sha256:153906200d8c1d2f8e09bd78dbef526916023de85ac3dab35912bfafb69ff04c", size = 26533, upload-time = "2026-03-26T14:20:38.73Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/22/41fb05f1dc5fda2c468e05a41814c20859016c85117b66c8a257cae814f6/opentelemetry_semantic_conventions_ai-0.5.1-py3-none-any.whl", hash = "sha256:25aeb22bd261543b4898a73824026d96770e5351209c7d07a0b1314762b1f6e4", size = 11250, upload-time = "2026-03-26T14:20:37.108Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "opentelemetry-sdk", specifier = ">=1.38.0,<2" },
+    { name = "opentelemetry-semantic-conventions", specifier = ">=0.59b0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "autopep8", specifier = ">=2.2.0,<3" },
+    { name = "pytest", specifier = ">=8.2.2,<9" },
+    { name = "pytest-sugar", specifier = "==1.0.0" },
+    { name = "ruff", specifier = ">=0.4.0" },
 ]
 
 [[package]]
 name = "opentelemetry-util-http"
-version = "0.60b1"
+version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/50/fc/c47bb04a1d8a941a4061307e1eddfa331ed4d0ab13d8a9781e6db256940a/opentelemetry_util_http-0.60b1.tar.gz", hash = "sha256:0d97152ca8c8a41ced7172d29d3622a219317f74ae6bb3027cfbdcf22c3cc0d6", size = 11053, upload-time = "2025-12-11T13:37:25.115Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/1b/aa71b63e18d30a8384036b9937f40f7618f8030a7aa213155fb54f6f2b47/opentelemetry_util_http-0.62b1.tar.gz", hash = "sha256:adf6facbb89aef8f8bc566e2f04624942ba08a7b678b3479a91051a8f4dc70a3", size = 11393, upload-time = "2026-04-24T13:23:12.994Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/5c/d3f1733665f7cd582ef0842fb1d2ed0bc1fba10875160593342d22bba375/opentelemetry_util_http-0.60b1-py3-none-any.whl", hash = "sha256:66381ba28550c91bee14dcba8979ace443444af1ed609226634596b4b0faf199", size = 8947, upload-time = "2025-12-11T13:36:37.151Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/85/a9d9d32161c1ced61346267db4c9702da54f81ec5dc88214bc65c23f4e9d/opentelemetry_util_http-0.62b1-py3-none-any.whl", hash = "sha256:c57e8a6c19fc422c288e6074e882f506f85030b69b7376182f74f9257b9261f0", size = 9295, upload-time = "2026-04-24T13:22:28.078Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
 Fixes #3236.
 
 Problem: use_legacy_attributes existed on every instrumentation but was
 unreachable through the SDK — users were locked to legacy gen_ai.prompt/
 gen_ai.completion span attributes with no way to opt into the new
 event-based format.

 Fix: thread use_legacy_attributes=True (default, no behaviour change) from
 Traceloop.init() through TracerWrapper, init_instrumentations(), and all
 8 instrumentations that support the flag: openai, anthropic, bedrock,
 sagemaker, groq, langchain, together, watsonx.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added use_attributes (default: true) to control whether prompt/completion data is emitted as span attributes or as events; this setting now propagates across all instrumentations and the deprecated use_legacy_attributes alias is supported.

* **Bug Fixes**
  * Passing both use_attributes and use_legacy_attributes now raises a TypeError; using use_legacy_attributes emits a DeprecationWarning.

* **Tests**
  * Added initialization tests for defaults, propagation, deprecation warning, and mutual-exclusion error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->