### PR TITLE
fix(agno): align opentelemetry-api minimum version with other packages

### DIFF
--- a/packages/opentelemetry-instrumentation-agno/pyproject.toml
+++ b/packages/opentelemetry-instrumentation-agno/pyproject.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
-  "opentelemetry-api>=1.28.0,<2",
+  "opentelemetry-api>=1.38.0,<2",
   "opentelemetry-instrumentation>=0.59b0",
   "opentelemetry-semantic-conventions-ai>=0.5.1,<0.6.0",
   "opentelemetry-semantic-conventions>=0.63b1",


### PR DESCRIPTION
## Summary
Align the `opentelemetry-api` dependency pin in `opentelemetry-instrumentation-agno` with the rest of the workspace: `>=1.28.0,<2` → `>=1.38.0,<2`.

## Motivation
All 33 sibling instrumentation packages and `traceloop-sdk` itself pin `opentelemetry-api>=1.38.0,<2`. The lower pin in `agno` was misleading — it advertised support for OTel API versions the package isn't tested against, and since any real install pulls the SDK's `>=1.38.0` anyway, the declaration was purely informational drift.

## Test plan
- [x] Parity confirmed with `grep 'opentelemetry-api>=' packages/*/pyproject.toml` — agno now matches the other 33 packages.
- [x] Only `pyproject.toml` metadata changes; no Python code paths affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the supported OpenTelemetry API version range for the Agno instrumentation package, improving compatibility with newer releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->