### PR TITLE
fix(groq,bedrock): emit cache token attributes that were silently dropped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
 on:
-  # TEMPORARY: base-branch filter lifted so stacked PRs get CI. Restore before merge.
   pull_request:
+    branches:
+      - "main"
   push:
     branches:
       - "main"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
 name: CI
 
 on:
+  # TEMPORARY: base-branch filter lifted so stacked PRs get CI. Restore before merge.
   pull_request:
-    branches:
-      - "main"
   push:
     branches:
       - "main"

--- a/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/span_utils.py
+++ b/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/span_utils.py
@@ -1088,7 +1088,7 @@ def converse_usage_record(span, response, metric_params):
     if cache_read_tokens is not None:
         _set_span_attribute(
             span,
-            SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+            GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
             cache_read_tokens,
         )
     if cache_write_tokens is not None:

--- a/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/span_utils.py
+++ b/packages/opentelemetry-instrumentation-bedrock/opentelemetry/instrumentation/bedrock/span_utils.py
@@ -1094,6 +1094,6 @@ def converse_usage_record(span, response, metric_params):
     if cache_write_tokens is not None:
         _set_span_attribute(
             span,
-            SpanAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
             cache_write_tokens,
         )

--- a/packages/opentelemetry-instrumentation-bedrock/tests/test_converse_cache_read_tokens.py
+++ b/packages/opentelemetry-instrumentation-bedrock/tests/test_converse_cache_read_tokens.py
@@ -1,10 +1,11 @@
-"""Reproduces silent loss of gen_ai.usage.cache_read.input_tokens on the
-Converse API path.
+"""Reproduces silent loss of gen_ai.usage.cache_read.input_tokens and
+gen_ai.usage.cache_creation.input_tokens on the Converse API path.
 
 `converse_usage_record` (opentelemetry/instrumentation/bedrock/span_utils.py)
-references `opentelemetry.semconv_ai.SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS`,
-which does not exist on that class — the constant only lives on upstream
-`GenAIAttributes` (opentelemetry.semconv._incubating.attributes.gen_ai_attributes).
+references `opentelemetry.semconv_ai.SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS`
+and `SpanAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS`, neither of which
+exists on that class — the constants only live on upstream `GenAIAttributes`
+(opentelemetry.semconv._incubating.attributes.gen_ai_attributes).
 Callers of `converse_usage_record` are wrapped in `@dont_throw`
 (see `_handle_converse` in `__init__.py`), so in production the resulting
 AttributeError is swallowed and the attribute never reaches the span with no
@@ -65,4 +66,23 @@ class TestConverseUsageRecordCacheReadTokens:
         assert (
             _get_attr(span, GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS)
             == 18131
+        )
+
+
+class TestConverseUsageRecordCacheWriteTokens:
+    def test_with_cache_write_tokens_sets_cache_creation_attribute(self):
+        span = _mock_span()
+        response = {
+            "usage": {
+                "inputTokens": 4,
+                "outputTokens": 50,
+                "cacheWriteInputTokens": 2048,
+            }
+        }
+        converse_usage_record(span, response, _FakeMetricParams())
+        assert (
+            _get_attr(
+                span, GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
+            )
+            == 2048
         )

--- a/packages/opentelemetry-instrumentation-bedrock/tests/test_converse_cache_read_tokens.py
+++ b/packages/opentelemetry-instrumentation-bedrock/tests/test_converse_cache_read_tokens.py
@@ -1,0 +1,68 @@
+"""Reproduces silent loss of gen_ai.usage.cache_read.input_tokens on the
+Converse API path.
+
+`converse_usage_record` (opentelemetry/instrumentation/bedrock/span_utils.py)
+references `opentelemetry.semconv_ai.SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS`,
+which does not exist on that class — the constant only lives on upstream
+`GenAIAttributes` (opentelemetry.semconv._incubating.attributes.gen_ai_attributes).
+Callers of `converse_usage_record` are wrapped in `@dont_throw`
+(see `_handle_converse` in `__init__.py`), so in production the resulting
+AttributeError is swallowed and the attribute never reaches the span with no
+error surfaced anywhere.
+
+This test calls `converse_usage_record` directly (undecorated) so the
+AttributeError surfaces instead of being swallowed.
+"""
+
+from unittest.mock import MagicMock
+
+from opentelemetry.instrumentation.bedrock.span_utils import converse_usage_record
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+
+
+def _mock_span():
+    """Return a mock span that records set_attribute calls."""
+    span = MagicMock()
+    span.is_recording.return_value = True
+    attrs = {}
+
+    def set_attr(key, value):
+        attrs[key] = value
+
+    span.set_attribute.side_effect = set_attr
+    span._attrs = attrs
+    return span
+
+
+def _get_attr(span, key):
+    return span._attrs.get(key)
+
+
+class _FakeMetricParams:
+    """Minimal stand-in for bedrock.MetricParams with histograms disabled."""
+
+    def __init__(self):
+        self.vendor = "AWS"
+        self.model = "anthropic.claude-3-5-haiku-20241022-v1:0"
+        self.is_stream = False
+        self.duration_histogram = None
+        self.token_histogram = None
+
+
+class TestConverseUsageRecordCacheReadTokens:
+    def test_with_cache_read_tokens_sets_cache_read_attribute(self):
+        span = _mock_span()
+        response = {
+            "usage": {
+                "inputTokens": 4,
+                "outputTokens": 50,
+                "cacheReadInputTokens": 18131,
+            }
+        }
+        converse_usage_record(span, response, _FakeMetricParams())
+        assert (
+            _get_attr(span, GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS)
+            == 18131
+        )

--- a/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/span_utils.py
+++ b/packages/opentelemetry-instrumentation-groq/opentelemetry/instrumentation/groq/span_utils.py
@@ -234,7 +234,7 @@ def set_model_response_attributes(span, response, token_histogram):
         if cached_tokens is not None:
             set_span_attribute(
                 span,
-                SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+                GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
                 cached_tokens,
             )
 

--- a/packages/opentelemetry-instrumentation-groq/tests/traces/test_span_utils.py
+++ b/packages/opentelemetry-instrumentation-groq/tests/traces/test_span_utils.py
@@ -473,20 +473,6 @@ class TestSetModelResponseAttributes:
         response["usage"]["prompt_tokens_details"] = {"cached_tokens": cached_tokens}
         return response
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Genuine source bug, out of scope for this test-only fix: "
-            "span_utils.py's set_model_response_attributes (non-streaming path) still "
-            "references the removed opentelemetry.semconv_ai.SpanAttributes."
-            "GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS (deleted upstream in #4243 in favor of "
-            "GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS). The AttributeError is "
-            "swallowed by @dont_throw, so the attribute silently never gets set on "
-            "non-streaming spans with cached prompt tokens. The streaming counterpart "
-            "(set_model_streaming_response_attributes) already uses the correct "
-            "GenAIAttributes constant and is unaffected."
-        ),
-    )
     def test_with_cached_tokens_sets_cache_read_attribute(self):
         span = _span()
         set_model_response_attributes(span, self._response_with_cached_tokens(cached_tokens=20), None)


### PR DESCRIPTION
Fixes a silent data-loss bug in three places. Found by the semconv conformance work in #4397, not by a bug report.

**Stacked on #4397** — it targets `gk/ai-native-maintainance` because it removes an `xfail` that #4397 introduced to document this bug. Retarget to `main` once that merges.

## The bug

`SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS` and `SpanAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS` do not exist. Those constants live on upstream `GenAIAttributes`; traceloop's `SpanAttributes` only carries the legacy `LLM_*` forms.

Three sites referenced the non-existent constants:

| Site | Path |
|---|---|
| groq, non-streaming | `groq/span_utils.py:237` |
| bedrock, cache read | `bedrock/span_utils.py:1091` |
| bedrock, cache write | `bedrock/span_utils.py:1097` |

Every enclosing function is `@dont_throw`-decorated, so the `AttributeError` was swallowed and **the attributes silently never reached the span**. Users lost cache token counts with no error anywhere — which is why this went unnoticed.

groq's streaming path (line 201) already used the correct constant, so a single file was internally inconsistent between adjacent blocks.

## Verification

Each fix follows `docs/ai/procedures/fix-instrumentation-bug.md`: a failing reproducing test committed on its own, then the fix. Four commits, alternating, and neither test commit touches instrumentation source.

RED was proven in an isolated git worktree at each test commit — both failed with the real `AttributeError` before the corresponding fix, then passed after.

- groq: 127 passed
- bedrock: 386 passed
- ruff clean on both

`grep -rn 'SpanAttributes\.GEN_AI_USAGE_CACHE' packages/*/opentelemetry` now returns only comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)