### PR TITLE
fix(cohere): avoid double-ending async error spans

### DIFF
--- a/packages/opentelemetry-instrumentation-cohere/opentelemetry/instrumentation/cohere/__init__.py
+++ b/packages/opentelemetry-instrumentation-cohere/opentelemetry/instrumentation/cohere/__init__.py
@@ -287,7 +287,6 @@ async def _awrap(
             if span.is_recording():
                 span.set_status(Status(StatusCode.ERROR, str(e)))
                 span.record_exception(e)
-                span.end()
             raise
 
         set_span_response_attributes(span, response)

--- a/packages/opentelemetry-instrumentation-cohere/tests/test_async_error_handling.py
+++ b/packages/opentelemetry-instrumentation-cohere/tests/test_async_error_handling.py
@@ -32,4 +32,11 @@ async def test_async_cohere_exception_records_error_once(
     assert span.name == "cohere.chat"
     assert span.status.status_code == StatusCode.ERROR
     assert "cohere async failure" in span.status.description
-    assert not any("Calling end() on an ended span" in record.message for record in caplog.records)
+    assert any(
+        event.name == "exception"
+        and "cohere async failure" in event.attributes.get("exception.message", "")
+        for event in span.events
+    )
+    assert not any(
+        "Calling end() on an ended span" in record.message for record in caplog.records
+    )

--- a/packages/opentelemetry-instrumentation-cohere/tests/test_async_error_handling.py
+++ b/packages/opentelemetry-instrumentation-cohere/tests/test_async_error_handling.py
@@ -1,0 +1,35 @@
+import logging
+
+import cohere
+import pytest
+from opentelemetry.instrumentation.cohere import CohereInstrumentor
+from opentelemetry.trace import StatusCode
+
+
+@pytest.mark.asyncio
+async def test_async_cohere_exception_records_error_once(
+    caplog, monkeypatch, span_exporter, tracer_provider
+):
+    async def failing_chat(self, *args, **kwargs):
+        raise RuntimeError("cohere async failure")
+
+    monkeypatch.setattr(cohere.AsyncClient, "chat", failing_chat)
+    instrumentor = CohereInstrumentor()
+    instrumentor.instrument(tracer_provider=tracer_provider)
+
+    try:
+        with caplog.at_level(logging.WARNING, logger="opentelemetry.sdk.trace"):
+            with pytest.raises(RuntimeError, match="cohere async failure"):
+                await cohere.AsyncClient("test_api_key").chat(
+                    model="command", message="Tell me a joke, pirate style"
+                )
+    finally:
+        instrumentor.uninstrument()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "cohere.chat"
+    assert span.status.status_code == StatusCode.ERROR
+    assert "cohere async failure" in span.status.description
+    assert not any("Calling end() on an ended span" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary

Fixes Cohere async instrumentation error handling so spans are not ended twice when an async Cohere call raises.

`_awrap()` uses `tracer.start_as_current_span(...)`, which already ends the span when the context manager exits. The exception handler also called `span.end()`, causing OpenTelemetry to emit:

```text
Calling end() on an ended span.
```

This removes the redundant manual end call while preserving ERROR status, exception recording, and re-raising behavior.

## Related

Related to #2338, which tracks Cohere async instrumentation behavior.

## Test Plan

- [x] `uv run pytest tests/test_async_error_handling.py tests/test_rerank.py::test_cohere_v2_rerank_legacy_async tests/test_chat.py::test_cohere_chat_legacy_async -q`
- [x] `uv run pytest tests/ -q`
- [x] `uv run ruff check .`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenTelemetry error handling for asynchronous Cohere chat requests.
  * Exceptions are still recorded with `ERROR` status, and spans now finish cleanly without duplicate-end warnings.
* **Tests**
  * Added an async test to verify the exception is raised once, the span is reported once with the correct error details, and includes an `exception` event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->