### PR TITLE
fix(anthropic): replace  guard with truthiness check to prevent NOT_G…

### DIFF
--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/event_emitter.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/event_emitter.py
@@ -51,7 +51,7 @@ def emit_input_events(event_logger: Optional[Logger], kwargs):
                 MessageEvent(content=message.get("content"), role=message.get("role")),
                 event_logger,
             )
-    if kwargs.get("tools") is not None:
+    if kwargs.get("tools"):
         emit_event(
             MessageEvent(content={"tools": kwargs.get("tools")}, role="user"),
             event_logger,

--- a/packages/opentelemetry-instrumentation-anthropic/tests/cassettes/test_messages/test_anthropic_message_create_without_tools_no_sentinel_leak.yaml
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/cassettes/test_messages/test_anthropic_message_create_without_tools_no_sentinel_leak.yaml
@@ -1,0 +1,92 @@
+interactions:
+- request:
+    body: '{"max_tokens": 1024, "messages": [{"role": "user", "content": "Tell me
+      a joke about OpenTelemetry"}], "model": "claude-3-opus-20240229"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '136'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.21.3
+      x-stainless-arch:
+      - other:amd64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Windows
+      x-stainless-package-version:
+      - 0.21.3
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.9.13
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5SUwW7cRgyGX4WZi1tAazjboml1KVIghxyMuqiBFogKY1biSvSOhhOSo7Vg+N2L
+        md24dpBLTwI4HPL/P3L06GhwrZt1vLt6e3vz93S44Z/v15/WP67lerpP9P6Da5ytCUsWqvoRXeOE
+        Qwl4VVLz0Vzjeo6G0Vz76fFLvuFDOamf1v2ZBRuYUPBCwcM9HxD8jrPB7wnjLQac0WRtu9jFv6YV
+        BhrAJoQBFwycUMAPnL7K/rWLv2Hvs2LJXeHoo+EAxmDi+xokATVMCj4OMKOhnKNJeBRUfVM6fnhI
+        wUdvxLHt4qseQOUucMK4Uc7SI/BOURa/o0C2wl78jEeWA9jkrdRdaMBiUtGA9/D+5qM2EGgnXgi1
+        qVKMOWhRSlFN8ozRGhgxonjDBnoOAXs75eJDYjGwZ0mDNw/fVY/aFFdC/blu4FG/hz0LDKQmtMuF
+        iK5qOOsl3E54Yp+CXxU4VshHlkGhc7Vi52qhzlVaTefgOFE/gReEA67Qc+wxmQLF19O4LCQ30Lnb
+        r+F3DgT3KNXwS12lIcWxObeguHBYUEGwZxkojlVe8jYVkB4EP2dUA69AVm4vWChOwnmcCvHqs+TO
+        1AuXMVGPennSdf2N8b+S9kzyP8efs49G5o0WhBm9ZsEyLD0JOjW8UEgoe5bZxx4rvh1OfiGWCuWZ
+        uuZxRDU9rco39huH10yLqtFThB1aEb+Q0nnvSpccB5TyBisr3p/N+ZQC9XWdL/RZSr3xQmcD91kN
+        Ah0QJj4CR4SZxsn+x+spSyDoAwTa46V7+qdxMw8YXOv64POAmx82nLJutlfbH6+2219c49Q43Ql6
+        5ehah3G4syzxy4GWEcceXRtzCI3L9afTPjqKKdud8QGjuvbtu8Zxtpeh7fbq6elfAAAA//8DALAq
+        KXrTBAAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 87084f30df5f31f7-LAX
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 07 Apr 2024 07:30:05 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      anthropic-ratelimit-requests-limit:
+      - '5'
+      anthropic-ratelimit-requests-remaining:
+      - '5'
+      anthropic-ratelimit-requests-reset:
+      - '2024-04-07T07:31:00Z'
+      anthropic-ratelimit-tokens-limit:
+      - '10000'
+      anthropic-ratelimit-tokens-remaining:
+      - '10000'
+      anthropic-ratelimit-tokens-reset:
+      - '2024-04-07T07:31:00Z'
+      request-id:
+      - req_01A7u6aDNi2C6mvDawgML8jB
+      via:
+      - 1.1 google
+      x-cloud-trace-context:
+      - ef9f2bfaf4cbc96c6557e43e805aa4f1
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_messages.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_messages.py
@@ -110,6 +110,33 @@ def test_anthropic_message_create_legacy(
         "Assert that it doesn't emit logs when use_legacy_attributes is True"
     )
 
+@pytest.mark.vcr
+def test_anthropic_message_create_without_tools_no_sentinel_leak(
+    instrument_with_content, anthropic_client, span_exporter, log_exporter, reader
+):
+    """Regression test: omitting tools= must not emit NOT_GIVEN into log body.
+    See https://github.com/traceloop/openllmetry/issues/4230"""
+    anthropic_client.messages.create(
+        max_tokens=1024,
+        messages=[
+            {
+                "role": "user",
+                "content": "Tell me a joke about OpenTelemetry",
+            }
+        ],
+        model="claude-3-opus-20240229",
+    )
+    logs = log_exporter.get_finished_logs()
+
+    # Should only have user message + assistant response — no tools event
+    assert len(logs) == 2
+
+    # Verify no log body contains NOT_GIVEN
+    for log in logs:
+        if log.log_record.body:
+            assert "NOT_GIVEN" not in str(log.log_record.body)
+
+
 
 @pytest.mark.vcr
 def test_anthropic_message_create_with_events_with_content(

--- a/packages/opentelemetry-instrumentation-anthropic/uv.lock
+++ b/packages/opentelemetry-instrumentation-anthropic/uv.lock
@@ -348,7 +348,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-anthropic"
-version = "0.60.0"
+version = "0.61.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION
Fixes #4230

When `tools` is omitted from a `messages.create()` call, the Anthropic SDK 
defaults it to `NOT_GIVEN`. The previous `is not None` guard let this sentinel 
through into the log body, causing OTLP export to fail with:

    Exception: Invalid type <class 'anthropic.NotGiven'> of value NOT_GIVEN

Changed the guard to a truthiness check (consistent with the existing `system` 
branch above it), which correctly drops both `NOT_GIVEN` and empty lists.

Added a regression test to verify no sentinel leaks into emitted log bodies.

- [yes] I have added tests that cover my changes.
- [N/A] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [yes] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [N/A] (If applicable) I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed instrumentation event emission behavior for Anthropic message creation when tools are not provided or empty.

* **Tests**
  * Added regression test to ensure instrumentation logging is correct when tools are omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->