### PR TITLE
fix(vertexai): re-enable integration tests with offline SDK mocks

### DIFF
--- a/packages/opentelemetry-instrumentation-vertexai/opentelemetry/instrumentation/vertexai/__init__.py
+++ b/packages/opentelemetry-instrumentation-vertexai/opentelemetry/instrumentation/vertexai/__init__.py
@@ -1,5 +1,6 @@
 """OpenTelemetry Vertex AI instrumentation"""
 
+import inspect
 import logging
 import types
 from typing import Collection
@@ -151,7 +152,7 @@ def _build_from_streaming_response(span, event_logger, response, llm_model):
     for item in response:
         item_to_yield = item
         complete_response += str(item.text)
-        if item.usage_metadata:
+        if getattr(item, "usage_metadata", None):
             token_usage = item.usage_metadata
 
         yield item_to_yield
@@ -170,12 +171,12 @@ async def _abuild_from_streaming_response(span, event_logger, response, llm_mode
     async for item in response:
         item_to_yield = item
         complete_response += str(item.text)
-        if item.usage_metadata:
+        if getattr(item, "usage_metadata", None):
             token_usage = item.usage_metadata
 
         yield item_to_yield
 
-    handle_streaming_response(span, event_logger, llm_model, response, token_usage)
+    handle_streaming_response(span, event_logger, llm_model, complete_response, token_usage)
 
     span.set_status(Status(StatusCode.OK))
     span.end()
@@ -191,13 +192,16 @@ async def _handle_request(span, event_logger, args, kwargs, llm_model):
 
 
 def _handle_response(span, event_logger, response, llm_model):
-    set_model_response_attributes(span, llm_model, response.usage_metadata)
+    token_usage = getattr(response, "usage_metadata", None)
+    set_model_response_attributes(span, llm_model, token_usage)
     if should_emit_events():
         emit_response_events(response, event_logger)
     else:
-        set_response_attributes(
-            span, llm_model, response.candidates[0].text if response.candidates else ""
-        )
+        generation_text = getattr(response, "text", "") or ""
+        if not generation_text and getattr(response, "candidates", None):
+            first_candidate = response.candidates[0]
+            generation_text = getattr(first_candidate, "text", str(first_candidate))
+        set_response_attributes(span, llm_model, generation_text)
     if span.is_recording():
         span.set_status(Status(StatusCode.OK))
 
@@ -245,7 +249,11 @@ async def _awrap(tracer, event_logger, to_wrap, wrapped, instance, args, kwargs)
 
     await _handle_request(span, event_logger, args, kwargs, llm_model)
 
-    response = await wrapped(*args, **kwargs)
+    result = wrapped(*args, **kwargs)
+    if inspect.isasyncgen(result):
+        response = result
+    else:
+        response = await result
 
     if response:
         if is_streaming_response(response):

--- a/packages/opentelemetry-instrumentation-vertexai/tests/mocks.py
+++ b/packages/opentelemetry-instrumentation-vertexai/tests/mocks.py
@@ -1,0 +1,189 @@
+"""Offline mocks for Vertex AI SDK calls (no GCP credentials or network required)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from google.cloud.aiplatform import models as aiplatform_models
+from vertexai.generative_models import GenerationResponse
+from vertexai.language_models import ChatModel, TextGenerationModel
+from vertexai.preview.generative_models import GenerativeModel
+
+BISON_COMPLETION = (
+    "1. Tell me about a time you led a cross-functional project.\n"
+    "2. How do you handle conflicting priorities?\n"
+)
+BISON_STREAM_CHUNKS = ["1. Tell me ", "about a time ", "you led a project."]
+CHAT_COMPLETION = "There are eight planets in the solar system."
+CHAT_STREAM_CHUNKS = ["There are ", "eight planets ", "in the solar system."]
+GEMINI_COMPLETION = "A plate of scones on a table."
+GEMINI_USAGE = SimpleNamespace(
+    total_token_count=100,
+    prompt_token_count=60,
+    candidates_token_count=40,
+)
+
+
+class FakeGeminiCandidate:
+    def __init__(self, text: str, index: int = 0, finish_reason_value: int = 1):
+        self.text = text
+        self.index = index
+        self.finish_reason = SimpleNamespace(value=finish_reason_value)
+
+
+class FakeGeminiResponse(GenerationResponse):
+    """Minimal GenerationResponse for offline tests and event emission."""
+
+    def __init__(self, text: str = GEMINI_COMPLETION, usage: SimpleNamespace = GEMINI_USAGE):
+        self._text = text
+        self._usage = usage
+        self._candidates = [FakeGeminiCandidate(text)]
+        self._raw_response = SimpleNamespace(usage_metadata=usage)
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+    @property
+    def candidates(self):
+        return self._candidates
+
+    @property
+    def usage_metadata(self):
+        return self._usage
+
+
+def _make_bison_prediction_dict(content: str) -> dict:
+    return {
+        "content": content,
+        "safetyAttributes": {
+            "blocked": False,
+            "errors": [],
+            "categories": [],
+            "scores": [],
+        },
+    }
+
+
+def _make_chat_prediction_dict(content: str) -> dict:
+    return {
+        "candidates": [{"content": content}],
+        "safetyAttributes": [
+            {
+                "blocked": False,
+                "errors": [],
+                "categories": [],
+                "scores": [],
+            }
+        ],
+    }
+
+
+def make_bison_prediction(content: str) -> aiplatform_models.Prediction:
+    return aiplatform_models.Prediction(
+        predictions=[_make_bison_prediction_dict(content)],
+        deployed_model_id="",
+    )
+
+
+def make_chat_prediction(content: str) -> aiplatform_models.Prediction:
+    return aiplatform_models.Prediction(
+        predictions=[_make_chat_prediction_dict(content)],
+        deployed_model_id="",
+    )
+
+
+def make_text_generation_model(model_id: str) -> TextGenerationModel:
+    model = object.__new__(TextGenerationModel)
+    model._model_id = model_id
+    model._endpoint = MagicMock()
+    model._endpoint_name = (
+        f"projects/test/locations/us-central1/publishers/google/models/{model_id}"
+    )
+    model._endpoint._prediction_client = MagicMock()
+    model._endpoint._prediction_async_client = MagicMock()
+    return model
+
+
+def make_chat_model(model_id: str) -> ChatModel:
+    model = object.__new__(ChatModel)
+    model._model_id = model_id
+    model._endpoint = MagicMock()
+    model._endpoint_name = (
+        f"projects/test/locations/us-central1/publishers/google/models/{model_id}"
+    )
+    model._endpoint._prediction_client = MagicMock()
+    return model
+
+
+def _fake_generative_model_init(self, model_name, **_kwargs):
+    self._model_name = model_name
+
+
+def patch_text_generation_from_pretrained():
+    def _from_pretrained(cls, model_name, **_kwargs):
+        return make_text_generation_model(model_name)
+
+    return patch.object(TextGenerationModel, "from_pretrained", classmethod(_from_pretrained))
+
+
+def patch_chat_from_pretrained():
+    def _from_pretrained(cls, model_name, **_kwargs):
+        return make_chat_model(model_name)
+
+    return patch.object(ChatModel, "from_pretrained", classmethod(_from_pretrained))
+
+
+def configure_predict(model: TextGenerationModel, content: str = BISON_COMPLETION):
+    model._endpoint.predict.return_value = make_bison_prediction(content)
+
+
+def configure_predict_async(model: TextGenerationModel, content: str = BISON_COMPLETION):
+    model._endpoint.predict_async = AsyncMock(
+        return_value=make_bison_prediction(content)
+    )
+
+
+def configure_chat_predict(model: ChatModel, content: str = CHAT_COMPLETION):
+    model._endpoint.predict.return_value = make_chat_prediction(content)
+
+
+def patch_bison_streaming(chunks: list[str]):
+    dicts = [_make_bison_prediction_dict(chunk) for chunk in chunks]
+    return patch(
+        "vertexai.language_models._language_models._streaming_prediction"
+        ".predict_stream_of_dicts_from_single_dict",
+        return_value=iter(dicts),
+    )
+
+
+def patch_bison_streaming_async(chunks: list[str]):
+    dicts = [_make_bison_prediction_dict(chunk) for chunk in chunks]
+
+    async def _async_stream(**_kwargs):
+        for item in dicts:
+            yield item
+
+    return patch(
+        "vertexai.language_models._language_models._streaming_prediction"
+        ".predict_stream_of_dicts_from_single_dict_async",
+        new=_async_stream,
+    )
+
+
+def patch_chat_streaming(chunks: list[str]):
+    dicts = [_make_chat_prediction_dict(chunk) for chunk in chunks]
+    return patch(
+        "vertexai.language_models._language_models._streaming_prediction"
+        ".predict_stream_of_dicts_from_single_dict",
+        return_value=iter(dicts),
+    )
+
+
+def patch_gemini_generate_content(response=None):
+    if response is None:
+        response = FakeGeminiResponse()
+    return patch.multiple(
+        GenerativeModel,
+        __init__=_fake_generative_model_init,
+        _generate_content=MagicMock(return_value=response),
+    )

--- a/packages/opentelemetry-instrumentation-vertexai/tests/test_bison.py
+++ b/packages/opentelemetry-instrumentation-vertexai/tests/test_bison.py
@@ -1,20 +1,31 @@
 import asyncio
 
-import pytest
 import vertexai
 from opentelemetry.sdk._logs import ReadableLogRecord
-from opentelemetry.semconv._incubating.attributes import (
-    event_attributes as EventAttributes,
-)
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
 from vertexai.language_models import ChatModel, InputOutputTextPair, TextGenerationModel
 
+from tests.mocks import (
+    BISON_STREAM_CHUNKS,
+    CHAT_STREAM_CHUNKS,
+    configure_chat_predict,
+    configure_predict,
+    configure_predict_async,
+    patch_bison_streaming,
+    patch_bison_streaming_async,
+    patch_chat_from_pretrained,
+    patch_chat_streaming,
+    patch_text_generation_from_pretrained,
+)
+
 vertexai.init()
 
+PROMPT = "Give me ten interview questions for the role of program manager."
+CHAT_MESSAGE = "How many planets are there in the solar system?"
 
-@pytest.mark.vcr
+
 def test_vertexai_predict(instrument_legacy, span_exporter, log_exporter):
     parameters = {
         "max_output_tokens": 256,
@@ -22,11 +33,10 @@ def test_vertexai_predict(instrument_legacy, span_exporter, log_exporter):
         "top_k": 40,
     }
 
-    model = TextGenerationModel.from_pretrained("text-bison@001")
-    response = model.predict(
-        "Give me ten interview questions for the role of program manager.",
-        **parameters,
-    )
+    with patch_text_generation_from_pretrained():
+        model = TextGenerationModel.from_pretrained("text-bison@001")
+        configure_predict(model)
+        response = model.predict(PROMPT, **parameters)
 
     response = response.text
 
@@ -39,10 +49,7 @@ def test_vertexai_predict(instrument_legacy, span_exporter, log_exporter):
     assert (
         vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL] == "text-bison@001"
     )
-    assert (
-        "Give me ten interview questions for the role of program manager."
-        in vertexai_span.attributes[f"{GenAIAttributes.GEN_AI_PROMPT}.0.user"]
-    )
+    assert PROMPT in vertexai_span.attributes[f"{GenAIAttributes.GEN_AI_PROMPT}.0.content"]
     assert vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_P] == 0.8
     assert vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS] == 256
     assert vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_K] == 40
@@ -52,22 +59,18 @@ def test_vertexai_predict(instrument_legacy, span_exporter, log_exporter):
     )
 
 
-@pytest.mark.vcr
 def test_vertexai_predict_async(instrument_legacy, span_exporter, log_exporter):
     async def async_predict_text() -> str:
-        """Ideation example with a Large Language Model"""
-
         parameters = {
             "max_output_tokens": 256,
             "top_p": 0.8,
             "top_k": 40,
         }
 
-        model = TextGenerationModel.from_pretrained("text-bison@001")
-        response = await model.predict_async(
-            "Give me ten interview questions for the role of program manager.",
-            **parameters,
-        )
+        with patch_text_generation_from_pretrained():
+            model = TextGenerationModel.from_pretrained("text-bison@001")
+            configure_predict_async(model)
+            response = await model.predict_async(PROMPT, **parameters)
 
         return response.text
 
@@ -75,17 +78,14 @@ def test_vertexai_predict_async(instrument_legacy, span_exporter, log_exporter):
 
     spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
-        "vertexai.predict",
+        "vertexai.predict_async",
     ]
 
     vertexai_span = spans[0]
     assert (
         vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL] == "text-bison@001"
     )
-    assert (
-        "Give me ten interview questions for the role of program manager."
-        in vertexai_span.attributes[f"{GenAIAttributes.GEN_AI_PROMPT}.0.user"]
-    )
+    assert PROMPT in vertexai_span.attributes[f"{GenAIAttributes.GEN_AI_PROMPT}.0.content"]
     assert vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_P] == 0.8
     assert vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS] == 256
     assert vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_K] == 40
@@ -95,73 +95,66 @@ def test_vertexai_predict_async(instrument_legacy, span_exporter, log_exporter):
     )
 
 
-@pytest.mark.vcr
 def test_vertexai_stream(instrument_legacy, span_exporter, log_exporter):
-    text_generation_model = TextGenerationModel.from_pretrained("text-bison")
     parameters = {
         "max_output_tokens": 256,
         "top_p": 0.8,
         "top_k": 40,
     }
-    responses = text_generation_model.predict_streaming(
-        prompt="Give me ten interview questions for the role of program manager.",
-        **parameters,
-    )
 
-    result = [response.text for response in responses]
-    response = result
+    with (
+        patch_text_generation_from_pretrained(),
+        patch_bison_streaming(BISON_STREAM_CHUNKS),
+    ):
+        text_generation_model = TextGenerationModel.from_pretrained("text-bison")
+        responses = text_generation_model.predict_streaming(prompt=PROMPT, **parameters)
+        result = [response.text for response in responses]
 
     spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
-        "vertexai.predict",
+        "vertexai.predict_streaming",
     ]
 
     vertexai_span = spans[0]
     assert vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL] == "text-bison"
-    assert (
-        "Give me ten interview questions for the role of program manager."
-        in vertexai_span.attributes[f"{GenAIAttributes.GEN_AI_PROMPT}.0.user"]
-    )
+    assert PROMPT in vertexai_span.attributes[f"{GenAIAttributes.GEN_AI_PROMPT}.0.user"]
     assert vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_P] == 0.8
     assert vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS] == 256
     assert vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_K] == 40
     assert vertexai_span.attributes[
         f"{GenAIAttributes.GEN_AI_COMPLETION}.0.content"
-    ] == "".join(response)
+    ] == "".join(result)
 
 
-@pytest.mark.vcr
 def test_vertexai_stream_async(instrument_legacy, span_exporter, log_exporter):
     async def async_streaming_prediction() -> list:
-        """Streaming Text Example with a Large Language Model"""
-
-        text_generation_model = TextGenerationModel.from_pretrained("text-bison")
         parameters = {
             "max_output_tokens": 256,
             "top_p": 0.8,
             "top_k": 40,
         }
 
-        responses = text_generation_model.predict_streaming_async(
-            prompt="Give me ten interview questions for the role of program manager.",
-            **parameters,
-        )
-        result = [response.text async for response in responses]
+        with (
+            patch_text_generation_from_pretrained(),
+            patch_bison_streaming_async(BISON_STREAM_CHUNKS),
+        ):
+            text_generation_model = TextGenerationModel.from_pretrained("text-bison")
+            responses = await text_generation_model.predict_streaming_async(
+                prompt=PROMPT, **parameters
+            )
+            result = [response.text async for response in responses]
         return result
 
     response = asyncio.run(async_streaming_prediction())
 
     spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
-        "vertexai.predict",
+        "vertexai.predict_streaming_async",
     ]
 
     vertexai_span = spans[0]
     assert vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL] == "text-bison"
-    assert (
-        "Give me ten interview questions for the role of program manager."
-        in vertexai_span.attributes[f"{GenAIAttributes.GEN_AI_PROMPT}.0.user"]
-    )
+    assert PROMPT in vertexai_span.attributes[f"{GenAIAttributes.GEN_AI_PROMPT}.0.user"]
     assert vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_P] == 0.8
     assert vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS] == 256
     assert vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_K] == 40
@@ -170,29 +163,26 @@ def test_vertexai_stream_async(instrument_legacy, span_exporter, log_exporter):
     ] == "".join(response)
 
 
-@pytest.mark.vcr
 def test_vertexai_chat(instrument_legacy, span_exporter, log_exporter):
-    chat_model = ChatModel.from_pretrained("chat-bison@001")
-
     parameters = {
         "max_output_tokens": 256,
         "top_p": 0.95,
         "top_k": 40,
     }
 
-    chat = chat_model.start_chat(
-        context="My name is Miles. You are an astronomer, knowledgeable about the solar system.",
-        examples=[
-            InputOutputTextPair(
-                input_text="How many moons does Mars have?",
-                output_text="The planet Mars has two moons, Phobos and Deimos.",
-            ),
-        ],
-    )
-
-    response = chat.send_message(
-        "How many planets are there in the solar system?", **parameters
-    )
+    with patch_chat_from_pretrained():
+        chat_model = ChatModel.from_pretrained("chat-bison@001")
+        configure_chat_predict(chat_model)
+        chat = chat_model.start_chat(
+            context="My name is Miles. You are an astronomer, knowledgeable about the solar system.",
+            examples=[
+                InputOutputTextPair(
+                    input_text="How many moons does Mars have?",
+                    output_text="The planet Mars has two moons, Phobos and Deimos.",
+                ),
+            ],
+        )
+        response = chat.send_message(CHAT_MESSAGE, **parameters)
 
     response = response.text
 
@@ -206,8 +196,8 @@ def test_vertexai_chat(instrument_legacy, span_exporter, log_exporter):
         vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL] == "chat-bison@001"
     )
     assert (
-        "How many planets are there in the solar system?"
-        in vertexai_span.attributes[f"{GenAIAttributes.GEN_AI_PROMPT}.0.user"]
+        CHAT_MESSAGE
+        in vertexai_span.attributes[f"{GenAIAttributes.GEN_AI_PROMPT}.0.content"]
     )
     assert vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_P] == 0.95
     assert vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS] == 256
@@ -218,10 +208,7 @@ def test_vertexai_chat(instrument_legacy, span_exporter, log_exporter):
     )
 
 
-@pytest.mark.vcr
 def test_vertexai_chat_stream(instrument_legacy, span_exporter, log_exporter):
-    chat_model = ChatModel.from_pretrained("chat-bison@001")
-
     parameters = {
         "temperature": 0.8,
         "max_output_tokens": 256,
@@ -229,26 +216,26 @@ def test_vertexai_chat_stream(instrument_legacy, span_exporter, log_exporter):
         "top_k": 40,
     }
 
-    chat = chat_model.start_chat(
-        context="My name is Miles. You are an astronomer, knowledgeable about the solar system.",
-        examples=[
-            InputOutputTextPair(
-                input_text="How many moons does Mars have?",
-                output_text="The planet Mars has two moons, Phobos and Deimos.",
-            ),
-        ],
-    )
-
-    responses = chat.send_message_streaming(
-        message="How many planets are there in the solar system?", **parameters
-    )
-
-    result = [response.text for response in responses]
-    response = result
+    with (
+        patch_chat_from_pretrained(),
+        patch_chat_streaming(CHAT_STREAM_CHUNKS),
+    ):
+        chat_model = ChatModel.from_pretrained("chat-bison@001")
+        chat = chat_model.start_chat(
+            context="My name is Miles. You are an astronomer, knowledgeable about the solar system.",
+            examples=[
+                InputOutputTextPair(
+                    input_text="How many moons does Mars have?",
+                    output_text="The planet Mars has two moons, Phobos and Deimos.",
+                ),
+            ],
+        )
+        responses = chat.send_message_streaming(message=CHAT_MESSAGE, **parameters)
+        result = [response.text for response in responses]
 
     spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
-        "vertexai.send_message",
+        "vertexai.send_message_streaming",
     ]
 
     vertexai_span = spans[0]
@@ -261,11 +248,11 @@ def test_vertexai_chat_stream(instrument_legacy, span_exporter, log_exporter):
     assert vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_K] == 40
     assert vertexai_span.attributes[
         f"{GenAIAttributes.GEN_AI_COMPLETION}.0.content"
-    ] == "".join(response)
+    ] == "".join(result)
 
 
 def assert_message_in_logs(log: ReadableLogRecord, event_name: str, expected_content: dict):
-    assert log.log_record.attributes.get(EventAttributes.EVENT_NAME) == event_name
+    assert log.log_record.event_name == event_name
     assert (
         log.log_record.attributes.get(GenAIAttributes.GEN_AI_SYSTEM)
         == GenAIAttributes.GenAiSystemValues.VERTEX_AI.value

--- a/packages/opentelemetry-instrumentation-vertexai/tests/test_gemini.py
+++ b/packages/opentelemetry-instrumentation-vertexai/tests/test_gemini.py
@@ -1,28 +1,27 @@
 import vertexai
 from opentelemetry.sdk._logs import ReadableLogRecord
 from opentelemetry.semconv._incubating.attributes import (
-    event_attributes as EventAttributes,
-)
-from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
 from opentelemetry.semconv_ai import SpanAttributes
 from vertexai.preview.generative_models import GenerativeModel, Part
 
+from tests.mocks import patch_gemini_generate_content
+
 vertexai.init()
+
+GEMINI_PROMPT = "what is shown in this image?"
+GEMINI_IMAGE_URI = "gs://generativeai-downloads/images/scones.jpg"
+GEMINI_CONTENT = [
+    Part.from_uri(GEMINI_IMAGE_URI, mime_type="image/jpeg"),
+    GEMINI_PROMPT,
+]
 
 
 def test_vertexai_generate_content(instrument_legacy, span_exporter, log_exporter):
-    multimodal_model = GenerativeModel("gemini-2.0-flash-lite")
-    response = multimodal_model.generate_content(
-        [
-            Part.from_uri(
-                "gs://generativeai-downloads/images/scones.jpg",
-                mime_type="image/jpeg",
-            ),
-            "what is shown in this image?",
-        ]
-    )
+    with patch_gemini_generate_content():
+        multimodal_model = GenerativeModel("gemini-2.0-flash-lite")
+        response = multimodal_model.generate_content(GEMINI_CONTENT)
 
     spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
@@ -30,10 +29,9 @@ def test_vertexai_generate_content(instrument_legacy, span_exporter, log_exporte
     ]
 
     vertexai_span = spans[0]
-    assert (
-        "what is shown in this image?"
-        in vertexai_span.attributes[f"{GenAIAttributes.GEN_AI_PROMPT}.0.user"]
-    )
+    assert GEMINI_PROMPT in vertexai_span.attributes[
+        f"{GenAIAttributes.GEN_AI_PROMPT}.0.content"
+    ]
     assert (
         vertexai_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]
         == "gemini-2.0-flash-lite"
@@ -61,20 +59,12 @@ def test_vertexai_generate_content(instrument_legacy, span_exporter, log_exporte
     ), "Assert that it doesn't emit logs when use_legacy_attributes is True"
 
 
-# @pytest.mark.vcr
 def test_vertexai_generate_content_with_events_with_content(
     instrument_with_content, span_exporter, log_exporter
 ):
-    multimodal_model = GenerativeModel("gemini-2.0-flash-lite")
-    response = multimodal_model.generate_content(
-        [
-            Part.from_uri(
-                "gs://generativeai-downloads/images/scones.jpg",
-                mime_type="image/jpeg",
-            ),
-            "what is shown in this image?",
-        ]
-    )
+    with patch_gemini_generate_content():
+        multimodal_model = GenerativeModel("gemini-2.0-flash-lite")
+        response = multimodal_model.generate_content(GEMINI_CONTENT)
 
     spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
@@ -103,17 +93,15 @@ def test_vertexai_generate_content_with_events_with_content(
     logs = log_exporter.get_finished_logs()
     assert len(logs) == 2
 
-    # Validate user message Event
     assert_message_in_logs(
         logs[0],
         "gen_ai.user.message",
         {
             "content": 'file_data {\n  mime_type: "image/jpeg"\n  file_uri: '
-            '"gs://generativeai-downloads/images/scones.jpg"\n}\n\nwhat is shown in this image?\n'
+            f'"{GEMINI_IMAGE_URI}"\n}}\n\n{GEMINI_PROMPT}\n'
         },
     )
 
-    # Validate the ai response
     choice_event = {
         "index": 0,
         "finish_reason": "stop",
@@ -125,16 +113,9 @@ def test_vertexai_generate_content_with_events_with_content(
 def test_vertexai_generate_content_with_events_with_no_content(
     instrument_with_no_content, span_exporter, log_exporter
 ):
-    multimodal_model = GenerativeModel("gemini-2.0-flash-lite")
-    response = multimodal_model.generate_content(
-        [
-            Part.from_uri(
-                "gs://generativeai-downloads/images/scones.jpg",
-                mime_type="image/jpeg",
-            ),
-            "what is shown in this image?",
-        ]
-    )
+    with patch_gemini_generate_content():
+        multimodal_model = GenerativeModel("gemini-2.0-flash-lite")
+        response = multimodal_model.generate_content(GEMINI_CONTENT)
 
     spans = span_exporter.get_finished_spans()
     assert [span.name for span in spans] == [
@@ -163,16 +144,14 @@ def test_vertexai_generate_content_with_events_with_no_content(
     logs = log_exporter.get_finished_logs()
     assert len(logs) == 2
 
-    # Validate user message Event
     assert_message_in_logs(logs[0], "gen_ai.user.message", {})
 
-    # Validate the ai response
     choice_event = {"index": 0, "finish_reason": "stop", "message": {}}
     assert_message_in_logs(logs[1], "gen_ai.choice", choice_event)
 
 
 def assert_message_in_logs(log: ReadableLogRecord, event_name: str, expected_content: dict):
-    assert log.log_record.attributes.get(EventAttributes.EVENT_NAME) == event_name
+    assert log.log_record.event_name == event_name
     assert (
         log.log_record.attributes.get(GenAIAttributes.GEN_AI_SYSTEM)
         == GenAIAttributes.GenAiSystemValues.VERTEX_AI.value


### PR DESCRIPTION
## Summary
- Re-enables 9 disabled VertexAI integration tests using offline SDK mocks instead of VCR (gRPC is not supported by vcr.py)
- Adds `tests/mocks.py` with fake Bison/Gemini responses; tests run without GCP credentials or network calls
- Fixes instrumentation edge cases for Bison response shapes, async streaming generators, and streaming completion handling


Fixes #417

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [x] I have added tests that cover my changes.
- [x] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [x] (If applicable) I have updated the documentation accordingly.
