### PR TITLE
fix(qdrant): cover `AsyncQdrantClient.query_points` and `query_batch_points`

### DIFF
--- a/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/async_qdrant_client_methods.json
+++ b/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/async_qdrant_client_methods.json
@@ -46,8 +46,18 @@
     },
     {
         "object": "AsyncQdrantClient",
+        "method": "query_points",
+        "span_name": "qdrant.query_points"
+    },
+    {
+        "object": "AsyncQdrantClient",
         "method": "query_batch",
         "span_name": "qdrant.query_batch"
+    },
+    {
+        "object": "AsyncQdrantClient",
+        "method": "query_batch_points",
+        "span_name": "qdrant.query_batch_points"
     },
     {
         "object": "AsyncQdrantClient",

--- a/packages/opentelemetry-instrumentation-qdrant/tests/test_qdrant_instrumentation.py
+++ b/packages/opentelemetry-instrumentation-qdrant/tests/test_qdrant_instrumentation.py
@@ -1,5 +1,7 @@
+import asyncio
+
 import pytest
-from qdrant_client import QdrantClient, models
+from qdrant_client import AsyncQdrantClient, QdrantClient, models
 from opentelemetry.semconv_ai import SpanAttributes
 
 
@@ -113,6 +115,80 @@ def search_batch(qdrant: QdrantClient):
 def test_qdrant_search(exporter, qdrant):
     upload_collection(qdrant)
     search_batch(qdrant)
+
+    spans = exporter.get_finished_spans()
+    span = next(span for span in spans if span.name == "qdrant.query_batch_points")
+
+    assert (
+        span.attributes.get(SpanAttributes.QDRANT_SEARCH_BATCH_COLLECTION_NAME)
+        == COLLECTION_NAME
+    )
+    assert span.attributes.get(SpanAttributes.QDRANT_SEARCH_BATCH_REQUESTS_COUNT) == 4
+
+
+# --- AsyncQdrantClient coverage for query_points / query_batch_points ---
+#
+# The sync client's query_points / query_batch_points are already wrapped, but
+# AsyncQdrantClient was missing the equivalents in async_qdrant_client_methods.json,
+# so async users got no spans for those calls. These tests pin the parity.
+
+async def _async_setup(client: AsyncQdrantClient) -> None:
+    # `AsyncQdrantClient.upload_collection` runs through a ThreadPoolExecutor
+    # internally and returns None instead of an awaitable, so set up the
+    # fixture data with `upsert` which is genuinely async.
+    await client.create_collection(
+        COLLECTION_NAME,
+        vectors_config=models.VectorParams(
+            size=EMBEDDING_DIM, distance=models.Distance.COSINE
+        ),
+    )
+    await client.upsert(
+        COLLECTION_NAME,
+        points=[
+            models.PointStruct(id=1, vector=[0.1] * EMBEDDING_DIM, payload={"name": "Paul"}),
+            models.PointStruct(id=2, vector=[0.2] * EMBEDDING_DIM, payload={"name": "John"}),
+            models.PointStruct(id=3, vector=[0.3] * EMBEDDING_DIM, payload={}),
+        ],
+    )
+
+
+def test_qdrant_async_query_points(exporter):
+    async def run() -> None:
+        client = AsyncQdrantClient(location=":memory:")
+        await _async_setup(client)
+        await client.query_points(
+            collection_name=COLLECTION_NAME,
+            query=[0.1] * EMBEDDING_DIM,
+            limit=1,
+        )
+
+    asyncio.run(run())
+
+    spans = exporter.get_finished_spans()
+    span = next(span for span in spans if span.name == "qdrant.query_points")
+
+    assert (
+        span.attributes.get(SpanAttributes.QDRANT_SEARCH_COLLECTION_NAME)
+        == COLLECTION_NAME
+    )
+    assert span.attributes.get(SpanAttributes.VECTOR_DB_QUERY_TOP_K) == 1
+
+
+def test_qdrant_async_query_batch_points(exporter):
+    async def run() -> None:
+        client = AsyncQdrantClient(location=":memory:")
+        await _async_setup(client)
+        await client.query_batch_points(
+            collection_name=COLLECTION_NAME,
+            requests=[
+                models.QueryRequest(query=[0.1] * EMBEDDING_DIM, limit=10),
+                models.QueryRequest(query=[0.2] * EMBEDDING_DIM, limit=5),
+                models.QueryRequest(query=[0.42] * EMBEDDING_DIM, limit=2),
+                models.QueryRequest(query=[0.21] * EMBEDDING_DIM, limit=1),
+            ],
+        )
+
+    asyncio.run(run())
 
     spans = exporter.get_finished_spans()
     span = next(span for span in spans if span.name == "qdrant.query_batch_points")

--- a/packages/opentelemetry-instrumentation-qdrant/tests/test_qdrant_instrumentation.py
+++ b/packages/opentelemetry-instrumentation-qdrant/tests/test_qdrant_instrumentation.py
@@ -153,6 +153,8 @@ async def _async_setup(client: AsyncQdrantClient) -> None:
 
 
 def test_qdrant_async_query_points(exporter):
+    exporter.clear()
+
     async def run() -> None:
         client = AsyncQdrantClient(location=":memory:")
         await _async_setup(client)
@@ -175,6 +177,8 @@ def test_qdrant_async_query_points(exporter):
 
 
 def test_qdrant_async_query_batch_points(exporter):
+    exporter.clear()
+
     async def run() -> None:
         client = AsyncQdrantClient(location=":memory:")
         await _async_setup(client)


### PR DESCRIPTION
## Summary

Follow-up to #3492 / #3500 picking up the async-parity gap @kngyeol flagged in the issue thread.

The original crash from `upload_records` is gone since #3500, but the `query_points` / `query_batch_points` mismatch between the sync and async method configs is still present on `main`. Both methods exist on `AsyncQdrantClient` in current `qdrant-client` releases, the sync JSON already lists them, the async JSON does not, so async users get no spans for the modern query APIs.

## Changes

- `async_qdrant_client_methods.json`: add `AsyncQdrantClient.query_points` and `AsyncQdrantClient.query_batch_points` next to the existing `query` / `query_batch` entries, mirroring the sync layout.
- `tests/test_qdrant_instrumentation.py`: add two async tests that drive `query_points` and `query_batch_points` through the in-memory `AsyncQdrantClient`, run via `asyncio.run` (no new test deps), and assert the spans show up with the expected attributes. Used `upsert` for setup since `AsyncQdrantClient.upload_collection` is sync internally and returns `None`.

## Test plan

- [x] `uv run pytest tests/` reports `6 passed` (4 existing sync tests + 2 new async ones).
- [x] `uv run ruff check .` reports `All checks passed!`.
- [x] Verified locally that both methods exist on `AsyncQdrantClient` in current `qdrant-client` so the wrap will not skip them at instrumentation time.

Refs #3492.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry spans for two asynchronous Qdrant query operations: qdrant.query_points and qdrant.query_batch_points, providing clearer tracing and query-specific attributes.

* **Tests**
  * Added tests that run async queries and verify emitted span names and key attributes (collection, top-k, batch count) to ensure telemetry correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->