### PR TITLE
docs(sample-app): add beginner-friendly LLM tracing example (#4069)

### DIFF
--- a/packages/sample-app/README.md
+++ b/packages/sample-app/README.md
@@ -1,3 +1,18 @@
 # sample-app
 
-Project description here.
+Runnable examples that exercise OpenLLMetry against real providers — useful as smoke tests and as starting points for your own code.
+
+## Start here if you're new
+
+[`sample_app/beginner_tracing_example.py`](sample_app/beginner_tracing_example.py) is a short walkthrough that covers `Traceloop.init`, `@workflow`, and `@task` against a single OpenAI call.
+
+```bash
+export OPENAI_API_KEY=sk-...
+poetry run python sample_app/beginner_tracing_example.py
+```
+
+Spans print to stdout by default. Point the standard `OTEL_EXPORTER_OTLP_*` env vars at a backend (Jaeger, Honeycomb, Datadog, Traceloop, …) to ship them.
+
+## Everything else
+
+The other files follow the same pattern but for specific providers and scenarios (Anthropic, Bedrock, Cohere, Pinecone, Chroma, agents, streaming, structured outputs, …). Pick whichever is closest to what you're building.

--- a/packages/sample-app/README.md
+++ b/packages/sample-app/README.md
@@ -8,10 +8,10 @@ Runnable examples that exercise OpenLLMetry against real providers — useful as
 
 ```bash
 export OPENAI_API_KEY=sk-...
-poetry run python sample_app/beginner_tracing_example.py
+uv run python sample_app/beginner_tracing_example.py
 ```
 
-Spans print to stdout by default. Point the standard `OTEL_EXPORTER_OTLP_*` env vars at a backend (Jaeger, Honeycomb, Datadog, Traceloop, …) to ship them.
+The example wires a `ConsoleSpanExporter` so spans land on stdout out of the box. For real backends (Traceloop, Jaeger, Honeycomb, Datadog, …) set `TRACELOOP_API_KEY` or the standard `OTEL_EXPORTER_OTLP_*` env vars and drop the explicit exporter from the script.
 
 ## Everything else
 

--- a/packages/sample-app/sample_app/beginner_tracing_example.py
+++ b/packages/sample-app/sample_app/beginner_tracing_example.py
@@ -10,13 +10,16 @@ Uses OpenAI here, but the structure is the same for any provider this
 repo instruments.
 
     export OPENAI_API_KEY=sk-...
-    poetry run python sample_app/beginner_tracing_example.py
+    uv run python sample_app/beginner_tracing_example.py
 
-Without extra config, spans print to stdout. Set the standard
-`OTEL_EXPORTER_OTLP_*` env vars to ship them to a backend instead.
+This example wires a ConsoleSpanExporter so spans land on stdout out of
+the box. For real backends (Traceloop, Jaeger, Honeycomb, Datadog, …)
+set `TRACELOOP_API_KEY` or the standard `OTEL_EXPORTER_OTLP_*` env vars
+and drop the explicit exporter argument.
 """
 
 from openai import OpenAI
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter
 
 from traceloop.sdk import Traceloop
 from traceloop.sdk.decorators import task, workflow
@@ -24,9 +27,12 @@ from traceloop.sdk.decorators import task, workflow
 # `app_name` shows up on every span. `disable_batch=True` flushes
 # synchronously, which is easier to read in a short script — leave the
 # default on in production so flushing doesn't block your hot path.
+# The explicit `exporter` makes spans visible on stdout even when no
+# TRACELOOP_API_KEY or OTLP endpoint is configured.
 Traceloop.init(
     app_name="beginner-tracing-example",
     disable_batch=True,
+    exporter=ConsoleSpanExporter(),
 )
 
 client = OpenAI()

--- a/packages/sample-app/sample_app/beginner_tracing_example.py
+++ b/packages/sample-app/sample_app/beginner_tracing_example.py
@@ -1,0 +1,67 @@
+"""Minimal walkthrough: trace an LLM call with OpenLLMetry.
+
+Three pieces, in the order you meet them in real code:
+
+  Traceloop.init  — wire up the SDK so spans are produced
+  @workflow       — top-level unit of work (one user-visible action)
+  @task           — sub-step nested under that workflow
+
+Uses OpenAI here, but the structure is the same for any provider this
+repo instruments.
+
+    export OPENAI_API_KEY=sk-...
+    poetry run python sample_app/beginner_tracing_example.py
+
+Without extra config, spans print to stdout. Set the standard
+`OTEL_EXPORTER_OTLP_*` env vars to ship them to a backend instead.
+"""
+
+from openai import OpenAI
+
+from traceloop.sdk import Traceloop
+from traceloop.sdk.decorators import task, workflow
+
+# `app_name` shows up on every span. `disable_batch=True` flushes
+# synchronously, which is easier to read in a short script — leave the
+# default on in production so flushing doesn't block your hot path.
+Traceloop.init(
+    app_name="beginner-tracing-example",
+    disable_batch=True,
+)
+
+client = OpenAI()
+
+
+@task(name="tell_joke")
+def tell_joke() -> str:
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "Tell me a short joke about telemetry."}],
+    )
+    return response.choices[0].message.content or ""
+
+
+@task(name="explain_joke")
+def explain_joke(joke: str) -> str:
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "user", "content": f"Explain the joke in one sentence:\n\n{joke}"},
+        ],
+    )
+    return response.choices[0].message.content or ""
+
+
+# Everything called inside the workflow — including the two @task functions
+# above — gets attached to the same trace automatically.
+@workflow(name="joke_and_explanation")
+def run() -> None:
+    joke = tell_joke()
+    print("Joke:", joke)
+
+    explanation = explain_joke(joke)
+    print("Explanation:", explanation)
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
Adds a short, heavily-commented walkthrough at \`packages/sample-app/sample_app/beginner_tracing_example.py\` that introduces \`Traceloop.init\`, \`@workflow\`, and \`@task\` against a single OpenAI call.

Closes #4069.

The existing examples in \`sample-app/\` are great references once you already know the SDK shape, but they assume you do. This one starts from \`Traceloop.init\` and works up to a two-task workflow so a first-time user can copy it, run it, and see the trace structure that everything else in the repo produces.

Also replaces the sample-app README placeholder (\`Project description here.\`) with a short paragraph that points new users at this example first.

\`\`\`bash
export OPENAI_API_KEY=sk-...
poetry run python sample_app/beginner_tracing_example.py
\`\`\`

\`\`\`
$ uvx ruff check packages/sample-app/sample_app/beginner_tracing_example.py
All checks passed!

$ uvx ruff format --check packages/sample-app/sample_app/beginner_tracing_example.py
1 file already formatted
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced sample app README with a “Start here if you’re new” quick-start, runnable walkthrough, instructions to switch to real tracing backends, and an overview of additional provider/scenario examples.

* **New Features**
  * Added a beginner tracing example that demonstrates instrumented AI chat workflows with real-time spans emitted to stdout and prints example outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->