### PR TITLE
 fix(sdk): warn when both exporter and processor are passed to Traceloop.init()

### DIFF
--- a/packages/traceloop-sdk/tests/conftest.py
+++ b/packages/traceloop-sdk/tests/conftest.py
@@ -64,7 +64,6 @@ def exporter_with_custom_span_processor():
 
     exporter = InMemorySpanExporter()
     Traceloop.init(
-        exporter=exporter,
         processor=CustomSpanProcessor(exporter),
     )
 

--- a/packages/traceloop-sdk/tests/test_sdk_initialization.py
+++ b/packages/traceloop-sdk/tests/test_sdk_initialization.py
@@ -231,19 +231,39 @@ def test_get_default_span_processor():
 
 def test_both_exporter_and_processor_warns():
     """Passing both exporter and processor is a mistake — the processor already wraps
-    the exporter internally. We warn instead of silently dropping the exporter."""
-    if hasattr(TracerWrapper, "instance"):
-        _instance = TracerWrapper.instance
+    the exporter internally. We warn instead of silently dropping the exporter, and
+    verify the standalone exporter receives nothing while the processor's wrapped
+    exporter receives the span."""
+    saved_instance = getattr(TracerWrapper, "instance", None)
+    if saved_instance is not None:
         del TracerWrapper.instance
 
-    exporter = InMemorySpanExporter()
-    processor = SimpleSpanProcessor(exporter)
+    try:
+        standalone_exporter = InMemorySpanExporter()
+        processor_exporter = InMemorySpanExporter()
+        processor = SimpleSpanProcessor(processor_exporter)
 
-    with pytest.warns(UserWarning, match="exporter.*ignored"):
-        Traceloop.init(
-            exporter=exporter,
-            processor=processor,
+        with pytest.warns(UserWarning, match="exporter.*ignored"):
+            Traceloop.init(
+                exporter=standalone_exporter,
+                processor=processor,
+            )
+
+        @workflow(name="probe_workflow")
+        def probe():
+            return "ok"
+
+        probe()
+
+        assert len(standalone_exporter.get_finished_spans()) == 0, (
+            "The standalone exporter must receive no spans — the warning promises it is ignored."
         )
-
-    if "_instance" in dir():
-        TracerWrapper.instance = _instance
+        processor_spans = processor_exporter.get_finished_spans()
+        assert any(span.name == "probe_workflow.workflow" for span in processor_spans), (
+            "The processor's wrapped exporter must receive the emitted span."
+        )
+    finally:
+        if hasattr(TracerWrapper, "instance"):
+            del TracerWrapper.instance
+        if saved_instance is not None:
+            TracerWrapper.instance = saved_instance

--- a/packages/traceloop-sdk/tests/test_sdk_initialization.py
+++ b/packages/traceloop-sdk/tests/test_sdk_initialization.py
@@ -2,7 +2,11 @@ import json
 import pytest
 from unittest.mock import patch
 from openai import OpenAI
+from traceloop.sdk import Traceloop
 from traceloop.sdk.decorators import workflow
+from traceloop.sdk.tracing.tracing import TracerWrapper
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 
 @pytest.fixture
@@ -223,3 +227,23 @@ def test_get_default_span_processor():
     assert isinstance(processor, BatchSpanProcessor)
     assert hasattr(processor, "_traceloop_processor")
     assert getattr(processor, "_traceloop_processor") is True
+
+
+def test_both_exporter_and_processor_warns():
+    """Passing both exporter and processor is a mistake — the processor already wraps
+    the exporter internally. We warn instead of silently dropping the exporter."""
+    if hasattr(TracerWrapper, "instance"):
+        _instance = TracerWrapper.instance
+        del TracerWrapper.instance
+
+    exporter = InMemorySpanExporter()
+    processor = SimpleSpanProcessor(exporter)
+
+    with pytest.warns(UserWarning, match="exporter.*ignored"):
+        Traceloop.init(
+            exporter=exporter,
+            processor=processor,
+        )
+
+    if "_instance" in dir():
+        TracerWrapper.instance = _instance

--- a/packages/traceloop-sdk/traceloop/sdk/__init__.py
+++ b/packages/traceloop-sdk/traceloop/sdk/__init__.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import warnings
 from pathlib import Path
 
 from typing import Callable, List, Optional, Set, Union
@@ -89,6 +90,14 @@ class Traceloop:
             return
 
         enable_content_tracing = is_content_tracing_enabled()
+
+        if exporter and processor:
+            warnings.warn(
+                "Both 'exporter' and 'processor' were provided to Traceloop.init(). "
+                "The 'exporter' will be ignored — your processor should already wrap the exporter.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         if exporter or processor:
             print(Fore.GREEN + "Traceloop exporting traces to a custom exporter")

--- a/packages/traceloop-sdk/traceloop/sdk/__init__.py
+++ b/packages/traceloop-sdk/traceloop/sdk/__init__.py
@@ -94,7 +94,8 @@ class Traceloop:
         if exporter and processor:
             warnings.warn(
                 "Both 'exporter' and 'processor' were provided to Traceloop.init(). "
-                "The 'exporter' will be ignored — your processor should already wrap the exporter.",
+                "The 'exporter' will be ignored — your processor should already wrap the exporter. "
+                "Wrap your exporter inside the processor, e.g.: SimpleSpanProcessor(my_exporter).",
                 UserWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
Fixes #3046.
Problem: passing both exporter and processor is a mistake — the processor already wraps the exporter
internally. The exporter was silently ignored with no feedback to the user.

Fix: emit a UserWarning pointing at the caller's line. Also removes the redundant
exporter= from the exporter_with_custom_span_processor test fixture which had the same bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Traceloop.init now emits a UserWarning when both an exporter and a processor are supplied, clarifying the exporter will be ignored and advising wrapping the exporter with a processor instead.

* **Tests**
  * Added a test confirming the warning is raised and that span export behavior follows the processor-wrapped exporter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->