### PR TITLE
feat(together): add finish_reason attribute to spans

### DIFF
--- a/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/span_utils.py
+++ b/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/span_utils.py
@@ -9,6 +9,7 @@ from opentelemetry.semconv_ai import (
 
 
 def _set_span_attribute(span, name, value):
+    """Set an attribute on the span if the value is not None or empty."""
     if value is not None:
         if value != "":
             span.set_attribute(name, value)
@@ -17,6 +18,7 @@ def _set_span_attribute(span, name, value):
 
 @dont_throw
 def set_prompt_attributes(span, llm_request_type, kwargs):
+    """Set prompt content attributes on the span based on the request type."""
     if not span.is_recording():
         return
 
@@ -43,6 +45,7 @@ def set_prompt_attributes(span, llm_request_type, kwargs):
 
 @dont_throw
 def set_model_prompt_attributes(span, kwargs):
+    """Set model and streaming attributes from the request kwargs."""
     if not span.is_recording():
         return
 
@@ -56,6 +59,7 @@ def set_model_prompt_attributes(span, kwargs):
 
 @dont_throw
 def set_completion_attributes(span, llm_request_type, response):
+    """Set completion content attributes on the span from the response."""
     if not span.is_recording():
         return
 
@@ -82,6 +86,7 @@ def set_completion_attributes(span, llm_request_type, response):
 
 @dont_throw
 def set_model_completion_attributes(span, response):
+    """Set model response attributes including token usage and finish reason."""
     if not span.is_recording():
         return
 

--- a/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/span_utils.py
+++ b/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/span_utils.py
@@ -107,3 +107,8 @@ def set_model_completion_attributes(span, response):
         GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS,
         input_tokens,
     )
+    _set_span_attribute(
+        span,
+        SpanAttributes.GEN_AI_RESPONSE_FINISH_REASON,
+        response.choices[0].finish_reason if response.choices else None,
+    )

--- a/packages/opentelemetry-instrumentation-together/tests/test_chat.py
+++ b/packages/opentelemetry-instrumentation-together/tests/test_chat.py
@@ -38,6 +38,7 @@ def test_together_chat_legacy(
         "gen_ai.usage.output_tokens"
     ) + together_span.attributes.get("gen_ai.usage.input_tokens")
     assert together_span.attributes.get("gen_ai.response.id") == "88fa668fac30bb19-MXP"
+    assert together_span.attributes.get("gen_ai.response.finish_reason") == "eos"
 
     logs = log_exporter.get_finished_logs()
     assert (


### PR DESCRIPTION
## What
Adds `gen_ai.response.finish_reason` attribute to Together AI spans.

## Why
Other instrumentations (OpenAI, Anthropic, Groq) already capture this attribute. It's useful for monitoring stop reasons (eos, length, stop) and alerting on unexpected truncations.

## Changes
- Added finish_reason extraction in `span_utils.py`
- Added test assertion in `test_chat.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Telemetry now records the AI response completion reason in observability spans (captures finish reason or null).

* **Tests**
  * Added/updated tests to validate response completion reason attributes in instrumentation tests.

* **Documentation**
  * Improved docstrings for span-attribute helper functions to clarify their behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4136)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->