### PR TITLE
feat(crewai): emit OTel GenAI plan spans

### DIFF
--- a/packages/opentelemetry-instrumentation-crewai/opentelemetry/instrumentation/crewai/instrumentation.py
+++ b/packages/opentelemetry-instrumentation-crewai/opentelemetry/instrumentation/crewai/instrumentation.py
@@ -22,6 +22,8 @@ from .crewai_span_attributes import CrewAISpanAttributes, set_span_attribute
 from .utils import _messages_to_otel_input, _response_to_otel_output
 
 _instruments = ("crewai >= 1.0.0",)
+# "plan" is defined by the GenAI semantic conventions, but the generated
+# GenAiOperationNameValues enum may lag the convention release.
 _GEN_AI_OPERATION_PLAN = "plan"
 _crew_planning_span = ContextVar("crew_planning_span", default=None)
 

--- a/packages/opentelemetry-instrumentation-crewai/opentelemetry/instrumentation/crewai/instrumentation.py
+++ b/packages/opentelemetry-instrumentation-crewai/opentelemetry/instrumentation/crewai/instrumentation.py
@@ -1,9 +1,10 @@
 import os
 import time
+from contextvars import ContextVar
 from typing import Collection
 
 from wrapt import wrap_function_wrapper
-from opentelemetry.trace import SpanKind, get_tracer, Tracer
+from opentelemetry.trace import SpanKind, get_current_span, get_tracer, Tracer
 from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.metrics import Histogram, Meter, get_meter
 from opentelemetry.instrumentation.utils import unwrap
@@ -21,6 +22,8 @@ from .crewai_span_attributes import CrewAISpanAttributes, set_span_attribute
 from .utils import _messages_to_otel_input, _response_to_otel_output
 
 _instruments = ("crewai >= 1.0.0",)
+_GEN_AI_OPERATION_PLAN = "plan"
+_crew_planning_span_active = ContextVar("crew_planning_span_active", default=False)
 
 # Maps LiteLLM vendor prefixes (e.g. "openai" in "openai/gpt-4") to OTel provider name values.
 # Uses GenAISystem (semconv-ai) and GenAiSystemValues (OTel upstream) — no raw strings.
@@ -92,12 +95,38 @@ class CrewAIInstrumentor(BaseInstrumentor):
                               wrap_task_execute(tracer, duration_histogram, token_histogram))
         wrap_function_wrapper("crewai.llm", "LLM.call",
                               wrap_llm_call(tracer, duration_histogram, token_histogram))
+        _wrap_optional_function_wrapper(
+            "crewai.utilities.planning_handler",
+            "CrewPlanner._handle_crew_planning",
+            wrap_crew_planning(tracer, duration_histogram, token_histogram),
+        )
+        _wrap_optional_function_wrapper(
+            "crewai.utilities.planning_handler",
+            "CrewPlanner._create_planning_agent",
+            wrap_create_planning_agent,
+        )
 
     def _uninstrument(self, **kwargs):
         unwrap("crewai.crew.Crew", "kickoff")
         unwrap("crewai.agent.Agent", "execute_task")
         unwrap("crewai.task.Task", "execute_sync")
         unwrap("crewai.llm.LLM", "call")
+        _unwrap_optional("crewai.utilities.planning_handler.CrewPlanner", "_handle_crew_planning")
+        _unwrap_optional("crewai.utilities.planning_handler.CrewPlanner", "_create_planning_agent")
+
+
+def _wrap_optional_function_wrapper(module, name, wrapper):
+    try:
+        wrap_function_wrapper(module, name, wrapper)
+    except (AttributeError, ImportError, ModuleNotFoundError):
+        pass
+
+
+def _unwrap_optional(module, name):
+    try:
+        unwrap(module, name)
+    except (AttributeError, ImportError, ModuleNotFoundError):
+        pass
 
 
 def with_tracer_wrapper(func):
@@ -211,6 +240,42 @@ def wrap_task_execute(tracer, duration_histogram, token_histogram, wrapped, inst
         except Exception as ex:
             span.set_status(Status(StatusCode.ERROR, str(ex)))
             raise
+
+
+@with_tracer_wrapper
+def wrap_crew_planning(tracer, duration_histogram, token_histogram, wrapped, instance, args, kwargs):
+    with tracer.start_as_current_span(
+        _GEN_AI_OPERATION_PLAN,
+        kind=SpanKind.INTERNAL,
+        attributes={
+            GenAIAttributes.GEN_AI_PROVIDER_NAME: GenAISystem.CREWAI.value,
+            GenAIAttributes.GEN_AI_OPERATION_NAME: _GEN_AI_OPERATION_PLAN,
+        },
+    ) as span:
+        token = _crew_planning_span_active.set(True)
+        try:
+            result = wrapped(*args, **kwargs)
+            span.set_status(Status(StatusCode.OK))
+            return result
+        except Exception as ex:
+            span.set_status(Status(StatusCode.ERROR, str(ex)))
+            raise
+        finally:
+            _crew_planning_span_active.reset(token)
+
+
+def wrap_create_planning_agent(wrapped, instance, args, kwargs):
+    planner_agent = wrapped(*args, **kwargs)
+    if _crew_planning_span_active.get():
+        span = get_current_span()
+        agent_name = getattr(planner_agent, "role", None)
+        agent_id = getattr(planner_agent, "id", None)
+        if agent_name:
+            set_span_attribute(span, GenAIAttributes.GEN_AI_AGENT_NAME, agent_name)
+            span.update_name(f"plan {agent_name}")
+        if agent_id:
+            set_span_attribute(span, GenAIAttributes.GEN_AI_AGENT_ID, str(agent_id))
+    return planner_agent
 
 
 @with_tracer_wrapper

--- a/packages/opentelemetry-instrumentation-crewai/opentelemetry/instrumentation/crewai/instrumentation.py
+++ b/packages/opentelemetry-instrumentation-crewai/opentelemetry/instrumentation/crewai/instrumentation.py
@@ -4,7 +4,7 @@ from contextvars import ContextVar
 from typing import Collection
 
 from wrapt import wrap_function_wrapper
-from opentelemetry.trace import SpanKind, get_current_span, get_tracer, Tracer
+from opentelemetry.trace import SpanKind, get_tracer, Tracer
 from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.metrics import Histogram, Meter, get_meter
 from opentelemetry.instrumentation.utils import unwrap
@@ -23,7 +23,7 @@ from .utils import _messages_to_otel_input, _response_to_otel_output
 
 _instruments = ("crewai >= 1.0.0",)
 _GEN_AI_OPERATION_PLAN = "plan"
-_crew_planning_span_active = ContextVar("crew_planning_span_active", default=False)
+_crew_planning_span = ContextVar("crew_planning_span", default=None)
 
 # Maps LiteLLM vendor prefixes (e.g. "openai" in "openai/gpt-4") to OTel provider name values.
 # Uses GenAISystem (semconv-ai) and GenAiSystemValues (OTel upstream) — no raw strings.
@@ -252,7 +252,7 @@ def wrap_crew_planning(tracer, duration_histogram, token_histogram, wrapped, ins
             GenAIAttributes.GEN_AI_OPERATION_NAME: _GEN_AI_OPERATION_PLAN,
         },
     ) as span:
-        token = _crew_planning_span_active.set(True)
+        token = _crew_planning_span.set(span)
         try:
             result = wrapped(*args, **kwargs)
             span.set_status(Status(StatusCode.OK))
@@ -261,13 +261,13 @@ def wrap_crew_planning(tracer, duration_histogram, token_histogram, wrapped, ins
             span.set_status(Status(StatusCode.ERROR, str(ex)))
             raise
         finally:
-            _crew_planning_span_active.reset(token)
+            _crew_planning_span.reset(token)
 
 
 def wrap_create_planning_agent(wrapped, instance, args, kwargs):
     planner_agent = wrapped(*args, **kwargs)
-    if _crew_planning_span_active.get():
-        span = get_current_span()
+    span = _crew_planning_span.get()
+    if span is not None:
         agent_name = getattr(planner_agent, "role", None)
         agent_id = getattr(planner_agent, "id", None)
         if agent_name:

--- a/packages/opentelemetry-instrumentation-crewai/tests/test_crewai_instrumentation.py
+++ b/packages/opentelemetry-instrumentation-crewai/tests/test_crewai_instrumentation.py
@@ -8,7 +8,11 @@ from crewai.llms.base_llm import BaseLLM
 from crewai.utilities.planning_handler import CrewPlanner, PlanPerTask, PlannerTaskPydanticOutput
 
 from opentelemetry.instrumentation.crewai import CrewAIInstrumentor
-from opentelemetry.instrumentation.crewai.instrumentation import wrap_crew_planning
+from opentelemetry.instrumentation.crewai.instrumentation import (
+    _crew_planning_span,
+    wrap_create_planning_agent,
+    wrap_crew_planning,
+)
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -29,6 +33,13 @@ class StubLLM(BaseLLM):
         response_model: type[BaseModel] | None = None,
     ):
         return "Mocked response"
+
+
+def _plan_per_task(task, plan):
+    values = {"task": task, "plan": plan}
+    if "task_number" in getattr(PlanPerTask, "model_fields", {}):
+        values["task_number"] = 1
+    return PlanPerTask(**values)
 
 
 @pytest.fixture
@@ -126,6 +137,7 @@ def test_wrap_crew_planning_creates_plan_span():
     planner._create_planning_agent.assert_not_called()
     span.set_status.assert_called_once()
     assert span.set_status.call_args.args[0].status_code == StatusCode.OK
+    assert _crew_planning_span.get() is None
 
 
 def test_wrap_crew_planning_records_error_status():
@@ -143,6 +155,39 @@ def test_wrap_crew_planning_records_error_status():
         wrap_crew_planning(tracer, None, None)(wrapped, planner, (), {})
 
     assert span.set_status.call_args.args[0].status_code == StatusCode.ERROR
+    assert _crew_planning_span.get() is None
+
+
+def test_wrap_create_planning_agent_ignores_agent_outside_plan_span(monkeypatch):
+    set_span_attribute = MagicMock()
+    monkeypatch.setattr(
+        "opentelemetry.instrumentation.crewai.instrumentation.set_span_attribute",
+        set_span_attribute,
+    )
+    planner_agent = MagicMock(role="Task Execution Planner", id="agent-id")
+    wrapped = MagicMock(return_value=planner_agent)
+
+    result = wrap_create_planning_agent(wrapped, MagicMock(), (), {})
+
+    assert result is planner_agent
+    assert _crew_planning_span.get() is None
+    set_span_attribute.assert_not_called()
+
+
+def test_wrap_create_planning_agent_enriches_stored_plan_span():
+    plan_span = MagicMock()
+    planner_agent = MagicMock(role="Task Execution Planner", id="agent-id")
+    wrapped = MagicMock(return_value=planner_agent)
+    token = _crew_planning_span.set(plan_span)
+    try:
+        result = wrap_create_planning_agent(wrapped, MagicMock(), (), {})
+    finally:
+        _crew_planning_span.reset(token)
+
+    assert result is planner_agent
+    plan_span.update_name.assert_called_once_with("plan Task Execution Planner")
+    plan_span.set_attribute.assert_any_call("gen_ai.agent.name", "Task Execution Planner")
+    plan_span.set_attribute.assert_any_call("gen_ai.agent.id", "agent-id")
 
 
 def test_crewai_planner_instrumentation_creates_plan_span_without_state_mutation():
@@ -164,7 +209,7 @@ def test_crewai_planner_instrumentation_creates_plan_span_without_state_mutation
         fake_task.execute_sync.return_value = SimpleNamespace(
             pydantic=PlannerTaskPydanticOutput(
                 list_of_plans_per_task=[
-                    PlanPerTask(task=task.description, plan="Use the researcher to collect the data")
+                    _plan_per_task(task.description, "Use the researcher to collect the data")
                 ]
             )
         )

--- a/packages/opentelemetry-instrumentation-crewai/tests/test_crewai_instrumentation.py
+++ b/packages/opentelemetry-instrumentation-crewai/tests/test_crewai_instrumentation.py
@@ -1,11 +1,17 @@
 import pytest
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 from pydantic import BaseModel
 
 from crewai import Agent, Crew, Task
 from crewai.llms.base_llm import BaseLLM
+from crewai.utilities.planning_handler import CrewPlanner, PlanPerTask, PlannerTaskPydanticOutput
 
 from opentelemetry.instrumentation.crewai import CrewAIInstrumentor
+from opentelemetry.instrumentation.crewai.instrumentation import wrap_crew_planning
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace.status import StatusCode
 
 
@@ -26,15 +32,24 @@ class StubLLM(BaseLLM):
 
 
 @pytest.fixture
-def mock_instrumentor():
-    instrumentor = CrewAIInstrumentor()
-    instrumentor.instrument = MagicMock()
-    instrumentor.uninstrument = MagicMock()
-    return instrumentor
+def disable_crewai_telemetry(monkeypatch):
+    from crewai.telemetry.telemetry import Telemetry
+
+    def telemetry_init(self):
+        self.ready = False
+        self.trace_set = False
+
+    monkeypatch.setattr(Telemetry, "__init__", telemetry_init)
+    monkeypatch.setattr(Telemetry, "set_tracer", lambda self: None)
 
 
 @pytest.fixture
-def mock_crew():
+def mock_instrumentor():
+    return MagicMock(spec=CrewAIInstrumentor)
+
+
+@pytest.fixture
+def mock_crew(disable_crewai_telemetry):
     llm = StubLLM(model="stub-model")
     agent = Agent(
         role="Data Collector",
@@ -89,3 +104,87 @@ def test_trace_status(mock_crew, mock_instrumentor):
 
     mock_instrumentor.uninstrument()
     mock_instrumentor.uninstrument.assert_called_once()
+
+
+def test_wrap_crew_planning_creates_plan_span():
+    span = MagicMock()
+    tracer = MagicMock()
+    tracer.start_as_current_span.return_value.__enter__.return_value = span
+    planner = MagicMock()
+    wrapped = MagicMock(return_value="planning-result")
+
+    result = wrap_crew_planning(tracer, None, None)(wrapped, planner, (), {})
+
+    assert result == "planning-result"
+    tracer.start_as_current_span.assert_called_once()
+    args, kwargs = tracer.start_as_current_span.call_args
+    assert args[0] == "plan"
+    assert kwargs["attributes"]["gen_ai.provider.name"] == "crewai"
+    assert kwargs["attributes"]["gen_ai.operation.name"] == "plan"
+    assert "gen_ai.agent.id" not in kwargs["attributes"]
+    assert "gen_ai.agent.name" not in kwargs["attributes"]
+    planner._create_planning_agent.assert_not_called()
+    span.set_status.assert_called_once()
+    assert span.set_status.call_args.args[0].status_code == StatusCode.OK
+
+
+def test_wrap_crew_planning_records_error_status():
+    span = MagicMock()
+    tracer = MagicMock()
+    tracer.start_as_current_span.return_value.__enter__.return_value = span
+    planner = MagicMock()
+    planner._create_planning_agent.return_value = MagicMock(
+        role="Task Execution Planner",
+        id="agent-id",
+    )
+    wrapped = MagicMock(side_effect=RuntimeError("planning failed"))
+
+    with pytest.raises(RuntimeError, match="planning failed"):
+        wrap_crew_planning(tracer, None, None)(wrapped, planner, (), {})
+
+    assert span.set_status.call_args.args[0].status_code == StatusCode.ERROR
+
+
+def test_crewai_planner_instrumentation_creates_plan_span_without_state_mutation():
+    exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    task = SimpleNamespace(
+        description="Collect stock data",
+        expected_output="A financial dataset",
+        tools=[],
+        agent=SimpleNamespace(role="Researcher", goal="Find market data", tools=[]),
+    )
+    planner = CrewPlanner(tasks=[task], planning_agent_llm=StubLLM(model="stub-planner-model"))
+    assert "_create_planning_agent" not in planner.__dict__
+
+    def create_planner_task(planning_agent, tasks_summary):
+        fake_task = MagicMock()
+        fake_task.execute_sync.return_value = SimpleNamespace(
+            pydantic=PlannerTaskPydanticOutput(
+                list_of_plans_per_task=[
+                    PlanPerTask(task=task.description, plan="Use the researcher to collect the data")
+                ]
+            )
+        )
+        return fake_task
+
+    planner._create_planner_task = create_planner_task
+    instrumentor = CrewAIInstrumentor()
+    try:
+        instrumentor.instrument(tracer_provider=tracer_provider)
+        result = planner._handle_crew_planning()
+    finally:
+        instrumentor.uninstrument()
+
+    assert isinstance(result, PlannerTaskPydanticOutput)
+    assert "_create_planning_agent" not in planner.__dict__
+    plan_spans = [
+        span for span in exporter.get_finished_spans() if span.attributes.get("gen_ai.operation.name") == "plan"
+    ]
+    assert len(plan_spans) == 1
+    assert plan_spans[0].name == "plan Task Execution Planner"
+    assert plan_spans[0].attributes["gen_ai.provider.name"] == "crewai"
+    assert plan_spans[0].attributes["gen_ai.agent.name"] == "Task Execution Planner"
+    assert "gen_ai.agent.id" in plan_spans[0].attributes


### PR DESCRIPTION
## Summary

- Emit OTel GenAI `plan` spans around CrewAI planning.
- Annotate the active plan span with the CrewAI planning agent name/id when CrewAI creates the real planning agent.
- Add a real `CrewPlanner` regression test that verifies the emitted span and ensures instrumentation does not leave an instance-level `_create_planning_agent` shadow behind.

## Reference

OTel GenAI plan-span semantics define `gen_ai.operation.name` as `plan` for agent planning/task decomposition phases: https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md#plan-span

## Tests

- `uv run --python 3.12 --group test pytest tests/`: 176 passed.
- `uv run --python 3.12 --group dev ruff check .`: passed.
- `git diff --check`: passed.
- Rebased onto latest `traceloop/openllmetry:main` before opening this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Crew planning tracing that creates explicit internal **“plan”** spans with GenAI attributes, propagates plan context across the planning-agent boundary, enriches spans with agent details when available, and records error status on failures.

* **Tests**
  * Expanded span-focused coverage for plan span creation, error handling, agent enrichment inside vs outside a stored plan context, and an end-to-end instrumentation check verifying exported spans and that planner state remains unmodified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->