### PR TITLE
feat(instrumentation-ollama): map standard GenAI semantic conventions

### DIFF
--- a/packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/span_utils.py
+++ b/packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/span_utils.py
@@ -56,6 +56,22 @@ def set_model_input_attributes(span, kwargs):
     _set_span_attribute(
         span, SpanAttributes.LLM_IS_STREAMING, kwargs.get("stream") or False
     )
+    _set_span_attribute(
+        span, SpanAttributes.GEN_AI_IS_STREAMING, kwargs.get("stream") or False
+    )
+
+    options = json_data.get("options")
+    if isinstance(options, dict):
+        _set_span_attribute(span, GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE, options.get("temperature"))
+        _set_span_attribute(span, GenAIAttributes.GEN_AI_REQUEST_TOP_P, options.get("top_p"))
+        _set_span_attribute(span, GenAIAttributes.GEN_AI_REQUEST_TOP_K, options.get("top_k"))
+        _set_span_attribute(span, SpanAttributes.GEN_AI_REQUEST_REPETITION_PENALTY, options.get("repeat_penalty"))
+        _set_span_attribute(span, GenAIAttributes.GEN_AI_REQUEST_PRESENCE_PENALTY, options.get("presence_penalty"))
+        _set_span_attribute(span, GenAIAttributes.GEN_AI_REQUEST_FREQUENCY_PENALTY, options.get("frequency_penalty"))
+        _set_span_attribute(span, GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS, options.get("num_predict"))
+        stop_seq = options.get("stop")
+        if isinstance(stop_seq, list):
+            _set_span_attribute(span, GenAIAttributes.GEN_AI_REQUEST_STOP_SEQUENCES, tuple(stop_seq))
 
 
 @dont_throw
@@ -110,6 +126,19 @@ def set_model_response_attributes(span, token_histogram, llm_request_type, respo
         input_tokens,
     )
     _set_span_attribute(span, GenAIAttributes.GEN_AI_SYSTEM, "Ollama")
+
+    done_reason = response.get("done_reason")
+    if done_reason is not None:
+        _set_span_attribute(
+            span,
+            SpanAttributes.GEN_AI_RESPONSE_FINISH_REASON,
+            done_reason,
+        )
+        _set_span_attribute(
+            span,
+            GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS,
+            (done_reason,),
+        )
 
     if (
         token_histogram is not None

--- a/packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/span_utils.py
+++ b/packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/span_utils.py
@@ -49,6 +49,7 @@ def set_input_attributes(span, llm_request_type, kwargs):
 
 @dont_throw
 def set_model_input_attributes(span, kwargs):
+    """Set model input and request option attributes for the span from kwargs."""
     if not span.is_recording():
         return
     json_data = kwargs.get("json", {})
@@ -102,6 +103,7 @@ def set_response_attributes(span, token_histogram, llm_request_type, response):
 
 @dont_throw
 def set_model_response_attributes(span, token_histogram, llm_request_type, response):
+    """Set model response and finish reason attributes for the span from response."""
     if llm_request_type == LLMRequestTypeValues.EMBEDDING or not span.is_recording():
         return
 

--- a/packages/opentelemetry-instrumentation-ollama/tests/test_chat.py
+++ b/packages/opentelemetry-instrumentation-ollama/tests/test_chat.py
@@ -46,6 +46,14 @@ def test_ollama_chat_legacy(
     ) == ollama_span.attributes.get(
         GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS
     ) + ollama_span.attributes.get(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS)
+    assert (
+        ollama_span.attributes.get(SpanAttributes.GEN_AI_RESPONSE_FINISH_REASON)
+        == "stop"
+    )
+    assert (
+        ollama_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS)
+        == ("stop",)
+    )
 
     logs = log_exporter.get_finished_logs()
     assert (
@@ -387,6 +395,14 @@ def test_ollama_streaming_chat_legacy(
     ) == ollama_span.attributes.get(
         GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS
     ) + ollama_span.attributes.get(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS)
+    assert (
+        ollama_span.attributes.get(SpanAttributes.GEN_AI_RESPONSE_FINISH_REASON)
+        == "stop"
+    )
+    assert (
+        ollama_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS)
+        == ("stop",)
+    )
 
     logs = log_exporter.get_finished_logs()
     assert (
@@ -533,6 +549,14 @@ async def test_ollama_async_chat_legacy(
     ) == ollama_span.attributes.get(
         GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS
     ) + ollama_span.attributes.get(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS)
+    assert (
+        ollama_span.attributes.get(SpanAttributes.GEN_AI_RESPONSE_FINISH_REASON)
+        == "stop"
+    )
+    assert (
+        ollama_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS)
+        == ("stop",)
+    )
 
     logs = log_exporter.get_finished_logs()
     assert (
@@ -677,6 +701,14 @@ async def test_ollama_async_streaming_chat_legacy(
     ) == ollama_span.attributes.get(
         GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS
     ) + ollama_span.attributes.get(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS)
+    assert (
+        ollama_span.attributes.get(SpanAttributes.GEN_AI_RESPONSE_FINISH_REASON)
+        == "stop"
+    )
+    assert (
+        ollama_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS)
+        == ("stop",)
+    )
 
     logs = log_exporter.get_finished_logs()
     assert (

--- a/packages/opentelemetry-instrumentation-ollama/tests/test_generation.py
+++ b/packages/opentelemetry-instrumentation-ollama/tests/test_generation.py
@@ -37,6 +37,14 @@ def test_ollama_generation_legacy(
     ) == ollama_span.attributes.get(
         GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS
     ) + ollama_span.attributes.get(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS)
+    assert (
+        ollama_span.attributes.get(SpanAttributes.GEN_AI_RESPONSE_FINISH_REASON)
+        == "stop"
+    )
+    assert (
+        ollama_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS)
+        == ("stop",)
+    )
 
     logs = log_exporter.get_finished_logs()
     assert (
@@ -161,6 +169,14 @@ def test_ollama_streaming_generation_legacy(
     ) == ollama_span.attributes.get(
         GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS
     ) + ollama_span.attributes.get(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS)
+    assert (
+        ollama_span.attributes.get(SpanAttributes.GEN_AI_RESPONSE_FINISH_REASON)
+        == "stop"
+    )
+    assert (
+        ollama_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS)
+        == ("stop",)
+    )
 
     logs = log_exporter.get_finished_logs()
     assert (
@@ -293,6 +309,14 @@ async def test_ollama_async_generation_legacy(
     ) == ollama_span.attributes.get(
         GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS
     ) + ollama_span.attributes.get(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS)
+    assert (
+        ollama_span.attributes.get(SpanAttributes.GEN_AI_RESPONSE_FINISH_REASON)
+        == "stop"
+    )
+    assert (
+        ollama_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS)
+        == ("stop",)
+    )
 
     logs = log_exporter.get_finished_logs()
     assert (
@@ -425,6 +449,14 @@ async def test_ollama_async_streaming_generation_legacy(
     ) == ollama_span.attributes.get(
         GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS
     ) + ollama_span.attributes.get(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS)
+    assert (
+        ollama_span.attributes.get(SpanAttributes.GEN_AI_RESPONSE_FINISH_REASON)
+        == "stop"
+    )
+    assert (
+        ollama_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS)
+        == ("stop",)
+    )
 
     logs = log_exporter.get_finished_logs()
     assert (

--- a/packages/opentelemetry-instrumentation-ollama/tests/test_semantic_conventions.py
+++ b/packages/opentelemetry-instrumentation-ollama/tests/test_semantic_conventions.py
@@ -10,6 +10,7 @@ from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
 
 
 def test_set_model_input_attributes_semantic_conventions():
+    """Test mapping of standard GenAI input semantic conventions for Ollama."""
     span = MagicMock()
     span.is_recording.return_value = True
 
@@ -49,6 +50,7 @@ def test_set_model_input_attributes_semantic_conventions():
 
 
 def test_set_model_response_attributes_semantic_conventions():
+    """Test mapping of standard GenAI response semantic conventions for Ollama."""
     span = MagicMock()
     span.is_recording.return_value = True
 

--- a/packages/opentelemetry-instrumentation-ollama/tests/test_semantic_conventions.py
+++ b/packages/opentelemetry-instrumentation-ollama/tests/test_semantic_conventions.py
@@ -1,0 +1,71 @@
+from unittest.mock import MagicMock
+from opentelemetry.instrumentation.ollama.span_utils import (
+    set_model_input_attributes,
+    set_model_response_attributes,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
+
+
+def test_set_model_input_attributes_semantic_conventions():
+    span = MagicMock()
+    span.is_recording.return_value = True
+
+    kwargs = {
+        "json": {
+            "model": "llama3",
+            "options": {
+                "temperature": 0.7,
+                "top_p": 0.9,
+                "top_k": 40,
+                "repeat_penalty": 1.1,
+                "presence_penalty": 0.0,
+                "frequency_penalty": 0.0,
+                "num_predict": 128,
+                "stop": ["\n", "User:"],
+            },
+        },
+        "stream": True,
+    }
+
+    set_model_input_attributes(span, kwargs)
+
+    # Verify standard model attributes
+    span.set_attribute.assert_any_call(GenAIAttributes.GEN_AI_REQUEST_MODEL, "llama3")
+    span.set_attribute.assert_any_call(SpanAttributes.LLM_IS_STREAMING, True)
+    span.set_attribute.assert_any_call(SpanAttributes.GEN_AI_IS_STREAMING, True)
+
+    # Verify request options
+    span.set_attribute.assert_any_call(GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE, 0.7)
+    span.set_attribute.assert_any_call(GenAIAttributes.GEN_AI_REQUEST_TOP_P, 0.9)
+    span.set_attribute.assert_any_call(GenAIAttributes.GEN_AI_REQUEST_TOP_K, 40)
+    span.set_attribute.assert_any_call(SpanAttributes.GEN_AI_REQUEST_REPETITION_PENALTY, 1.1)
+    span.set_attribute.assert_any_call(GenAIAttributes.GEN_AI_REQUEST_PRESENCE_PENALTY, 0.0)
+    span.set_attribute.assert_any_call(GenAIAttributes.GEN_AI_REQUEST_FREQUENCY_PENALTY, 0.0)
+    span.set_attribute.assert_any_call(GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS, 128)
+    span.set_attribute.assert_any_call(GenAIAttributes.GEN_AI_REQUEST_STOP_SEQUENCES, ("\n", "User:"))
+
+
+def test_set_model_response_attributes_semantic_conventions():
+    span = MagicMock()
+    span.is_recording.return_value = True
+
+    response = {
+        "model": "llama3",
+        "prompt_eval_count": 10,
+        "eval_count": 20,
+        "done_reason": "stop",
+    }
+
+    set_model_response_attributes(span, None, LLMRequestTypeValues.CHAT, response)
+
+    span.set_attribute.assert_any_call(GenAIAttributes.GEN_AI_RESPONSE_MODEL, "llama3")
+    span.set_attribute.assert_any_call(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS, 10)
+    span.set_attribute.assert_any_call(GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS, 20)
+    span.set_attribute.assert_any_call(SpanAttributes.LLM_USAGE_TOTAL_TOKENS, 30)
+
+    # Verify finish reasons
+    span.set_attribute.assert_any_call(SpanAttributes.GEN_AI_RESPONSE_FINISH_REASON, "stop")
+    span.set_attribute.assert_any_call(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS, ("stop",))


### PR DESCRIPTION
## Summary
Adds standard OpenTelemetry GenAI semantic conventions mapping for request options and response finish reasons to Ollama tracing spans.
Added attributes:
- gen_ai.request.temperature
- gen_ai.request.top_p
- gen_ai.request.top_k
- gen_ai.request.repetition_penalty
- gen_ai.request.presence_penalty
- gen_ai.request.frequency_penalty
- gen_ai.request.max_tokens (mapped from num_predict)
- gen_ai.request.stop_sequences (mapped from stop)
- gen_ai.response.finish_reason (mapped from done_reason)
- gen_ai.response.finish_reasons
## Changes
- Extended `set_model_input_attributes()` in `span_utils.py` to map inputs/options parameter telemetry fields from Ollama requests.
- Extended `set_model_response_attributes()` in `span_utils.py` to map output `done_reason` to `finish_reason` / `finish_reasons`.
- Created dedicated unit tests in `test_semantic_conventions.py` using Mocks.
- Extended existing integration VCR tests in `test_chat.py` and `test_generation.py` with assertions for response finish reasons.
## Verification
Verified locally through the test suite:
- Ran `npx nx run opentelemetry-instrumentation-ollama:test` (all 42 unit and VCR integration tests passed).
- Ran `npx nx run opentelemetry-instrumentation-ollama:lint` (all Ruff checks passed).
---
- [x] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced telemetry for Ollama instrumentation: spans now include streaming status, generation options (temperature, top-p, top-k, repetition/presence/frequency penalties, max tokens, stop sequences), and response finish-reason attributes for improved observability.

* **Tests**
  * Expanded test coverage validating new semantic-convention span attributes across legacy, sync/async, and streaming flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->