### PR TITLE
fix(mistralai): emit input cache tokens

### DIFF
--- a/packages/opentelemetry-instrumentation-mistralai/opentelemetry/instrumentation/mistralai/__init__.py
+++ b/packages/opentelemetry-instrumentation-mistralai/opentelemetry/instrumentation/mistralai/__init__.py
@@ -212,7 +212,7 @@ def _set_model_response_attributes(span, llm_request_type, response):
         if cached_tokens is not None:
             _set_span_attribute(
                 span,
-                SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+                GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
                 cached_tokens,
             )
 

--- a/packages/opentelemetry-instrumentation-mistralai/opentelemetry/instrumentation/mistralai/__init__.py
+++ b/packages/opentelemetry-instrumentation-mistralai/opentelemetry/instrumentation/mistralai/__init__.py
@@ -197,6 +197,25 @@ def _set_model_response_attributes(span, llm_request_type, response):
         input_tokens,
     )
 
+    prompt_tokens_details = (
+        getattr(response.usage, "prompt_tokens_details", None)
+        or getattr(response.usage, "additional_properties", {}).get(
+            "prompt_tokens_details"
+        )
+    )
+    if prompt_tokens_details:
+        cached_tokens = (
+            prompt_tokens_details.get("cached_tokens")
+            if isinstance(prompt_tokens_details, dict)
+            else getattr(prompt_tokens_details, "cached_tokens", None)
+        )
+        if cached_tokens is not None:
+            _set_span_attribute(
+                span,
+                SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+                cached_tokens,
+            )
+
 
 def _accumulate_streaming_response(span, event_logger, llm_request_type, response):
     accumulated_response = ChatCompletionResponse(

--- a/packages/opentelemetry-instrumentation-mistralai/tests/cassettes/test_chat/test_mistralai_chat_with_cache_tokens.yaml
+++ b/packages/opentelemetry-instrumentation-mistralai/tests/cassettes/test_chat/test_mistralai_chat_with_cache_tokens.yaml
@@ -1,0 +1,31 @@
+interactions:
+- request:
+    body: '{"model":"mistral-tiny","messages":[{"content":"Tell me a joke about OpenTelemetry","role":"user"}],"stream":false}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '115'
+      content-type:
+      - application/json
+      host:
+      - api.mistral.ai
+      user-agent:
+      - mistral-client-python/1.9.10
+    method: POST
+    uri: https://api.mistral.ai/v1/chat/completions
+  response:
+    body:
+      string: '{"id":"abc123cached456","object":"chat.completion","created":1757759490,"model":"mistral-tiny","choices":[{"index":0,"message":{"role":"assistant","content":"Why
+        did OpenTelemetry go to therapy? Because it had too many unresolved traces!","tool_calls":null},"finish_reason":"stop","logprobs":null}],"usage":{"prompt_tokens":20,"completion_tokens":18,"total_tokens":38,"prompt_tokens_details":{"cached_tokens":10}}}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/packages/opentelemetry-instrumentation-mistralai/tests/test_chat.py
+++ b/packages/opentelemetry-instrumentation-mistralai/tests/test_chat.py
@@ -639,6 +639,27 @@ async def test_mistralai_async_streaming_chat_with_events_with_no_content(
     assert_message_in_logs(logs[1], "gen_ai.choice", choice_event)
 
 
+@pytest.mark.vcr
+def test_mistralai_chat_with_cache_tokens(
+    instrument_legacy, mistralai_client, span_exporter, log_exporter
+):
+    mistralai_client.chat.complete(
+        model="mistral-tiny",
+        messages=[
+            UserMessage(content="Tell me a joke about OpenTelemetry"),
+        ],
+    )
+
+    spans = span_exporter.get_finished_spans()
+    mistral_span = spans[0]
+    assert mistral_span.attributes.get(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS) == 20
+    assert mistral_span.attributes.get(GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS) == 18
+    assert (
+        mistral_span.attributes.get(SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS)
+        == 10
+    )
+
+
 def assert_message_in_logs(log: ReadableLogRecord, event_name: str, expected_content: dict):
     assert log.log_record.event_name == event_name
     assert log.log_record.attributes.get(GenAIAttributes.GEN_AI_SYSTEM) == "mistral_ai"

--- a/packages/opentelemetry-instrumentation-mistralai/uv.lock
+++ b/packages/opentelemetry-instrumentation-mistralai/uv.lock
@@ -350,7 +350,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-mistralai"
-version = "0.60.0"
+version = "0.61.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced MistralAI instrumentation to capture cached prompt-token details from API responses and record cached input token metrics on generated spans.

* **Tests**
  * Added a new VCR-backed chat test that verifies span token-usage attributes for requests with cached tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->