### PR TITLE
fix(sdk): log errors from Fetcher.api_post instead of printing to stdout

### DIFF
--- a/packages/traceloop-sdk/tests/test_fetcher_logging.py
+++ b/packages/traceloop-sdk/tests/test_fetcher_logging.py
@@ -1,0 +1,25 @@
+import logging
+from unittest.mock import patch
+
+from traceloop.sdk.fetcher import Fetcher
+
+
+def test_api_post_logs_error_instead_of_printing(caplog, capsys):
+    fetcher = Fetcher(base_url="http://example.invalid", api_key="test-key")
+
+    with patch(
+        "traceloop.sdk.fetcher.post_url",
+        side_effect=RuntimeError("boom"),
+    ):
+        with caplog.at_level(logging.ERROR):
+            fetcher.api_post("some-endpoint", {"payload": "x"})
+
+    error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert error_records, "expected an ERROR log record from Fetcher.api_post"
+
+    message = error_records[-1].getMessage()
+    assert "some-endpoint" in message
+    assert "boom" in message
+
+    captured = capsys.readouterr()
+    assert "boom" not in captured.out

--- a/packages/traceloop-sdk/traceloop/sdk/fetcher.py
+++ b/packages/traceloop-sdk/traceloop/sdk/fetcher.py
@@ -68,7 +68,7 @@ class Fetcher:
         try:
             post_url(f"{self._base_url}/v2/{api}", self._api_key, body)
         except Exception as e:
-            print(e)
+            logging.error("Failed to post to %s: %s", api, e)
 
 
 class RetryIfServerError(retry_if_exception):


### PR DESCRIPTION
## Summary
Replace `print(e)` in `Fetcher.api_post` with `logging.error(\"Failed to post to %s: %s\", api, e)`.

## Motivation
Every other error path in `fetcher.py` uses `logging.error(...)` — see lines 108, 111, 143. The `print(e)` in `api_post` was the odd one out:
- Errors bypassed the log stream (invisible to log aggregators and level filters).
- Message dropped all context (no endpoint name, no traceback).
- Emitted to stdout instead of stderr.

The other `print(...)` calls in `traceloop/sdk/__init__.py`, `tracing.py`, and `experiment/*` are intentional colorama-styled user-facing startup output and are out of scope.

## Test plan
- [x] New `tests/test_fetcher_logging.py` asserts an ERROR record is emitted through the log stream with the endpoint name in the formatted message, and that stdout stays silent.
- [x] `uv run ruff check` passes on the modified files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error handling for API requests now logs failures instead of printing them to the console.
  * Failure messages include the affected endpoint and the error details, making issues easier to trace.
  * Added coverage to ensure errors are logged correctly and not sent to standard output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->