### PR TITLE
fix(mcp): prevent exception swallowing and handle non-iterable result types in mcp stream wrappers

### DIFF
--- a/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
+++ b/packages/opentelemetry-instrumentation-mcp/opentelemetry/instrumentation/mcp/instrumentation.py
@@ -502,37 +502,36 @@ class InstrumentedStreamReader(ObjectProxy):  # type: ignore
     async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> Any:
         return await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
 
-    @dont_throw
     async def __aiter__(self) -> AsyncGenerator[Any, None]:
         from mcp.types import JSONRPCMessage, JSONRPCRequest
 
         async for item in self.__wrapped__:
-            # Handle different item types based on what's available
-            request = None
-            if hasattr(item, "message") and hasattr(item.message, "root"):
-                request = item.message.root
-            elif type(item) is JSONRPCMessage:
-                request = cast(JSONRPCMessage, item).root
-            elif hasattr(item, "root"):
-                request = item.root
-            else:
-                yield item
-                continue
+            try:
+                # Handle different item types based on what's available
+                request = None
+                if hasattr(item, "message") and hasattr(item.message, "root"):
+                    request = item.message.root
+                elif type(item) is JSONRPCMessage:
+                    request = cast(JSONRPCMessage, item).root
+                elif hasattr(item, "root"):
+                    request = item.root
 
-            if not isinstance(request, JSONRPCRequest):
-                yield item
-                continue
+                if request and isinstance(request, JSONRPCRequest):
+                    if request.params and isinstance(request.params, dict):
+                        meta = request.params.get("_meta")
+                        if meta:
+                            ctx = propagate.extract(meta)
+                            restore = context.attach(ctx)
+                            try:
+                                yield item
+                                continue
+                            finally:
+                                context.detach(restore)
+            except Exception as e:
+                logging.warning(
+                    f"mcp instrumentation InstrumentedStreamReader telemetry exception: {e}"
+                )
 
-            if request.params:
-                meta = request.params.get("_meta")
-                if meta:
-                    ctx = propagate.extract(meta)
-                    restore = context.attach(ctx)
-                    try:
-                        yield item
-                        continue
-                    finally:
-                        context.detach(restore)
             yield item
 
 
@@ -548,7 +547,6 @@ class InstrumentedStreamWriter(ObjectProxy):  # type: ignore
     async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> Any:
         return await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
 
-    @dont_throw
     async def send(self, item: Any) -> Any:
         from mcp.types import JSONRPCMessage, JSONRPCRequest
 
@@ -563,31 +561,66 @@ class InstrumentedStreamWriter(ObjectProxy):  # type: ignore
         else:
             return await self.__wrapped__.send(item)
 
-        with self._tracer.start_as_current_span("ResponseStreamWriter") as span:
-            if hasattr(request, "result"):
-                span.set_attribute(
-                    SpanAttributes.MCP_RESPONSE_VALUE, f"{serialize(request.result)}"
-                )
-                if "isError" in request.result:
-                    if request.result["isError"] is True:
-                        span.set_status(
-                            Status(
-                                StatusCode.ERROR,
-                                f"{request.result['content'][0]['text']}",
-                            )
-                        )
-            if hasattr(request, "id"):
-                span.set_attribute(SpanAttributes.MCP_REQUEST_ID, f"{request.id}")
+        item_to_send = item
+        try:
+            with self._tracer.start_as_current_span("ResponseStreamWriter") as span:
+                if hasattr(request, "result") and request.result is not None:
+                    span.set_attribute(
+                        SpanAttributes.MCP_RESPONSE_VALUE, f"{serialize(request.result)}"
+                    )
 
-            if not isinstance(request, JSONRPCRequest):
-                return await self.__wrapped__.send(item)
-            meta = None
-            if not request.params:
-                request.params = {}
-            meta = request.params.setdefault("_meta", {})
+                    is_error = False
+                    error_text = ""
+                    res = request.result
 
-            propagate.get_global_textmap().inject(meta)
-            return await self.__wrapped__.send(item)
+                    if isinstance(res, dict):
+                        is_error = res.get("isError") is True
+                        if (
+                            is_error
+                            and "content" in res
+                            and isinstance(res["content"], list)
+                            and len(res["content"]) > 0
+                        ):
+                            content_item = res["content"][0]
+                            if isinstance(content_item, dict):
+                                error_text = content_item.get("text", "")
+                            else:
+                                error_text = getattr(content_item, "text", str(content_item))
+                    elif hasattr(res, "isError"):
+                        is_error = getattr(res, "isError") is True
+                        if (
+                            is_error
+                            and hasattr(res, "content")
+                            and isinstance(res.content, list)
+                            and len(res.content) > 0
+                        ):
+                            content_item = res.content[0]
+                            if hasattr(content_item, "text"):
+                                error_text = content_item.text
+                            elif isinstance(content_item, dict):
+                                error_text = content_item.get("text", "")
+                            else:
+                                error_text = str(content_item)
+
+                    if is_error:
+                        span.set_status(Status(StatusCode.ERROR, error_text))
+
+                if hasattr(request, "id"):
+                    span.set_attribute(SpanAttributes.MCP_REQUEST_ID, f"{request.id}")
+
+                if isinstance(request, JSONRPCRequest):
+                    # Only inject metadata if params is a dict (or make it a dict if None/empty)
+                    if request.params is None:
+                        request.params = {}
+                    if isinstance(request.params, dict):
+                        meta = request.params.setdefault("_meta", {})
+                        propagate.get_global_textmap().inject(meta)
+        except Exception as e:
+            logging.warning(
+                f"mcp instrumentation InstrumentedStreamWriter telemetry exception: {e}"
+            )
+
+        return await self.__wrapped__.send(item_to_send)
 
 
 @dataclass(slots=True, frozen=True)
@@ -608,11 +641,20 @@ class ContextSavingStreamWriter(ObjectProxy):  # type: ignore
     async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> Any:
         return await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
 
-    @dont_throw
     async def send(self, item: Any) -> Any:
         # Removed RequestStreamWriter span creation - we don't need low-level protocol spans
-        ctx = context.get_current()
-        return await self.__wrapped__.send(ItemWithContext(item, ctx))
+        ctx = None
+        try:
+            ctx = context.get_current()
+        except Exception as e:
+            logging.warning(
+                f"mcp instrumentation ContextSavingStreamWriter telemetry exception: {e}"
+            )
+
+        if ctx is not None:
+            return await self.__wrapped__.send(ItemWithContext(item, ctx))
+        else:
+            return await self.__wrapped__.send(item)
 
 
 class ContextAttachingStreamReader(ObjectProxy):  # type: ignore

--- a/packages/opentelemetry-instrumentation-mcp/tests/test_stream_wrappers.py
+++ b/packages/opentelemetry-instrumentation-mcp/tests/test_stream_wrappers.py
@@ -1,0 +1,94 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from opentelemetry.instrumentation.mcp.instrumentation import (
+    InstrumentedStreamReader,
+    InstrumentedStreamWriter,
+)
+from opentelemetry.trace import get_tracer
+
+
+@pytest.mark.asyncio
+async def test_writer_sends_non_iterable_result():
+    # Mock underlying stream writer
+    mock_wrapped = AsyncMock()
+    mock_wrapped.send = AsyncMock(return_value=None)
+
+    tracer = get_tracer("test")
+    writer = InstrumentedStreamWriter(mock_wrapped, tracer)
+
+    # Mock a result that is a non-iterable class (no __contains__ / __iter__)
+    class NonIterableResult:
+        pass
+
+    class CustomRequest:
+        def __init__(self):
+            self.result = NonIterableResult()
+            self.id = 123
+            self.params = None
+
+    class CustomMessage:
+        def __init__(self):
+            self.root = CustomRequest()
+
+    # Test that InstrumentedStreamWriter.send does not raise TypeError and successfully sends
+    await writer.send(CustomMessage())
+
+    # Assert send was called
+    mock_wrapped.send.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_writer_propagates_exceptions():
+    # Mock underlying stream writer that raises a transport exception
+    mock_wrapped = AsyncMock()
+    mock_wrapped.send = AsyncMock(side_effect=ConnectionResetError("Connection lost"))
+
+    tracer = get_tracer("test")
+    writer = InstrumentedStreamWriter(mock_wrapped, tracer)
+
+    class CustomRequest:
+        def __init__(self):
+            self.id = 123
+            self.params = None
+
+    class CustomMessage:
+        def __init__(self):
+            self.root = CustomRequest()
+
+    # Test that InstrumentedStreamWriter propagates the transport exception instead of swallowing it
+    with pytest.raises(ConnectionResetError):
+        await writer.send(CustomMessage())
+
+
+@pytest.mark.asyncio
+async def test_reader_handles_list_params():
+    # Create an async iterable mock
+    mock_wrapped = MagicMock()
+
+    class CustomRequest:
+        def __init__(self):
+            # List parameters, which do not support .get()
+            self.params = [1, 2, 3]
+
+    class CustomMessage:
+        def __init__(self):
+            self.root = CustomRequest()
+
+    messages = [CustomMessage()]
+
+    async def mock_aiter(*args, **kwargs):
+        for msg in messages:
+            yield msg
+
+    mock_wrapped.__aiter__ = mock_aiter
+
+    tracer = get_tracer("test")
+    reader = InstrumentedStreamReader(mock_wrapped, tracer)
+
+    # Test that InstrumentedStreamReader.__aiter__ does not crash on non-dict params
+    results = []
+    async for item in reader:
+        results.append(item)
+
+    assert len(results) == 1
+    assert results[0] == messages[0]


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->
- [x] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
## Description
This PR resolves Issue #4038 (**"MCP InstrumentedStreamWriter.send() assumes dict-shaped request.result and can fail for object/model results"**), as well as a critical exception swallowing bug and a potential crash vector in the `opentelemetry-instrumentation-mcp` package:
### 1. **Exception Swallowing in I/O Wrappers**
The `@dont_throw` decorator was applied directly to `InstrumentedStreamReader.__aiter__`, `InstrumentedStreamWriter.send`, and `ContextSavingStreamWriter.send`. Because these wrappers delegate to the underlying transport stream's standard operations (e.g. sending payloads over pipes/sockets), any authentic transport exception (like connection resets or broken pipes) was intercepted and swallowed by the decorator, converting connection failures into silent, clean terminations or returns.
* **Fix**: Removed `@dont_throw` from the outer stream wrappers, allowing transport exceptions to propagate correctly to the calling application. Wrapped only the specific telemetry/span-related instructions inside localized `try...except` blocks to ensure telemetry failure never interrupts the primary stream operations.
### 2. **TypeError on Non-Iterable Results (Issue #4038)**
In `InstrumentedStreamWriter.send`, checking `"isError" in request.result` raises a `TypeError` if `request.result` is not iterable (e.g. standard class instances, custom objects, or Pydantic models).
* **Fix**: Implemented safe, robust type checks inspecting both `dict` structures and arbitrary class properties (using `getattr` and `hasattr`) without assuming support for `in`.
### 3. **AttributeError on List/Non-Dict Parameters**
In `InstrumentedStreamReader.__aiter__`, extracting `meta` via `request.params.get("_meta")` raises `AttributeError` when `request.params` is a list instead of a dict (e.g. JSON-RPC positional arguments).
* **Fix**: Validated that `request.params` is an instance of `dict` before calling `.get()`.
---
## **Tests Added**
Added a comprehensive unit testing suite in `packages/opentelemetry-instrumentation-mcp/tests/test_stream_wrappers.py` containing three new async test cases:
1. `test_writer_sends_non_iterable_result`: Verifies that a class instance/non-iterable object passed as `request.result` does not crash telemetry or block sending.
2. `test_writer_propagates_exceptions`: Verifies that connection resets or transport exceptions from the wrapped stream are properly propagated up instead of swallowed.
3. `test_reader_handles_list_params`: Verifies that positional/list parameters do not crash `__aiter__` extraction.
---
## **Verification Results**
- Tested with `uv run pytest tests/` -> `8 passed in 0.39s` (including all new & existing fastmcp tests).
- Lint verified with `uv run ruff check .` -> `All checks passed!`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced tracing context propagation for MCP message streams
  * Improved span reporting for both inbound and outbound messages
  * More robust telemetry exception handling with informative logging

* **Bug Fixes**
  * Increased robustness in handling edge cases during message stream processing
  * Better error propagation for transport-level failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->