### PR TITLE
fix: mark tracer disabled when tracing is disabled via env var

### DIFF
--- a/packages/traceloop-sdk/tests/test_sdk_initialization.py
+++ b/packages/traceloop-sdk/tests/test_sdk_initialization.py
@@ -358,3 +358,25 @@ def test_both_exporter_and_processor_warns():
             del TracerWrapper.instance
         if saved_instance is not None:
             TracerWrapper.instance = saved_instance
+
+
+def test_tracing_disabled_via_env_var_is_silent_noop(
+    isolated_tracer_wrapper, monkeypatch, capsys
+):
+    """When tracing is disabled via TRACELOOP_TRACING_ENABLED=false, init() must
+    mark the tracer disabled so @workflow becomes a silent no-op rather than
+    warning that Traceloop was never initialized (issue #4191)."""
+    monkeypatch.setenv("TRACELOOP_TRACING_ENABLED", "false")
+    try:
+        Traceloop.init(app_name="test")
+        assert TracerWrapper.verify_initialized() is False
+
+        @workflow(name="w")
+        def f():
+            return 42
+
+        capsys.readouterr()  # discard init() output
+        assert f() == 42
+        assert "Traceloop not initialized" not in capsys.readouterr().out
+    finally:
+        TracerWrapper.set_disabled(False)

--- a/packages/traceloop-sdk/traceloop/sdk/__init__.py
+++ b/packages/traceloop-sdk/traceloop/sdk/__init__.py
@@ -122,6 +122,10 @@ class Traceloop:
         Traceloop.__app_name = app_name
 
         if not is_tracing_enabled():
+            # Mirror the `enabled=False` path: mark the tracer disabled so the
+            # @workflow/@task decorators become silent no-ops instead of warning
+            # that Traceloop was never initialized.
+            TracerWrapper.set_disabled(True)
             print(Fore.YELLOW + "Tracing is disabled" + Fore.RESET)
             return
 


### PR DESCRIPTION
Fixes #4191.

There are two ways to disable tracing, and they diverge:

- `Traceloop.init(enabled=False)` calls `TracerWrapper.set_disabled(True)` and returns, so `@workflow`/`@task` decorators become clean no-ops (`verify_initialized()` returns `False` early when disabled).
- `TRACELOOP_TRACING_ENABLED=false` just prints `"Tracing is disabled"` and returns **without** `set_disabled(True)`.

So with the env var, `TracerWrapper` is never initialized *and* never marked disabled. Decorated functions then hit the uninitialized branch and spam `Warning: Traceloop not initialized, make sure you call Traceloop.init()`.

The fix calls `TracerWrapper.set_disabled(True)` in the env-var path too, mirroring the `enabled=False` branch.

Added `test_tracing_disabled_via_env_var_is_silent_noop` (in `test_sdk_initialization.py`): with `TRACELOOP_TRACING_ENABLED=false`, after `init()` a `@workflow`-decorated call must not print the "not initialized" warning. It fails before the fix and passes after.

(The issue title says `TRACELOOP_TRACKING_ENABLED`, but the actual env var is `TRACELOOP_TRACING_ENABLED` — the behavior is the same regardless.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SDK to operate silently when tracing is disabled via configuration, preventing unnecessary warnings from decorated functions.

* **Tests**
  * Added test to verify that disabled tracing state allows decorated functions to execute as silent no-ops without initialization warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traceloop/openllmetry/pull/4203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->