### PR TITLE
fix(llamaindex): emit cache tokens

### DIFF
--- a/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/_response_utils.py
+++ b/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/_response_utils.py
@@ -26,6 +26,8 @@ class TokenUsage:
     input_tokens: Optional[int] = None
     output_tokens: Optional[int] = None
     total_tokens: Optional[int] = None
+    cache_read_tokens: Optional[int] = None
+    cache_creation_tokens: Optional[int] = None
 
 
 def detect_provider_name(instance_or_class_name: Any) -> Optional[str]:
@@ -63,10 +65,13 @@ def extract_response_id(raw: Any) -> Optional[str]:
 
 
 def extract_token_usage(raw: Any) -> TokenUsage:
-    """Extract token usage from raw response. Handles OpenAI, Cohere, and dict formats."""
+    """Extract token usage from raw response. Handles OpenAI, Anthropic, Cohere, and dict formats."""
     usage = _get_nested(raw, "usage")
     if usage:
         result = _extract_openai_usage(usage)
+        if result.input_tokens is not None:
+            return result
+        result = _extract_anthropic_usage(usage)
         if result.input_tokens is not None:
             return result
 
@@ -90,16 +95,53 @@ def _get_nested(obj: Any, key: str) -> Any:
 def _extract_openai_usage(usage: Any) -> TokenUsage:
     """Extract tokens from OpenAI-style usage object/dict."""
     if hasattr(usage, "completion_tokens"):
+        details = getattr(usage, "prompt_tokens_details", None)
+        cached = getattr(details, "cached_tokens", None) if details is not None else None
         return TokenUsage(
             input_tokens=usage.prompt_tokens,
             output_tokens=usage.completion_tokens,
             total_tokens=usage.total_tokens,
+            cache_read_tokens=cached,
         )
-    if isinstance(usage, dict):
+    if isinstance(usage, dict) and (
+        "prompt_tokens" in usage or "completion_tokens" in usage
+    ):
+        details = usage.get("prompt_tokens_details") or {}
         return TokenUsage(
             input_tokens=usage.get("prompt_tokens"),
             output_tokens=usage.get("completion_tokens"),
             total_tokens=usage.get("total_tokens"),
+            cache_read_tokens=details.get("cached_tokens"),
+        )
+    return TokenUsage()
+
+
+def _extract_anthropic_usage(usage: Any) -> TokenUsage:
+    """Extract tokens from Anthropic-style usage object/dict.
+
+    Anthropic uses `input_tokens` / `output_tokens` (not prompt/completion) and exposes
+    cache fields as siblings of input_tokens. Cache fields are disjoint from input_tokens
+    (additive), unlike OpenAI's subset semantics — see project-cache-token-semantics memo.
+    """
+    if hasattr(usage, "input_tokens") and hasattr(usage, "output_tokens"):
+        inp = getattr(usage, "input_tokens", None)
+        out = getattr(usage, "output_tokens", None)
+        return TokenUsage(
+            input_tokens=inp,
+            output_tokens=out,
+            total_tokens=_safe_sum(inp, out),
+            cache_read_tokens=getattr(usage, "cache_read_input_tokens", None),
+            cache_creation_tokens=getattr(usage, "cache_creation_input_tokens", None),
+        )
+    if isinstance(usage, dict) and "input_tokens" in usage and "output_tokens" in usage:
+        inp = usage.get("input_tokens")
+        out = usage.get("output_tokens")
+        return TokenUsage(
+            input_tokens=inp,
+            output_tokens=out,
+            total_tokens=_safe_sum(inp, out),
+            cache_read_tokens=usage.get("cache_read_input_tokens"),
+            cache_creation_tokens=usage.get("cache_creation_input_tokens"),
         )
     return TokenUsage()
 

--- a/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/custom_llm_instrumentor.py
+++ b/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/custom_llm_instrumentor.py
@@ -202,11 +202,11 @@ def _handle_response(span, llm_request_type, instance, response):
             span.set_attribute(SpanAttributes.GEN_AI_USAGE_TOTAL_TOKENS, int(usage.total_tokens))
         if usage.cache_read_tokens is not None:
             span.set_attribute(
-                SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, int(usage.cache_read_tokens)
+                GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, int(usage.cache_read_tokens)
             )
         if usage.cache_creation_tokens is not None:
             span.set_attribute(
-                SpanAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+                GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
                 int(usage.cache_creation_tokens),
             )
 

--- a/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/custom_llm_instrumentor.py
+++ b/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/custom_llm_instrumentor.py
@@ -200,6 +200,15 @@ def _handle_response(span, llm_request_type, instance, response):
             span.set_attribute(GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS, int(usage.output_tokens))
         if usage.total_tokens is not None:
             span.set_attribute(SpanAttributes.GEN_AI_USAGE_TOTAL_TOKENS, int(usage.total_tokens))
+        if usage.cache_read_tokens is not None:
+            span.set_attribute(
+                SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, int(usage.cache_read_tokens)
+            )
+        if usage.cache_creation_tokens is not None:
+            span.set_attribute(
+                SpanAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+                int(usage.cache_creation_tokens),
+            )
 
     # CRITICAL: finish_reasons is NOT gated by should_send_prompts()
     reasons = extract_finish_reasons(raw) if raw else []

--- a/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/span_utils.py
+++ b/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/span_utils.py
@@ -106,11 +106,11 @@ def set_llm_chat_response_model_attributes(event, span):
         span.set_attribute(SpanAttributes.GEN_AI_USAGE_TOTAL_TOKENS, int(usage.total_tokens))
     if usage.cache_read_tokens is not None:
         span.set_attribute(
-            SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, int(usage.cache_read_tokens)
+            GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, int(usage.cache_read_tokens)
         )
     if usage.cache_creation_tokens is not None:
         span.set_attribute(
-            SpanAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
             int(usage.cache_creation_tokens),
         )
 

--- a/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/span_utils.py
+++ b/packages/opentelemetry-instrumentation-llamaindex/opentelemetry/instrumentation/llamaindex/span_utils.py
@@ -104,6 +104,15 @@ def set_llm_chat_response_model_attributes(event, span):
         span.set_attribute(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS, int(usage.input_tokens))
     if usage.total_tokens is not None:
         span.set_attribute(SpanAttributes.GEN_AI_USAGE_TOTAL_TOKENS, int(usage.total_tokens))
+    if usage.cache_read_tokens is not None:
+        span.set_attribute(
+            SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, int(usage.cache_read_tokens)
+        )
+    if usage.cache_creation_tokens is not None:
+        span.set_attribute(
+            SpanAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+            int(usage.cache_creation_tokens),
+        )
 
     # CRITICAL: finish_reasons is NOT gated by should_send_prompts()
     finish_reasons = extract_finish_reasons(raw)

--- a/packages/opentelemetry-instrumentation-llamaindex/uv.lock
+++ b/packages/opentelemetry-instrumentation-llamaindex/uv.lock
@@ -2322,7 +2322,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-chromadb"
-version = "0.60.0"
+version = "0.61.0"
 source = { editable = "../opentelemetry-instrumentation-chromadb" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -2357,7 +2357,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-cohere"
-version = "0.60.0"
+version = "0.61.0"
 source = { editable = "../opentelemetry-instrumentation-cohere" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -2411,7 +2411,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-llamaindex"
-version = "0.60.0"
+version = "0.61.0"
 source = { editable = "." }
 dependencies = [
     { name = "inflection" },
@@ -2495,7 +2495,7 @@ test = [
 
 [[package]]
 name = "opentelemetry-instrumentation-openai"
-version = "0.60.0"
+version = "0.61.0"
 source = { editable = "../opentelemetry-instrumentation-openai" }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for capturing cached token metrics from both OpenAI- and Anthropic-style usage data.
  * LLM spans now include additional attributes for cache read tokens and cache creation input tokens when available, improving visibility into cache hit behavior.
* **Updates**
  * Enhanced token-usage extraction to populate cached token counts for both object and dict usage shapes, with safer parsing and clearer total token computation for Anthropic-style responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->