### PR TITLE
fix: add encoding='utf-8' to open() calls to prevent UnicodeDecodeError on non-UTF-8 systems

### DIFF
--- a/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/__init__.py
+++ b/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/__init__.py
@@ -23,11 +23,11 @@ logger = logging.getLogger(__name__)
 _instruments = ("qdrant-client >= 1.7",)
 
 p = Path(__file__).with_name("qdrant_client_methods.json")
-with open(p, "r") as f:
+with open(p, "r" , encoding="utf-8") as f:
     QDRANT_CLIENT_METHODS = json.loads(f.read())
 
 p = Path(__file__).with_name("async_qdrant_client_methods.json")
-with open(p, "r") as f:
+with open(p, "r", encoding="utf-8") as f:
     ASYNC_QDRANT_CLIENT_METHODS = json.loads(f.read())
 
 WRAPPED_METHODS = QDRANT_CLIENT_METHODS + ASYNC_QDRANT_CLIENT_METHODS

--- a/scripts/codegen/generate_evaluator_models.py
+++ b/scripts/codegen/generate_evaluator_models.py
@@ -24,7 +24,7 @@ def extract_definitions_and_mappings(swagger_path: str) -> tuple[dict, dict]:
         tuple: (filtered_definitions, slug_mappings)
         slug_mappings: {slug: {"request": "ModelName", "response": "ModelName"}}
     """
-    with open(swagger_path) as f:
+    with open(swagger_path,encoding="utf-8") as f:
         data = json.load(f)
 
     all_definitions = data["definitions"]


### PR DESCRIPTION
Fixes #4286

On Windows systems with non-UTF-8 locales (e.g. GBK), open() calls 
without explicit encoding crash with UnicodeDecodeError.

Added encoding='utf-8' to text-mode open() calls in:
- packages/opentelemetry-instrumentation-qdrant/__init__.py (lines 26, 30)
- scripts/codegen/generate_evaluator_models.py (line 27)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved character encoding handling by explicitly specifying UTF-8 when reading configuration and API specification files, ensuring consistent behavior across all operating systems and platform settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->