### PR TITLE
fix(sdk): decode SSE error body before formatting in stream client

### DIFF
--- a/packages/traceloop-sdk/tests/evaluator/test_stream_client.py
+++ b/packages/traceloop-sdk/tests/evaluator/test_stream_client.py
@@ -1,0 +1,37 @@
+import pytest
+
+from traceloop.sdk.evaluator.stream_client import SSEClient
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, body: bytes):
+        self.status_code = status_code
+        self._body = body
+
+    async def aread(self) -> bytes:
+        return self._body
+
+
+@pytest.mark.asyncio
+async def test_error_body_is_decoded_in_exception_message():
+    client = SSEClient.__new__(SSEClient)
+    response = _FakeResponse(500, b'{"error":"boom"}')
+
+    with pytest.raises(Exception) as exc_info:
+        await client._handle_sse_response(response)  # type: ignore[arg-type]
+
+    message = str(exc_info.value)
+    assert '{"error":"boom"}' in message
+    assert "b'" not in message
+    assert "500" in message
+
+
+@pytest.mark.asyncio
+async def test_error_body_with_invalid_utf8_does_not_raise():
+    client = SSEClient.__new__(SSEClient)
+    response = _FakeResponse(502, b"\xff\xfeinvalid")
+
+    with pytest.raises(Exception) as exc_info:
+        await client._handle_sse_response(response)  # type: ignore[arg-type]
+
+    assert "502" in str(exc_info.value)

--- a/packages/traceloop-sdk/traceloop/sdk/evaluator/stream_client.py
+++ b/packages/traceloop-sdk/traceloop/sdk/evaluator/stream_client.py
@@ -55,9 +55,8 @@ class SSEClient:
     async def _handle_sse_response(self, response: httpx.Response) -> ExecutionResponse:
         """Handle SSE response: check status and parse result"""
         if response.status_code != 200:
-            error_text = await response.aread()
-            # TODO: Fix bytes formatting - should decode error_text or use !r
-            error_msg = f"Failed to stream results: {response.status_code}, body: {error_text}"  # type: ignore[str-bytes-safe]  # noqa: E501
+            error_text = (await response.aread()).decode(errors="replace")
+            error_msg = f"Failed to stream results: {response.status_code}, body: {error_text}"
             raise Exception(error_msg)
 
         response_text = await response.aread()


### PR DESCRIPTION
## Summary
Decode the bytes body in `SSEClient._handle_sse_response` before interpolating it into the error message, using `.decode(errors=\"replace\")` to stay safe on non-UTF-8 responses. Drops the acknowledging `# TODO`, the `# type: ignore[str-bytes-safe]`, and the `# noqa: E501`.

## Motivation
`response.aread()` returns `bytes`, so the previous f-string rendered the body as `b'{\"error\":...}'` — leading `b`, surrounding quotes, and `\xNN` escapes for any non-ASCII byte. The success path two lines below already does `response_text.decode()`; this PR reuses that pattern for the error path. The existing `# TODO: Fix bytes formatting - should decode error_text or use !r` in the file called this out.

## Test plan
- [x] New `tests/evaluator/test_stream_client.py` covers the happy path (readable decoded body in the raised exception, no `b'` artifact) and non-UTF-8 input (does not raise on decode).
- [x] `uv run ruff check` passes on the modified files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for failed streaming responses so response bodies are shown as readable text instead of raw bytes.
  * Ensured invalid text in error responses no longer breaks error handling; the HTTP status code is still included.

* **Tests**
  * Added coverage for error-response handling, including valid text bodies and invalid UTF-8 cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->