### PR TITLE
feat(instrumentation-ollama): add duration telemetry span attributes

### DIFF
--- a/packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/span_utils.py
+++ b/packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/span_utils.py
@@ -111,6 +111,30 @@ def set_model_response_attributes(span, token_histogram, llm_request_type, respo
     )
     _set_span_attribute(span, GenAIAttributes.GEN_AI_SYSTEM, "Ollama")
 
+    _set_span_attribute(
+        span,
+        "llm.ollama.total_duration",
+        response.get("total_duration"),
+    )
+
+    _set_span_attribute(
+        span,
+        "llm.ollama.load_duration",
+        response.get("load_duration"),
+    )
+
+    _set_span_attribute(
+        span,
+        "llm.ollama.prompt_eval_duration",
+        response.get("prompt_eval_duration"),
+    )
+
+    _set_span_attribute(
+        span,
+        "llm.ollama.eval_duration",
+        response.get("eval_duration"),
+    )
+
     if (
         token_histogram is not None
         and isinstance(input_tokens, int)

--- a/packages/opentelemetry-instrumentation-ollama/tests/test_generation.py
+++ b/packages/opentelemetry-instrumentation-ollama/tests/test_generation.py
@@ -38,6 +38,14 @@ def test_ollama_generation_legacy(
         GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS
     ) + ollama_span.attributes.get(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS)
 
+    assert ollama_span.attributes.get("llm.ollama.total_duration") > 0
+
+    assert ollama_span.attributes.get("llm.ollama.load_duration") > 0
+
+    assert ollama_span.attributes.get("llm.ollama.prompt_eval_duration") > 0
+
+    assert ollama_span.attributes.get("llm.ollama.eval_duration") > 0
+
     logs = log_exporter.get_finished_logs()
     assert (
         len(logs) == 0
@@ -161,6 +169,14 @@ def test_ollama_streaming_generation_legacy(
     ) == ollama_span.attributes.get(
         GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS
     ) + ollama_span.attributes.get(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS)
+
+    assert ollama_span.attributes.get("llm.ollama.total_duration") > 0
+
+    assert ollama_span.attributes.get("llm.ollama.load_duration") > 0
+
+    assert ollama_span.attributes.get("llm.ollama.prompt_eval_duration") > 0
+
+    assert ollama_span.attributes.get("llm.ollama.eval_duration") > 0
 
     logs = log_exporter.get_finished_logs()
     assert (


### PR DESCRIPTION
## Summary

Adds Ollama duration-related response metadata as tracing span attributes.

Added attributes:

* `llm.ollama.total_duration`
* `llm.ollama.load_duration`
* `llm.ollama.prompt_eval_duration`
* `llm.ollama.eval_duration`

## Changes

* Extended `set_model_response_attributes()` to capture duration telemetry fields from Ollama responses
* Added tracing assertions for generation and streaming generation tests

## Verification

Verified locally through exported span output.

Example observed Ollama response fields:

```json
{
  "total_duration": 115588345200,
  "load_duration": 53118691900,
  "prompt_eval_duration": 48132531100,
  "eval_duration": 13506373700
}
```

These values are now exported as tracing span attributes.

## Checklist

* [x] I have added tests that cover my changes.
* [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
* [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
* [ ] (If applicable) I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ollama instrumentation now captures four additional timing metrics in distributed traces: total duration, load duration, prompt evaluation duration, and evaluation duration. This enhancement provides deeper insight into model execution performance and resource utilization during inference operations.

* **Tests**
  * Added comprehensive test coverage to verify these new duration metrics are captured accurately and contain valid timing values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->