### PR TITLE
fix(vertexai): emit cache tokens

### DIFF
--- a/packages/opentelemetry-instrumentation-vertexai/opentelemetry/instrumentation/vertexai/span_utils.py
+++ b/packages/opentelemetry-instrumentation-vertexai/opentelemetry/instrumentation/vertexai/span_utils.py
@@ -311,3 +311,13 @@ def set_model_response_attributes(span, llm_model, token_usage):
             GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS,
             token_usage.prompt_token_count,
         )
+
+        cached_content_token_count = getattr(
+            token_usage, "cached_content_token_count", None
+        )
+        if cached_content_token_count is not None:
+            _set_span_attribute(
+                span,
+                SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+                cached_content_token_count,
+            )

--- a/packages/opentelemetry-instrumentation-vertexai/opentelemetry/instrumentation/vertexai/span_utils.py
+++ b/packages/opentelemetry-instrumentation-vertexai/opentelemetry/instrumentation/vertexai/span_utils.py
@@ -318,6 +318,6 @@ def set_model_response_attributes(span, llm_model, token_usage):
         if cached_content_token_count is not None:
             _set_span_attribute(
                 span,
-                SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+                GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
                 cached_content_token_count,
             )

--- a/packages/opentelemetry-instrumentation-vertexai/uv.lock
+++ b/packages/opentelemetry-instrumentation-vertexai/uv.lock
@@ -586,7 +586,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-vertexai"
-version = "0.60.0"
+version = "0.61.0"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vertex AI instrumentation now captures cached token usage metrics in observation spans. If cached content token counts are available, they’re automatically recorded as span attributes, improving visibility into how caching impacts token consumption and enabling easier analysis of cache performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->