### PR TITLE
fix(groq):emit cache input tokens

### DIFF
--- a/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/span_utils.py
+++ b/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/span_utils.py
@@ -198,7 +198,7 @@ def set_model_streaming_response_attributes(span, usage, finish_reasons=None):
             if cached_tokens is not None:
                 set_span_attribute(
                     span,
-                    SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+                    GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
                     cached_tokens,
                 )
 

--- a/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/span_utils.py
+++ b/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/span_utils.py
@@ -192,6 +192,16 @@ def set_model_streaming_response_attributes(span, usage, finish_reasons=None):
         set_span_attribute(span, GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS, usage.prompt_tokens)
         set_span_attribute(span, SpanAttributes.GEN_AI_USAGE_TOTAL_TOKENS, usage.total_tokens)
 
+        prompt_tokens_details = getattr(usage, "prompt_tokens_details", None)
+        if prompt_tokens_details is not None:
+            cached_tokens = getattr(prompt_tokens_details, "cached_tokens", None)
+            if cached_tokens is not None:
+                set_span_attribute(
+                    span,
+                    SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+                    cached_tokens,
+                )
+
     if finish_reasons:
         mapped = [_map_groq_finish_reason(fr) for fr in finish_reasons]
         mapped = [m for m in mapped if m]
@@ -219,6 +229,14 @@ def set_model_response_attributes(span, response, token_histogram):
         set_span_attribute(span, SpanAttributes.GEN_AI_USAGE_TOTAL_TOKENS, usage.get("total_tokens"))
         set_span_attribute(span, GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS, completion_tokens)
         set_span_attribute(span, GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS, prompt_tokens)
+
+        cached_tokens = (usage.get("prompt_tokens_details") or {}).get("cached_tokens")
+        if cached_tokens is not None:
+            set_span_attribute(
+                span,
+                SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+                cached_tokens,
+            )
 
     if isinstance(prompt_tokens, int) and prompt_tokens >= 0 and token_histogram is not None:
         token_histogram.record(

--- a/packages/opentelemetry-instrumentation-groq/tests/traces/test_span_utils.py
+++ b/packages/opentelemetry-instrumentation-groq/tests/traces/test_span_utils.py
@@ -24,6 +24,7 @@ from opentelemetry.instrumentation.groq.span_utils import (
     set_streaming_response_attributes,
 )
 from opentelemetry.instrumentation.groq.utils import TRACELOOP_TRACE_CONTENT
+from opentelemetry.semconv_ai import SpanAttributes
 
 
 # ---------------------------------------------------------------------------
@@ -377,6 +378,41 @@ class TestSetModelStreamingResponseAttributes:
         set_model_streaming_response_attributes(span, None, finish_reasons=["unknown_reason_xyz"])
         assert _attr(span, GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS) == ["unknown_reason_xyz"]
 
+    def test_with_cached_tokens_sets_cache_read_attribute(self):
+        span = _span()
+        usage = MagicMock()
+        usage.completion_tokens = 10
+        usage.prompt_tokens = 50
+        usage.total_tokens = 60
+        prompt_tokens_details = MagicMock()
+        prompt_tokens_details.cached_tokens = 30
+        usage.prompt_tokens_details = prompt_tokens_details
+        set_model_streaming_response_attributes(span, usage)
+        assert _attr(span, SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS) == 30
+
+    def test_without_prompt_tokens_details_skips_cache_read_attribute(self):
+        span = _span()
+        usage = MagicMock(spec=["completion_tokens", "prompt_tokens", "total_tokens"])
+        usage.completion_tokens = 10
+        usage.prompt_tokens = 50
+        usage.total_tokens = 60
+        set_model_streaming_response_attributes(span, usage)
+        set_keys = [c[0][0] for c in span.set_attribute.call_args_list]
+        assert SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS not in set_keys
+
+    def test_with_none_cached_tokens_skips_cache_read_attribute(self):
+        span = _span()
+        usage = MagicMock()
+        usage.completion_tokens = 10
+        usage.prompt_tokens = 50
+        usage.total_tokens = 60
+        prompt_tokens_details = MagicMock()
+        prompt_tokens_details.cached_tokens = None
+        usage.prompt_tokens_details = prompt_tokens_details
+        set_model_streaming_response_attributes(span, usage)
+        set_keys = [c[0][0] for c in span.set_attribute.call_args_list]
+        assert SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS not in set_keys
+
 
 # ---------------------------------------------------------------------------
 # set_model_response_attributes
@@ -432,6 +468,28 @@ class TestSetModelResponseAttributes:
         second = histogram.record.call_args_list[1]
         assert second[0][0] == 5
         assert second[1]["attributes"]["gen_ai.token.type"] == "output"
+
+    def _response_with_cached_tokens(self, cached_tokens, prompt_tokens=50, completion_tokens=10):
+        response = self._response(prompt_tokens=prompt_tokens, completion_tokens=completion_tokens)
+        response["usage"]["prompt_tokens_details"] = {"cached_tokens": cached_tokens}
+        return response
+
+    def test_with_cached_tokens_sets_cache_read_attribute(self):
+        span = _span()
+        set_model_response_attributes(span, self._response_with_cached_tokens(cached_tokens=20), None)
+        assert _attr(span, SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS) == 20
+
+    def test_without_prompt_tokens_details_skips_cache_read_attribute(self):
+        span = _span()
+        set_model_response_attributes(span, self._response(), None)
+        set_keys = [c[0][0] for c in span.set_attribute.call_args_list]
+        assert SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS not in set_keys
+
+    def test_with_none_cached_tokens_skips_cache_read_attribute(self):
+        span = _span()
+        set_model_response_attributes(span, self._response_with_cached_tokens(cached_tokens=None), None)
+        set_keys = [c[0][0] for c in span.set_attribute.call_args_list]
+        assert SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS not in set_keys
 
 
 # ---------------------------------------------------------------------------

--- a/packages/opentelemetry-instrumentation-groq/uv.lock
+++ b/packages/opentelemetry-instrumentation-groq/uv.lock
@@ -197,7 +197,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-groq"
-version = "0.60.0"
+version = "0.61.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },

--- a/packages/opentelemetry-instrumentation-openai-agents/uv.lock
+++ b/packages/opentelemetry-instrumentation-openai-agents/uv.lock
@@ -1307,7 +1307,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-openai-agents"
-version = "0.61.0"
+version = "0.60.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },

--- a/packages/opentelemetry-instrumentation-openai-agents/uv.lock
+++ b/packages/opentelemetry-instrumentation-openai-agents/uv.lock
@@ -1307,7 +1307,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-openai-agents"
-version = "0.60.0"
+version = "0.61.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tracking of cached prompt token usage for Groq AI instrumentation via span attributes when available.

* **Tests**
  * Added unit tests for both streaming and non-streaming responses to verify cached token attribution, including cases where details are missing or cached token counts are null.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->