### PR TITLE
fix(openai-agents): emit gen_ai.* attributes for GenerationSpanData (issue #4157)

### DIFF
--- a/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/opentelemetry/instrumentation/openai_agents/_hooks.py
@@ -383,6 +383,69 @@ def _extract_prompt_attributes(otel_span, input_data, trace_content: bool):
         )
 
 
+def _extract_generation_span_data_attributes(otel_span, span_data, trace_content: bool):
+    """Extract OTel gen_ai.* attributes from a GenerationSpanData object.
+
+    GenerationSpanData (used by LiteLLM and other providers that do not go through
+    the OpenAI Responses API) exposes ``model``, ``model_config``, ``output``, and
+    ``usage`` *directly* on the span_data object rather than via a nested
+    ``response`` attribute.  This function maps those fields to the same OTel
+    attributes that :func:`_extract_response_attributes` populates for
+    ResponseSpanData, fixing the silent data loss reported in issue #4157.
+    """
+    # Response model name
+    model = getattr(span_data, "model", None)
+    if model:
+        otel_span.set_attribute(GenAIAttributes.GEN_AI_RESPONSE_MODEL, model)
+
+    # Model config: temperature, top_p, max_tokens (stored as a plain dict)
+    model_config = getattr(span_data, "model_config", None) or {}
+    if isinstance(model_config, dict):
+        temperature = model_config.get("temperature")
+        if temperature is not None:
+            otel_span.set_attribute(GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE, temperature)
+        top_p = model_config.get("top_p")
+        if top_p is not None:
+            otel_span.set_attribute(GenAIAttributes.GEN_AI_REQUEST_TOP_P, top_p)
+        max_tokens = model_config.get("max_tokens") or model_config.get("max_output_tokens")
+        if max_tokens is not None:
+            otel_span.set_attribute(GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS, max_tokens)
+
+    # Output messages (each item is typically a dict with ``role`` and ``content``)
+    output = getattr(span_data, "output", None)
+    if output and trace_content:
+        output_messages = []
+        for item in output:
+            if isinstance(item, dict):
+                role = item.get("role", "assistant")
+                content = item.get("content", "")
+            else:
+                role = getattr(item, "role", "assistant")
+                content = getattr(item, "content", "")
+            if content is not None:
+                output_messages.append({
+                    "role": role,
+                    "parts": [{"type": "text", "content": str(content) if not isinstance(content, str) else content}],
+                })
+        if output_messages:
+            otel_span.set_attribute(
+                GenAIAttributes.GEN_AI_OUTPUT_MESSAGES, json.dumps(output_messages)
+            )
+
+    # Usage (stored as a plain dict with snake_case keys)
+    usage = getattr(span_data, "usage", None) or {}
+    if isinstance(usage, dict):
+        input_tokens = usage.get("input_tokens") or usage.get("prompt_tokens")
+        if input_tokens is not None:
+            otel_span.set_attribute(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS, input_tokens)
+        output_tokens = usage.get("output_tokens") or usage.get("completion_tokens")
+        if output_tokens is not None:
+            otel_span.set_attribute(GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS, output_tokens)
+        total_tokens = usage.get("total_tokens")
+        if total_tokens is not None:
+            otel_span.set_attribute(SpanAttributes.GEN_AI_USAGE_TOTAL_TOKENS, total_tokens)
+
+
 def _extract_response_attributes(otel_span, response, trace_content: bool):
     """
     Extract model settings, completions, and usage from a response object
@@ -975,6 +1038,14 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
 
         if response:
             _extract_response_attributes(otel_span, response, trace_content)
+        elif getattr(span_data, "output", None) is not None or getattr(span_data, "usage", None) is not None:
+            # GenerationSpanData (e.g. produced by LiteLLM and other non-OpenAI
+            # providers) does NOT have a ``response`` attribute.  Instead it exposes
+            # ``model``, ``model_config``, ``output``, and ``usage`` directly on the
+            # span_data object.  Without this branch those fields are silently ignored
+            # and *all* gen_ai.response.* / gen_ai.usage.* OTel attributes are missing.
+            # See https://github.com/traceloop/openllmetry/issues/4157
+            _extract_generation_span_data_attributes(otel_span, span_data, trace_content)
 
     def _end_function_span(self, otel_span, span_data, trace_content):
         """Handle on_span_end logic for function/tool spans.

--- a/packages/opentelemetry-instrumentation-openai-agents/tests/test_tracing_processor.py
+++ b/packages/opentelemetry-instrumentation-openai-agents/tests/test_tracing_processor.py
@@ -975,6 +975,93 @@ class TestEndGenerationSpan:
 
         otel_span.end()
 
+    # ------------------------------------------------------------------
+    # GenerationSpanData (no .response attribute) – issue #4157
+    # ------------------------------------------------------------------
+
+    def test_generation_span_data_usage_attributes(self, tracer_and_exporter, processor):
+        """GenerationSpanData without a .response attr must still emit usage tokens.
+
+        Regression test for https://github.com/traceloop/openllmetry/issues/4157 –
+        _end_generation_span was looking for span_data.response (which does not exist
+        on GenerationSpanData) and therefore never called _extract_response_attributes,
+        silently dropping all gen_ai.usage.* and gen_ai.response.* OTel attributes.
+        """
+        from types import SimpleNamespace
+
+        tracer, _ = tracer_and_exporter
+        otel_span = tracer.start_span("test-gen-data")
+
+        span_data = SimpleNamespace(
+            input=[{"role": "user", "content": "Hello"}],
+            output=[{"role": "assistant", "content": "Hi there"}],
+            model="gpt-4o-mini",
+            model_config={"temperature": 0.7, "top_p": 1.0, "max_tokens": 256},
+            usage={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+            # Deliberately no .response attribute – matches GenerationSpanData
+        )
+
+        processor._end_generation_span(otel_span, span_data, trace_content=True)
+
+        assert otel_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_MODEL) == "gpt-4o-mini"
+        assert otel_span.attributes.get(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS) == 10
+        assert otel_span.attributes.get(GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS) == 5
+        assert otel_span.attributes.get(GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE) == 0.7
+        assert otel_span.attributes.get(GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS) == 256
+
+        otel_span.end()
+
+    def test_generation_span_data_output_messages(self, tracer_and_exporter, processor):
+        """GenerationSpanData output messages are emitted when trace_content=True."""
+        from types import SimpleNamespace
+
+        tracer, _ = tracer_and_exporter
+        otel_span = tracer.start_span("test-gen-data-output")
+
+        span_data = SimpleNamespace(
+            input=[],
+            output=[{"role": "assistant", "content": "The answer is 42."}],
+            model="gpt-4o",
+            model_config={},
+            usage={"input_tokens": 3, "output_tokens": 7},
+        )
+
+        processor._end_generation_span(otel_span, span_data, trace_content=True)
+
+        raw = otel_span.attributes.get(GenAIAttributes.GEN_AI_OUTPUT_MESSAGES)
+        assert raw is not None, "gen_ai.output.messages must be set for GenerationSpanData"
+        messages = json.loads(raw)
+        assert messages[0]["role"] == "assistant"
+        assert messages[0]["parts"][0]["content"] == "The answer is 42."
+
+        otel_span.end()
+
+    def test_generation_span_data_output_suppressed_when_content_gated(
+        self, tracer_and_exporter, processor
+    ):
+        """GenerationSpanData output messages are NOT emitted when trace_content=False."""
+        from types import SimpleNamespace
+
+        tracer, _ = tracer_and_exporter
+        otel_span = tracer.start_span("test-gen-data-no-content")
+
+        span_data = SimpleNamespace(
+            input=[],
+            output=[{"role": "assistant", "content": "The answer is 42."}],
+            model="gpt-4o",
+            model_config={},
+            usage={"input_tokens": 3, "output_tokens": 7},
+        )
+
+        processor._end_generation_span(otel_span, span_data, trace_content=False)
+
+        # Usage/model are NOT content-gated – they must still be set
+        assert otel_span.attributes.get(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS) == 3
+        # Output messages ARE content-gated – they must be absent
+        assert GenAIAttributes.GEN_AI_OUTPUT_MESSAGES not in otel_span.attributes
+
+        otel_span.end()
+
 
 # ---------------------------------------------------------------------------
 # Tests: _set_realtime_io_attributes


### PR DESCRIPTION
## Problem

`_end_generation_span` in `_hooks.py` always looked for `span_data.response` to populate OTel output/usage attributes:

```python
response = getattr(span_data, "response", None)   # line 960
...
if response:                                        # line 976
    _extract_response_attributes(otel_span, response, trace_content)
```

`GenerationSpanData` (the span type produced by LiteLLM and any other provider that does not go through the OpenAI Responses API) has **no `response` attribute**. Its fields are `input`, `output`, `model`, `model_config`, and `usage` — directly on the object. So `response` was always `None`, the `if response:` guard never fired, and **every `gen_ai.response.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, and `gen_ai.output.messages` attribute was silently dropped** for those spans.

Reported in issue #4157.

## Fix

Add a new `_extract_generation_span_data_attributes` helper that handles the `GenerationSpanData` shape: reads `model`, `model_config` (temperature, top_p, max_tokens), `output` (list of message dicts), and `usage` (dict of token counts) directly from `span_data`, then maps them to the same OTel attributes that `_extract_response_attributes` sets for `ResponseSpanData`.

`_end_generation_span` falls through to the new helper when `span_data` has no `response` attribute but does expose `output` or `usage` (i.e. when it is a `GenerationSpanData`).

## Tests

Three new tests in `TestEndGenerationSpan`:

| Test | Verifies |
|---|---|
| `test_generation_span_data_usage_attributes` | model, usage tokens, temperature, max_tokens are all set |
| `test_generation_span_data_output_messages` | output messages serialised when `trace_content=True` |
| `test_generation_span_data_output_suppressed_when_content_gated` | messages absent but usage still set when `trace_content=False` |

All 13 `TestEndGenerationSpan` tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced compatibility with non-OpenAI providers by ensuring model settings, token usage, and output messages are properly captured in telemetry traces.

* **Tests**
  * Added test coverage for generation span data handling with configurable message serialization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->