### PR TITLE
fix(sdk): replace deprecated cuid with cuid2 to resolve sonatype-2023-2645

### DIFF
--- a/packages/traceloop-sdk/pyproject.toml
+++ b/packages/traceloop-sdk/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
   "jinja2>=3.1.5,<4",
   "deprecated>=1.2.14,<2",
   "aiohttp>=3.11.11,<4",
-  "cuid>=0.4,<0.5",
+  "cuid2>=2.0.1,<3",
 ]
 
 [project.urls]
@@ -133,7 +133,7 @@ exclude = [
 
 [[tool.mypy.overrides]]
 module = [
-    "cuid.*",
+    "cuid2.*",
     "posthog.*",
     "opentelemetry.semconv_ai.*",
 ]

--- a/packages/traceloop-sdk/traceloop/sdk/experiment/experiment.py
+++ b/packages/traceloop-sdk/traceloop/sdk/experiment/experiment.py
@@ -1,4 +1,3 @@
-import cuid
 import asyncio
 import json
 import os
@@ -20,6 +19,9 @@ from traceloop.sdk.experiment.model import (
 )
 from traceloop.sdk.evaluator.config import EvaluatorDetails
 import httpx
+from cuid2 import Cuid
+
+_EXPERIMENT_SLUG_CUID = Cuid(length=11)
 
 
 class Experiment:
@@ -122,7 +124,7 @@ class Experiment:
         """
 
         if not experiment_slug:
-            experiment_slug = self._experiment_slug or "exp-" + str(cuid.cuid())[:11]
+            experiment_slug = self._experiment_slug or "exp-" + _EXPERIMENT_SLUG_CUID.generate()
         self._last_experiment_slug = experiment_slug
 
         experiment_run_metadata = {
@@ -307,7 +309,7 @@ class Experiment:
             )
 
         if not experiment_slug:
-            experiment_slug = self._experiment_slug or "exp-" + str(cuid.cuid())[:11]
+            experiment_slug = self._experiment_slug or "exp-" + _EXPERIMENT_SLUG_CUID.generate()
         self._last_experiment_slug = experiment_slug
 
         # Fetch dataset rows

--- a/packages/traceloop-sdk/uv.lock
+++ b/packages/traceloop-sdk/uv.lock
@@ -419,10 +419,13 @@ wheels = [
 ]
 
 [[package]]
-name = "cuid"
-version = "0.4"
+name = "cuid2"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/55/ca/d323556e2bf9bfb63219fbb849ce61bb830cc42d1b25b91cde3815451b91/cuid-0.4.tar.gz", hash = "sha256:74eaba154916a2240405c3631acee708c263ef8fa05a86820b87d0f59f84e978", size = 4986, upload-time = "2023-03-06T00:41:12.708Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/63/97ffc74f33e5a5f913bf073e8250a5b5a64d52d411b09a9c36c902db2cc4/cuid2-2.0.1.tar.gz", hash = "sha256:8d262eb467c16b81419361e18e47f41da77c4446dd2cf0640eac2616680bc924", size = 7033, upload-time = "2024-04-16T23:51:52.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/d2/90fce0050c5a9196d259ac8f0c4720c69ec6b5a322612edf3892f0036c5d/cuid2-2.0.1-py3-none-any.whl", hash = "sha256:943bdf86dc3ed07f32253e1be6e3c34dda8c7bda1c453f851f4ebaaa5a2dcfbf", size = 8154, upload-time = "2024-04-16T23:51:50.953Z" },
+]
 
 [[package]]
 name = "datamodel-code-generator"
@@ -3883,7 +3886,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "colorama" },
-    { name = "cuid" },
+    { name = "cuid2" },
     { name = "deprecated" },
     { name = "jinja2" },
     { name = "opentelemetry-api" },
@@ -3965,7 +3968,7 @@ test = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.11.11,<4" },
     { name = "colorama", specifier = ">=0.4.6,<0.5.0" },
-    { name = "cuid", specifier = ">=0.4,<0.5" },
+    { name = "cuid2", specifier = ">=2.0.1,<3" },
     { name = "deprecated", specifier = ">=1.2.14,<2" },
     { name = "jinja2", specifier = ">=3.1.5,<4" },
     { name = "opentelemetry-api", specifier = ">=1.38.0,<2" },


### PR DESCRIPTION
## Summary

Closes #4155.

The `cuid` package (v0.4) that `traceloop-sdk` depends on is deprecated upstream due to a security advisory ([sonatype-2023-2645](https://guide.sonatype.com/vulnerability/sonatype-2023-2645)). Sonatype-protected enterprise PyPI mirrors quarantine the package, so business users currently cannot `pip install traceloop-sdk` at all.

This PR swaps `cuid` for the maintained Python port [`cuid2`](https://github.com/gordon-code/cuid2) (PyPI `cuid2==2.0.1`, the successor recommended by upstream `cuid`'s own deprecation notice).

## Changes

- `packages/traceloop-sdk/pyproject.toml`: `cuid>=0.4,<0.5` → `cuid2>=2.0.1,<3`; mypy `ignore_missing_imports` override renamed from `cuid.*` to `cuid2.*`.
- `packages/traceloop-sdk/traceloop/sdk/experiment/experiment.py`: replace `import cuid` with `from cuid2 import Cuid`; instantiate a module-level `_EXPERIMENT_SLUG_CUID = Cuid(length=11)` (matches gordon-code's recommended pattern for reusing a counter-bearing generator); both call sites switch from `"exp-" + str(cuid.cuid())[:11]` to `"exp-" + _EXPERIMENT_SLUG_CUID.generate()`.
- `packages/traceloop-sdk/uv.lock`: regenerated.

## Behaviour preserved

The generated experiment slug shape `exp-<11 lowercase base36 chars>` (total length 15) is unchanged — the old code already truncated `cuid.cuid()` to 11 chars via `[:11]`, and `Cuid(length=11)` produces the same shape. Repo-wide grep confirms `cuid` had no other usages.

## Test plan

- [x] `npx nx run traceloop-sdk:install` — `cuid2==2.0.1` resolved, `cuid` removed from the resolved tree.
- [x] `npx nx run traceloop-sdk:lock` — `uv.lock` regenerated cleanly.
- [x] `npx nx run traceloop-sdk:lint` — `ruff check` passes.
- [x] `npx nx run traceloop-sdk:test` — **412 passed**, 0 failed.
- [x] Manual sanity check: `_EXPERIMENT_SLUG_CUID.generate()` produces 11-char ids; full slug is `exp-` + 11 chars (length 15), matching the previous shape.

## PR checklist

- [ ] I have added tests that cover my changes. — _Not applicable: this is a drop-in dependency swap that preserves the existing slug shape. The existing experiment tests in `packages/traceloop-sdk/tests/experiment/` exercise the surrounding code paths and continue to pass._
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change. — _Not applicable, no instrumentation change._
- [x] PR name follows conventional commits format.
- [ ] (If applicable) I have updated the documentation accordingly. — _Not applicable._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python package dependencies with corresponding configuration adjustments to maintain consistency across the SDK.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->