### PR TITLE
fix(qdrant): add query_points and query_batch_points to async client instrumentation

### DIFF
--- a/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/async_qdrant_client_methods.json
+++ b/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/async_qdrant_client_methods.json
@@ -46,6 +46,16 @@
     },
     {
         "object": "AsyncQdrantClient",
+        "method": "query_points",
+        "span_name": "qdrant.query_points"
+    },
+    {
+        "object": "AsyncQdrantClient",
+        "method": "query_batch_points",
+        "span_name": "qdrant.query_batch_points"
+    },
+    {
+        "object": "AsyncQdrantClient",
         "method": "query_batch",
         "span_name": "qdrant.query_batch"
     },


### PR DESCRIPTION
## Summary

The sync `QdrantClient` instrumentation includes `query_points` and `query_batch_points` in its method config, but the async `AsyncQdrantClient` config was missing both. This means async users get no tracing spans when calling these methods.

This PR adds the two missing entries to `async_qdrant_client_methods.json`, bringing async instrumentation to parity with the sync client.

The instrumentor already uses `hasattr` checks (line 55 in `__init__.py`), so this is safe across all qdrant-client versions — if a version doesn't have these methods, they're silently skipped.

## Changes

- Added `query_points` and `query_batch_points` to `async_qdrant_client_methods.json`

## Test plan

- [x] All 4 existing tests pass with `pytest tests/ -v`
- [x] Verified `AsyncQdrantClient` has both `query_points` and `query_batch_points` methods (qdrant-client 1.18.0)
- [x] Verified the JSON is valid and loads correctly

## Related issues

- Closes #3492 (follow-up on async coverage gap noted in [this comment](https://github.com/traceloop/openllmetry/issues/3492#issuecomment-4544042663))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended instrumentation coverage for async query operations, adding additional spans to improve observability and performance monitoring of asynchronous queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->