### PR TITLE
feat(together): add streaming and async support with error handling

### DIFF
--- a/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/__init__.py
+++ b/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/__init__.py
@@ -89,6 +89,7 @@ def _with_tracer_wrapper(func):
 
 
 def _llm_request_type_by_method(method_name):
+    """Determine the LLM request type based on the wrapped method name."""
     if "chat.completions" in method_name:
         return LLMRequestTypeValues.CHAT
     elif "completions" in method_name:
@@ -99,6 +100,7 @@ def _llm_request_type_by_method(method_name):
 
 @dont_throw
 def _handle_input(span, event_logger, llm_request_type, kwargs):
+    """Set input/prompt attributes on the span and emit prompt events if configured."""
     set_model_prompt_attributes(span, kwargs)
 
     if should_emit_events() and event_logger:
@@ -109,6 +111,7 @@ def _handle_input(span, event_logger, llm_request_type, kwargs):
 
 @dont_throw
 def _handle_response(span, event_logger, llm_request_type, response):
+    """Set completion/response attributes on the span and emit completion events if configured."""
     if should_emit_events() and event_logger:
         emit_completion_event(event_logger, llm_request_type, response)
     else:
@@ -329,9 +332,11 @@ class TogetherAiInstrumentor(BaseInstrumentor):
         Config.use_legacy_attributes = use_legacy_attributes
 
     def instrumentation_dependencies(self) -> Collection[str]:
+        """Return the list of instrumented packages and their version constraints."""
         return _instruments
 
     def _instrument(self, **kwargs):
+        """Enable instrumentation by wrapping Together AI client methods."""
         tracer_provider = kwargs.get("tracer_provider")
         tracer = get_tracer(__name__, __version__, tracer_provider)
 
@@ -364,6 +369,7 @@ class TogetherAiInstrumentor(BaseInstrumentor):
                 pass  # async methods may not be available in all versions
 
     def _uninstrument(self, **kwargs):
+        """Disable instrumentation by unwrapping Together AI client methods."""
         for wrapped_method in WRAPPED_METHODS:
             wrap_object = wrapped_method.get("object")
             unwrap(

--- a/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/__init__.py
+++ b/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/__init__.py
@@ -52,6 +52,29 @@ WRAPPED_METHODS = [
     },
 ]
 
+WRAPPED_AMETHODS = [
+    {
+        "object": "resources",
+        "method": "chat.completions.AsyncChatCompletions.create",
+        "span_name": "together.chat",
+    },
+    {
+        "object": "resources",
+        "method": "completions.AsyncCompletions.create",
+        "span_name": "together.completion",
+    },
+]
+
+
+def _is_streaming_response(response):
+    """Check if the response is a streaming iterator."""
+    return hasattr(response, "__iter__") and not hasattr(response, "choices")
+
+
+def _is_async_streaming_response(response):
+    """Check if the response is an async streaming iterator."""
+    return hasattr(response, "__aiter__")
+
 
 def _with_tracer_wrapper(func):
     """Helper for providing tracer for wrapper functions."""
@@ -66,9 +89,9 @@ def _with_tracer_wrapper(func):
 
 
 def _llm_request_type_by_method(method_name):
-    if method_name == "chat.completions.ChatCompletions.create":
+    if "chat.completions" in method_name:
         return LLMRequestTypeValues.CHAT
-    elif method_name == "completions.Completions.create":
+    elif "completions" in method_name:
         return LLMRequestTypeValues.COMPLETION
     else:
         return LLMRequestTypeValues.UNKNOWN
@@ -92,6 +115,109 @@ def _handle_response(span, event_logger, llm_request_type, response):
         set_completion_attributes(span, llm_request_type, response)
 
     set_model_completion_attributes(span, response)
+
+
+def _process_streaming_chunk(chunk):
+    """Extract content and finish_reason from a streaming chunk."""
+    content = ""
+    finish_reason = None
+
+    if hasattr(chunk, "choices") and chunk.choices:
+        for choice in chunk.choices:
+            if hasattr(choice, "delta") and choice.delta:
+                delta_content = getattr(choice.delta, "content", None)
+                if delta_content:
+                    content += delta_content
+            if choice.finish_reason:
+                finish_reason = str(choice.finish_reason.value) if hasattr(
+                    choice.finish_reason, "value"
+                ) else str(choice.finish_reason)
+
+    return content, finish_reason
+
+
+def _build_accumulated_response(chunk, accumulated_content, finish_reason):
+    """Build a response-like object from accumulated streaming data for attribute setting."""
+
+    class _AccumulatedChoice:
+        def __init__(self, content, finish_reason):
+            self.message = type("obj", (object,), {"content": content, "role": "assistant"})()
+            self.finish_reason = finish_reason
+
+    class _AccumulatedResponse:
+        def __init__(self, chunk, content, finish_reason):
+            self.model = getattr(chunk, "model", None)
+            self.id = getattr(chunk, "id", None)
+            self.choices = [_AccumulatedChoice(content, finish_reason)]
+            self.usage = getattr(chunk, "usage", None)
+
+    return _AccumulatedResponse(chunk, accumulated_content, finish_reason)
+
+
+def _create_stream_processor(response, span, event_logger, llm_request_type):
+    """Create a generator that processes a stream while collecting telemetry."""
+    accumulated_content = ""
+    finish_reason = None
+    last_chunk = None
+
+    try:
+        for chunk in response:
+            last_chunk = chunk
+            content, chunk_finish_reason = _process_streaming_chunk(chunk)
+            if content:
+                accumulated_content += content
+            if chunk_finish_reason:
+                finish_reason = chunk_finish_reason
+            yield chunk
+    except Exception as e:
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        span.record_exception(e)
+        span.end()
+        raise
+
+    # Build accumulated response and set attributes
+    if last_chunk:
+        accumulated_response = _build_accumulated_response(
+            last_chunk, accumulated_content, finish_reason
+        )
+        _handle_response(span, event_logger, llm_request_type, accumulated_response)
+
+    if span.is_recording():
+        span.set_status(Status(StatusCode.OK))
+    span.end()
+
+
+async def _create_async_stream_processor(response, span, event_logger, llm_request_type):
+    """Create an async generator that processes a stream while collecting telemetry."""
+    accumulated_content = ""
+    finish_reason = None
+    last_chunk = None
+
+    try:
+        async for chunk in response:
+            last_chunk = chunk
+            content, chunk_finish_reason = _process_streaming_chunk(chunk)
+            if content:
+                accumulated_content += content
+            if chunk_finish_reason:
+                finish_reason = chunk_finish_reason
+            yield chunk
+    except Exception as e:
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        span.record_exception(e)
+        span.end()
+        raise
+
+    # Build accumulated response and set attributes
+    if last_chunk:
+        accumulated_response = _build_accumulated_response(
+            last_chunk, accumulated_content, finish_reason
+        )
+        _handle_response(span, event_logger, llm_request_type, accumulated_response)
+
+    if span.is_recording():
+        span.set_status(Status(StatusCode.OK))
+    span.end()
 
 
 @_with_tracer_wrapper
@@ -122,9 +248,70 @@ def _wrap(
     )
     _handle_input(span, event_logger, llm_request_type, kwargs)
 
-    response = wrapped(*args, **kwargs)
+    try:
+        response = wrapped(*args, **kwargs)
+    except Exception as e:
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        span.record_exception(e)
+        span.end()
+        raise
 
     if response:
+        if kwargs.get("stream", False) and _is_streaming_response(response):
+            return _create_stream_processor(
+                response, span, event_logger, llm_request_type
+            )
+
+        _handle_response(span, event_logger, llm_request_type, response)
+        if span.is_recording():
+            span.set_status(Status(StatusCode.OK))
+
+    span.end()
+    return response
+
+
+@_with_tracer_wrapper
+async def _awrap(
+    tracer,
+    event_logger,
+    to_wrap,
+    wrapped,
+    instance,
+    args,
+    kwargs,
+):
+    """Instruments and calls every async function defined in TO_WRAP."""
+    if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY) or context_api.get_value(
+        SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION_KEY
+    ):
+        return await wrapped(*args, **kwargs)
+
+    name = to_wrap.get("span_name")
+    llm_request_type = _llm_request_type_by_method(to_wrap.get("method"))
+    span = tracer.start_span(
+        name,
+        kind=SpanKind.CLIENT,
+        attributes={
+            GenAIAttributes.GEN_AI_SYSTEM: "TogetherAI",
+            SpanAttributes.LLM_REQUEST_TYPE: llm_request_type.value,
+        },
+    )
+    _handle_input(span, event_logger, llm_request_type, kwargs)
+
+    try:
+        response = await wrapped(*args, **kwargs)
+    except Exception as e:
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        span.record_exception(e)
+        span.end()
+        raise
+
+    if response:
+        if kwargs.get("stream", False) and _is_async_streaming_response(response):
+            return _create_async_stream_processor(
+                response, span, event_logger, llm_request_type
+            )
+
         _handle_response(span, event_logger, llm_request_type, response)
         if span.is_recording():
             span.set_status(Status(StatusCode.OK))
@@ -164,6 +351,18 @@ class TogetherAiInstrumentor(BaseInstrumentor):
                 _wrap(tracer, event_logger, wrapped_method),
             )
 
+        for wrapped_method in WRAPPED_AMETHODS:
+            wrap_object = wrapped_method.get("object")
+            wrap_method = wrapped_method.get("method")
+            try:
+                wrap_function_wrapper(
+                    "together",
+                    f"{wrap_object}.{wrap_method}",
+                    _awrap(tracer, event_logger, wrapped_method),
+                )
+            except (ModuleNotFoundError, AttributeError):
+                pass  # async methods may not be available in all versions
+
     def _uninstrument(self, **kwargs):
         for wrapped_method in WRAPPED_METHODS:
             wrap_object = wrapped_method.get("object")
@@ -171,3 +370,12 @@ class TogetherAiInstrumentor(BaseInstrumentor):
                 f"together.{wrap_object}",
                 wrapped_method.get("method"),
             )
+        for wrapped_method in WRAPPED_AMETHODS:
+            wrap_object = wrapped_method.get("object")
+            try:
+                unwrap(
+                    f"together.{wrap_object}",
+                    wrapped_method.get("method"),
+                )
+            except (ModuleNotFoundError, AttributeError):
+                pass

--- a/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/__init__.py
+++ b/packages/opentelemetry-instrumentation-together/opentelemetry/instrumentation/together/__init__.py
@@ -366,7 +366,10 @@ class TogetherAiInstrumentor(BaseInstrumentor):
                     _awrap(tracer, event_logger, wrapped_method),
                 )
             except (ModuleNotFoundError, AttributeError):
-                pass  # async methods may not be available in all versions
+                logger.debug(
+                    "Could not wrap async method %s — async instrumentation disabled",
+                    wrap_method,
+                )
 
     def _uninstrument(self, **kwargs):
         """Disable instrumentation by unwrapping Together AI client methods."""
@@ -384,4 +387,7 @@ class TogetherAiInstrumentor(BaseInstrumentor):
                     wrapped_method.get("method"),
                 )
             except (ModuleNotFoundError, AttributeError):
-                pass
+                logger.debug(
+                    "Could not unwrap async method %s",
+                    wrapped_method.get("method"),
+                )


### PR DESCRIPTION
## What

Adds streaming support, async method instrumentation, and proper error handling to the Together AI instrumentation package.

## Why

The Together AI instrumentation was the only LLM provider package that:
- Had **no streaming support** — when `stream=True` is passed, telemetry was lost
- Had **no async support** — `AsyncChatCompletions.create` and `AsyncCompletions.create` were not instrumented
- Had **no error handling** — if the API call raised an exception, the span leaked without recording the error (related to #412)

Every other major instrumentation (OpenAI, Anthropic, Groq, Ollama, Mistral) handles all three. This PR brings Together AI to parity.

## Changes

### Streaming Support
- Added `_create_stream_processor()` — a generator that wraps the streaming response, accumulates content across chunks, and records the full response as span attributes when the stream ends
- Added `_create_async_stream_processor()` — async version of the above
- Detects streaming via `kwargs.get('stream', False)` and response type checking

### Async Support
- Added `WRAPPED_AMETHODS` list targeting `AsyncChatCompletions.create` and `AsyncCompletions.create`
- Added `_awrap()` async wrapper function following the same pattern as the sync wrapper
- Properly handles `await` and async streaming responses

### Error Handling
- Both `_wrap()` and `_awrap()` now catch exceptions from the API call
- On error: sets `StatusCode.ERROR`, calls `span.record_exception(e)`, and ends the span before re-raising
- Streaming processors also catch errors mid-stream and properly close spans

## Testing

- All 6 existing tests pass ✅
- Lint passes ✅
- Backward compatible — no changes to existing behavior for non-streaming, sync calls

## Related

- Partially addresses #412 (errors not logged) for the Together package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for async client methods and async streaming responses in Together AI instrumentation.

* **Improvements**
  * Streaming telemetry now accumulates streamed chunks and final finish reason for richer completion attributes.
  * Centralized span lifecycle with explicit status setting and exception recording for clearer traces.
  * Request-type inference improved via method-name substring matching.
  * Instrumentation/uninstrumentation made more resilient to missing async APIs across versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4138)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->