### PR TITLE
fix(openai-agents): record cached input tokens and reasoning tokens

### DIFF
--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
@@ -586,6 +586,28 @@ def _extract_response_attributes(otel_span, response, trace_content: bool):
                 SpanAttributes.GEN_AI_USAGE_TOTAL_TOKENS, usage.total_tokens
             )
 
+        # Cached input tokens (matches opentelemetry-instrumentation-openai behavior;
+        # the OpenAI Agents SDK Usage object carries this via input_tokens_details.cached_tokens).
+        input_details = getattr(usage, "input_tokens_details", None)
+        if input_details is not None:
+            cached_tokens = getattr(input_details, "cached_tokens", None)
+            if cached_tokens is not None:
+                otel_span.set_attribute(
+                    SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+                    cached_tokens,
+                )
+
+        # Reasoning tokens (for reasoning models like o1/o3) via
+        # output_tokens_details.reasoning_tokens.
+        output_details = getattr(usage, "output_tokens_details", None)
+        if output_details is not None:
+            reasoning_tokens = getattr(output_details, "reasoning_tokens", None)
+            if reasoning_tokens is not None:
+                otel_span.set_attribute(
+                    SpanAttributes.GEN_AI_USAGE_REASONING_TOKENS,
+                    reasoning_tokens,
+                )
+
     return model_settings
 
 

--- a/packages/opentelemetry-instrumentation-openai-agents/tests/test_semconv_messages.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/tests/test_semconv_messages.py
@@ -3633,3 +3633,86 @@ class TestToolCallNameAlwaysPresent:
         assert part["name"] == "get_weather"
         span.end()
         span.end()
+
+
+# ---------------------------------------------------------------------------
+# Cached input tokens and reasoning tokens (issue #4060)
+# ---------------------------------------------------------------------------
+
+class TestUsageTokenDetails:
+    """Verify that nested usage details (cached input tokens, reasoning tokens)
+    on the OpenAI Agents SDK Usage object are propagated to span attributes,
+    matching the behavior of opentelemetry-instrumentation-openai."""
+
+    def test_cache_read_input_tokens_recorded_when_present(self, tracer_and_exporter):
+        """If usage.input_tokens_details.cached_tokens > 0, the span must record
+        gen_ai.usage.cache_read_input_tokens."""
+        from opentelemetry.instrumentation.openai_agents._hooks import (
+            _extract_response_attributes,
+        )
+        from opentelemetry.semconv_ai import SpanAttributes
+        from types import SimpleNamespace
+
+        tracer, _ = tracer_and_exporter
+        span = tracer.start_span("test")
+
+        usage = MockUsage(input_tokens=100, output_tokens=20, total_tokens=120)
+        usage.input_tokens_details = SimpleNamespace(cached_tokens=80)
+        response = MockResponse(output=[], model="gpt-4o", usage=usage)
+
+        _extract_response_attributes(span, response, trace_content=True)
+
+        assert (
+            span.attributes.get(SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS)
+            == 80
+        )
+        span.end()
+
+    def test_reasoning_tokens_recorded_when_present(self, tracer_and_exporter):
+        """If usage.output_tokens_details.reasoning_tokens is set (reasoning models),
+        the span must record gen_ai.usage.reasoning_tokens."""
+        from opentelemetry.instrumentation.openai_agents._hooks import (
+            _extract_response_attributes,
+        )
+        from opentelemetry.semconv_ai import SpanAttributes
+        from types import SimpleNamespace
+
+        tracer, _ = tracer_and_exporter
+        span = tracer.start_span("test")
+
+        usage = MockUsage(input_tokens=50, output_tokens=200, total_tokens=250)
+        usage.output_tokens_details = SimpleNamespace(reasoning_tokens=150)
+        response = MockResponse(output=[], model="o1", usage=usage)
+
+        _extract_response_attributes(span, response, trace_content=True)
+
+        assert (
+            span.attributes.get(SpanAttributes.GEN_AI_USAGE_REASONING_TOKENS) == 150
+        )
+        span.end()
+
+    def test_cache_and_reasoning_absent_when_details_missing(self, tracer_and_exporter):
+        """Sanity: when input_tokens_details / output_tokens_details are absent,
+        no cache_read_input_tokens or reasoning_tokens attribute is emitted."""
+        from opentelemetry.instrumentation.openai_agents._hooks import (
+            _extract_response_attributes,
+        )
+        from opentelemetry.semconv_ai import SpanAttributes
+
+        tracer, _ = tracer_and_exporter
+        span = tracer.start_span("test")
+
+        response = MockResponse(
+            output=[], model="gpt-4o", usage=MockUsage()
+        )
+
+        _extract_response_attributes(span, response, trace_content=True)
+
+        assert (
+            span.attributes.get(SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS)
+            is None
+        )
+        assert (
+            span.attributes.get(SpanAttributes.GEN_AI_USAGE_REASONING_TOKENS) is None
+        )
+        span.end()


### PR DESCRIPTION
# Record cached input tokens and reasoning tokens for openai-agents instrumentation

## Summary

Fixes #4060.

The `opentelemetry-instrumentation-openai-agents` package was recording `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens` on LLM spans, but never recording cached input tokens, even though the OpenAI Agents SDK `Usage` object carries this information via `usage.input_tokens_details.cached_tokens`. The raw-OpenAI instrumentor (`opentelemetry-instrumentation-openai`) already records `gen_ai.usage.cache_read_input_tokens` correctly, so anyone using the Agents SDK instrumentor alone (to avoid double-instrumentation artifacts) had no cache visibility, distorting visible cost by >10x for high-cache workloads.

This PR adds:

1. `gen_ai.usage.cache_read_input_tokens` recording from `usage.input_tokens_details.cached_tokens`.
2. `gen_ai.usage.reasoning_tokens` recording from `usage.output_tokens_details.reasoning_tokens` (for reasoning models like o1/o3).

Both behaviors match what the raw-OpenAI instrumentor already does in `responses_wrappers.py`.

## Changes

**`packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py`**
Added two blocks in `_extract_response_attributes`, immediately after the existing `total_tokens` recording. Both use defensive `getattr` access in case the SDK omits the details object or its nested fields.

**`packages/opentelemetry-instrumentation-openai-agents/tests/test_semconv_messages.py`**
Added a `TestUsageTokenDetails` class with three tests:

- `test_cache_read_input_tokens_recorded_when_present` — verifies cache attribute is set when `cached_tokens` is populated.
- `test_reasoning_tokens_recorded_when_present` — verifies reasoning attribute is set for reasoning-model responses.
- `test_cache_and_reasoning_absent_when_details_missing` — sanity check that no attribute is emitted when the details objects are absent (no false positives on older SDK responses).

## Test results

```
tests/test_semconv_messages.py::TestUsageTokenDetails::test_cache_read_input_tokens_recorded_when_present PASSED
tests/test_semconv_messages.py::TestUsageTokenDetails::test_reasoning_tokens_recorded_when_present PASSED
tests/test_semconv_messages.py::TestUsageTokenDetails::test_cache_and_reasoning_absent_when_details_missing PASSED
```

Full unit-test suite (`tests/test_semconv_messages.py`, `test_semconv_compliance.py`, `test_content_parts.py`, `test_finish_reasons.py`, `test_tracing_processor.py`): **329 passed, 0 failures.**

Integration tests that hit the OpenAI API (`test_openai_agents.py`, etc.) were not run in my environment because they require API credentials and VCR cassettes; my changes do not touch any code paths exercised only by those tests.

## Notes

- The OTel semconv constants `SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS` and `SpanAttributes.GEN_AI_USAGE_REASONING_TOKENS` were already imported in `_hooks.py` (via `from opentelemetry.semconv_ai import SpanAttributes`), so no new imports were required.
- Existing VCR cassettes for this package already contain `usage.input_tokens_details.cached_tokens` and `usage.output_tokens_details.reasoning_tokens` in the recorded responses, so once the integration tests are re-run by CI they should exercise the new code paths naturally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced OpenAI usage tracking now captures additional token metrics including cached input tokens and reasoning tokens for improved observability and monitoring.

* **Tests**
  * Added comprehensive test coverage to validate proper capture and reporting of cached input token and reasoning token metrics, including cases when metrics are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->