### PR TITLE
fix(google generativeai:)emit cache input tokens

### DIFF
--- a/packages/opentelemetry-instrumentation-google-generativeai/opentelemetry/instrumentation/google_generativeai/span_utils.py
+++ b/packages/opentelemetry-instrumentation-google-generativeai/opentelemetry/instrumentation/google_generativeai/span_utils.py
@@ -746,7 +746,7 @@ def set_model_response_attributes(
         if cached_content_token_count is not None:
             _set_span_attribute(
                 span,
-                SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+                GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
                 cached_content_token_count,
             )
 

--- a/packages/opentelemetry-instrumentation-google-generativeai/opentelemetry/instrumentation/google_generativeai/span_utils.py
+++ b/packages/opentelemetry-instrumentation-google-generativeai/opentelemetry/instrumentation/google_generativeai/span_utils.py
@@ -742,6 +742,14 @@ def set_model_response_attributes(
             um.prompt_token_count,
         )
 
+        cached_content_token_count = getattr(um, "cached_content_token_count", None)
+        if cached_content_token_count is not None:
+            _set_span_attribute(
+                span,
+                SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+                cached_content_token_count,
+            )
+
     if token_histogram and um is not None:
         token_histogram.record(
             um.prompt_token_count,

--- a/packages/opentelemetry-instrumentation-google-generativeai/tests/test_generate_content.py
+++ b/packages/opentelemetry-instrumentation-google-generativeai/tests/test_generate_content.py
@@ -186,3 +186,47 @@ def test_set_model_request_attributes_reads_system_instruction_from_config(monke
     parts = json.loads(sys_attr_calls[0][1])
     assert parts[0]["type"] == "text"
     assert parts[0]["content"] == "Reply in one sentence."
+
+
+def test_set_model_response_attributes_emits_cache_read_tokens():
+    from opentelemetry.instrumentation.google_generativeai import span_utils as su
+
+    span = MagicMock()
+    span.is_recording.return_value = True
+
+    class UsageMetadata:
+        total_token_count = 150
+        candidates_token_count = 50
+        prompt_token_count = 100
+        cached_content_token_count = 40
+
+    class Response:
+        usage_metadata = UsageMetadata()
+        response_id = None
+
+    su.set_model_response_attributes(span, Response(), "gemini-pro", token_histogram=None)
+
+    set_attr_calls = {c[0][0]: c[0][1] for c in span.set_attribute.call_args_list}
+    assert set_attr_calls[SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] == 40
+
+
+def test_set_model_response_attributes_no_cache_read_tokens_when_absent():
+    from opentelemetry.instrumentation.google_generativeai import span_utils as su
+
+    span = MagicMock()
+    span.is_recording.return_value = True
+
+    class UsageMetadata:
+        total_token_count = 150
+        candidates_token_count = 50
+        prompt_token_count = 100
+        # no cached_content_token_count attribute
+
+    class Response:
+        usage_metadata = UsageMetadata()
+        response_id = None
+
+    su.set_model_response_attributes(span, Response(), "gemini-pro", token_histogram=None)
+
+    set_attr_keys = [c[0][0] for c in span.set_attribute.call_args_list]
+    assert SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS not in set_attr_keys

--- a/packages/opentelemetry-instrumentation-google-generativeai/uv.lock
+++ b/packages/opentelemetry-instrumentation-google-generativeai/uv.lock
@@ -475,7 +475,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-google-generativeai"
-version = "0.60.0"
+version = "0.61.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Google Generative AI instrumentation to track cached input tokens. When cached token data is present in usage metadata, it’s now recorded on spans as a dedicated span attribute.
* **Tests**
  * Added unit tests to verify the cached input token attribute is set when available and omitted when cached token data is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->