### PR TITLE
fix(instrumentation): record langchain cache_creation (cache-write) t…

### DIFF
--- a/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/span_utils.py
+++ b/packages/opentelemetry-instrumentation-langchain/opentelemetry/instrumentation/langchain/span_utils.py
@@ -394,6 +394,7 @@ def set_chat_response_usage(
     output_tokens = 0
     total_tokens = 0
     cache_read_tokens = 0
+    cache_creation_tokens = 0
 
     # Early return if no generations to avoid potential issues
     if not response.generations:
@@ -424,6 +425,9 @@ def set_chat_response_usage(
                             "input_token_details", {}
                         )
                         cache_read_tokens += input_token_details.get("cache_read", 0)
+                        cache_creation_tokens += input_token_details.get(
+                            "cache_creation", 0
+                        )
     except Exception as e:
         # If there's any issue processing usage metadata, continue without it
         logger.warning("Error processing usage metadata: %s", e)
@@ -434,6 +438,7 @@ def set_chat_response_usage(
         or output_tokens > 0
         or total_tokens > 0
         or cache_read_tokens > 0
+        or cache_creation_tokens > 0
     ):
         _set_span_attribute(
             span,
@@ -454,6 +459,11 @@ def set_chat_response_usage(
             span,
             SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
             cache_read_tokens,
+        )
+        _set_span_attribute(
+            span,
+            SpanAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+            cache_creation_tokens,
         )
         if record_token_usage:
             vendor = span.attributes.get(GenAIAttributes.GEN_AI_PROVIDER_NAME, "langchain")

--- a/packages/opentelemetry-instrumentation-langchain/tests/cassettes/test_llms/test_anthropic_prompt_caching_usage.yaml
+++ b/packages/opentelemetry-instrumentation-langchain/tests/cassettes/test_llms/test_anthropic_prompt_caching_usage.yaml
@@ -1,0 +1,32 @@
+interactions:
+- request:
+    body: '{"max_tokens": 1024, "messages": [{"role": "user", "content": "Summarize
+      the cached document."}], "model": "claude-3-5-sonnet-20241022", "system": [{"type":
+      "text", "text": "You are a helpful assistant.", "cache_control": {"type": "ephemeral"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: '{"id": "msg_01PromptCacheCreation00000000", "type": "message", "role":
+        "assistant", "model": "claude-3-5-sonnet-20241022", "content": [{"type": "text",
+        "text": "Cached context acknowledged."}], "stop_reason": "end_turn", "stop_sequence":
+        null, "usage": {"input_tokens": 12, "output_tokens": 8, "cache_creation_input_tokens":
+        1024, "cache_read_input_tokens": 0}}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/packages/opentelemetry-instrumentation-langchain/tests/test_llms.py
+++ b/packages/opentelemetry-instrumentation-langchain/tests/test_llms.py
@@ -611,6 +611,33 @@ def test_openai_functions_with_events_with_no_content(
 
 
 @pytest.mark.vcr
+def test_anthropic_prompt_caching_usage(instrument_legacy, span_exporter, log_exporter):
+    # The recorded response carries prompt-cache usage as returned by Anthropic on a
+    # cache write: cache_creation_input_tokens > 0 (tokens used to create the cache)
+    # and cache_read_input_tokens == 0. langchain-anthropic surfaces these via
+    # usage_metadata["input_token_details"]["cache_creation"] / ["cache_read"]; the
+    # instrumentation must emit both as span attributes.
+    model = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+
+    model.invoke("Summarize the cached document.")
+
+    spans = span_exporter.get_finished_spans()
+    anthropic_span = next(span for span in spans if span.name == "ChatAnthropic.chat")
+
+    # cache_creation is the attribute this test guards; cache_read is asserted too so
+    # a regression in the existing behavior is caught alongside it.
+    assert (
+        anthropic_span.attributes[SpanAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]
+        == 1024
+    )
+    assert (
+        anthropic_span.attributes[SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]
+        == 0
+    )
+    assert anthropic_span.attributes[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS] == 8
+
+
+@pytest.mark.vcr
 def test_anthropic(instrument_legacy, span_exporter, log_exporter):
     prompt = ChatPromptTemplate.from_messages(
         [("system", "You are a helpful assistant"), ("user", "{input}")]


### PR DESCRIPTION
## Summary
`set_chat_response_usage` in the LangChain instrumentation reads only `cache_read`
from LangChain's `usage_metadata["input_token_details"]` and emits
`gen_ai.usage.cache_read.input_tokens`. It never reads `cache_creation`, so
cache-write tokens — the most expensive token class — are dropped and never
surface as a span attribute, leaving downstream cost tracking under-counted.

The value is already available from the provider adapters: both
`langchain-anthropic` and `langchain-aws` (Bedrock Converse) populate
`input_token_details["cache_creation"]`. This change reads it and emits
`gen_ai.usage.cache_creation.input_tokens`, mirroring the existing `cache_read`
handling. `input_tokens` is left untouched — LangChain's value is already
inclusive of cache tokens, so there is no double counting.

This is the LangChain counterpart to the Anthropic-instrumentation fix in #3648.

## Changes
- `span_utils.py`: accumulate `cache_creation` from `input_token_details` and set
  `SpanAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS` (constant already
  defined in the semantic-conventions package).
- Add a regression test (`test_anthropic_prompt_caching_usage`) with a VCR
  cassette carrying a prompt-cache write (`cache_creation_input_tokens > 0`). It
  fails without this change and passes with it.

## Screenshots
Same `ChatBedrockConverse` call (a prompt-cache write of ~5.6k tokens), traced to
Langfuse. Before, the cache-creation tokens are dropped and the cost is output-only;
after, they are captured and priced.

### Before (released 0.61.0) — cache-creation tokens dropped
<img width="441" height="385" alt="image" src="https://github.com/user-attachments/assets/459535ea-a4ee-41e2-b72d-bd659badcb47" />

### After (this PR) — gen_ai.usage.cache_creation.input_tokens captured
<img width="464" height="400" alt="image" src="https://github.com/user-attachments/assets/f26710c4-1f4d-4db0-beac-04627e113ed9" />

---

- [x] I have added tests that cover my changes.
- [x] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [x] (If applicable) I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking cache creation and cache read input tokens from language model API responses, enabling observability into prompt caching efficiency and providing insights into cached request resource usage.

* **Tests**
  * Added test coverage including recorded API interaction cassettes to validate proper capture, tracking, and attribution of cache-related token usage metrics in observability spans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->