### PR TITLE
docs: add TokenLab OpenAI-compatible instrumentation example

### DIFF
--- a/packages/opentelemetry-instrumentation-openai/README.md
+++ b/packages/opentelemetry-instrumentation-openai/README.md
@@ -20,6 +20,28 @@ from opentelemetry.instrumentation.openai import OpenAIInstrumentor
 OpenAIInstrumentor().instrument()
 ```
 
+The instrumentation also works when the official OpenAI SDK is configured for an OpenAI-compatible endpoint. For example,
+TokenLab:
+
+```python
+import os
+
+from openai import OpenAI
+from opentelemetry.instrumentation.openai import OpenAIInstrumentor
+
+OpenAIInstrumentor().instrument()
+
+client = OpenAI(
+    api_key=os.environ["TOKENLAB_API_KEY"],
+    base_url="https://api.tokenlab.sh/v1",
+)
+
+client.chat.completions.create(
+    model="claude-sonnet-5",
+    messages=[{"role": "user", "content": "Trace this request"}],
+)
+```
+
 ## Privacy
 
 **By default, this instrumentation logs prompts, completions, and embeddings to span attributes**. This gives you a clear visibility into how your LLM application is working, and can make it easy to debug and evaluate the quality of the outputs.


### PR DESCRIPTION
## Summary
- Show OpenLLMetry's OpenAI instrumentation with a TokenLab base_url.
- Keep the change docs-only and scoped to the project's existing OpenAI-compatible configuration surface.

## Validation
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the example usage guide with an additional Python example.
  * Clarified that instrumentation works with OpenAI-compatible `base_url` configurations.
  * Added a sample showing how to create a client with a custom endpoint and trace chat completion requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

Supersedes #4354. The previous PR was closed while fixing contributor commit metadata; this replacement branch preserves the same scoped diff with commits authored by `hedging8563 <45883076+hedging8563@users.noreply.github.com>`.
