### PR TITLE
fix: add explicit encoding='utf-8' to open() calls for Windows compat

### DIFF
--- a/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/__init__.py
+++ b/packages/opentelemetry-instrumentation-qdrant/opentelemetry/instrumentation/qdrant/__init__.py
@@ -23,11 +23,11 @@ logger = logging.getLogger(__name__)
 _instruments = ("qdrant-client >= 1.7",)
 
 p = Path(__file__).with_name("qdrant_client_methods.json")
-with open(p, "r") as f:
+with open(p, "r", encoding="utf-8") as f:
     QDRANT_CLIENT_METHODS = json.loads(f.read())
 
 p = Path(__file__).with_name("async_qdrant_client_methods.json")
-with open(p, "r") as f:
+with open(p, "r", encoding="utf-8") as f:
     ASYNC_QDRANT_CLIENT_METHODS = json.loads(f.read())
 
 WRAPPED_METHODS = QDRANT_CLIENT_METHODS + ASYNC_QDRANT_CLIENT_METHODS

--- a/scripts/codegen/generate_evaluator_models.py
+++ b/scripts/codegen/generate_evaluator_models.py
@@ -24,7 +24,7 @@ def extract_definitions_and_mappings(swagger_path: str) -> tuple[dict, dict]:
         tuple: (filtered_definitions, slug_mappings)
         slug_mappings: {slug: {"request": "ModelName", "response": "ModelName"}}
     """
-    with open(swagger_path) as f:
+    with open(swagger_path, encoding="utf-8") as f:
         data = json.load(f)
 
     all_definitions = data["definitions"]


### PR DESCRIPTION
Three open() calls in the codebase read text files without specifying an encoding. On Windows with non-UTF-8 locales (like GBK on Chinese Windows), this blows up with UnicodeDecodeError.

Added encoding=utf-8 to the two calls in the qdrant instrumentation `__init__.py` (loading the JSON method lists) and the one in `generate_evaluator_models.py` (reading the Swagger definition). That's it — three characters each, no behavioral change on systems that already default to UTF-8.

Existing tests cover the import path that triggers these reads, so passing tests confirms the fix works.

Closes #4286