### PR TITLE
fix(ollama): emit gen_ai.response.finish_reasons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
 on:
-  # TEMPORARY: base-branch filter lifted so stacked PRs get CI. Restore before merge.
   pull_request:
+    branches:
+      - "main"
   push:
     branches:
       - "main"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
 name: CI
 
 on:
+  # TEMPORARY: base-branch filter lifted so stacked PRs get CI. Restore before merge.
   pull_request:
-    branches:
-      - "main"
   push:
     branches:
       - "main"

--- a/packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/span_utils.py
+++ b/packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/span_utils.py
@@ -91,6 +91,11 @@ def set_model_response_attributes(span, token_histogram, llm_request_type, respo
 
     _set_span_attribute(span, GenAIAttributes.GEN_AI_RESPONSE_MODEL, response.get("model"))
 
+    if done_reason := response.get("done_reason"):
+        _set_span_attribute(
+            span, GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS, [done_reason]
+        )
+
     input_tokens = response.get("prompt_eval_count") or 0
     output_tokens = response.get("eval_count") or 0
 

--- a/packages/opentelemetry-instrumentation-ollama/tests/test_chat.py
+++ b/packages/opentelemetry-instrumentation-ollama/tests/test_chat.py
@@ -54,6 +54,32 @@ def test_ollama_chat_legacy(
 
 
 @pytest.mark.vcr
+@pytest.mark.default_cassette("test_ollama_chat_legacy")
+def test_ollama_chat_sets_finish_reasons(
+    instrument_legacy, ollama_client, span_exporter, log_exporter
+):
+    """Reproduces the gap: span_utils.py never sets
+    gen_ai.response.finish_reasons even though the Ollama API response
+    carries done_reason (see cassette test_ollama_chat_legacy.yaml)."""
+    ollama_client.chat(
+        model="llama3",
+        messages=[
+            {
+                "role": "user",
+                "content": "Tell me a joke about OpenTelemetry",
+            },
+        ],
+    )
+
+    spans = span_exporter.get_finished_spans()
+    ollama_span = spans[0]
+    assert ollama_span.name == "ollama.chat"
+    assert ollama_span.attributes.get(
+        GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS
+    ) == ("stop",)
+
+
+@pytest.mark.vcr
 def test_ollama_chat_with_events_with_content(
     instrument_with_content, ollama_client, span_exporter, log_exporter
 ):

--- a/packages/opentelemetry-instrumentation-ollama/tests/test_conformance.py
+++ b/packages/opentelemetry-instrumentation-ollama/tests/test_conformance.py
@@ -25,13 +25,14 @@ CONTRACT_GROUP = "span.gen_ai.inference.client"
 # marks most of these merely `recommended`, so without this set the harness would
 # not notice them going missing. Adding a name here is a commitment.
 #
-# Note: `gen_ai.response.finish_reasons` is NOT emitted by this package in either
-# the legacy or streaming path (span_utils.py never sets it), so it is
-# deliberately absent from EXPECTED — a #4362-class gap.
+# `gen_ai.response.finish_reasons` is set from Ollama's `done_reason` in
+# span_utils.py (set_model_response_attributes), in both the legacy and
+# streaming paths — closing the #4362-class gap.
 EXPECTED = frozenset(
     {
         "gen_ai.request.model",
         "gen_ai.response.model",
+        "gen_ai.response.finish_reasons",
         "gen_ai.usage.input_tokens",
         "gen_ai.usage.output_tokens",
     }


### PR DESCRIPTION
Closes a semconv conformance gap the contract surfaced. Second pilot of `docs/ai/procedures/fix-instrumentation-bug.md`.

**Stacked on #4398** (which is stacked on #4397). Retarget as those merge.

## The gap

Ollama's API returns `done_reason`, and the events path already reads it (`event_emitter.py:84,97`) — but `span_utils.py` never set `gen_ai.response.finish_reasons`, so span consumers lost it entirely.

The contract marks that attribute `recommended` for `span.gen_ai.inference.client`, which is precisely why the contract alone never flagged it. Only ~9% of contract attributes are `required`; see `docs/ai/knowledge/semconv-requirement-levels-are-weak.md`.

## The fix

`span_utils.py` now emits `GEN_AI_RESPONSE_FINISH_REASONS` as a one-element sequence from `done_reason`, following the pattern already used in `opentelemetry-instrumentation-cohere` (walrus-guarded, single string wrapped in a list). Anthropic's approach was not copied — it needs a reason-mapping table that ollama's single string does not warrant.

Nothing is emitted when `done_reason` is absent.

## Why it cannot silently regress

`gen_ai.response.finish_reasons` is added to `EXPECTED` in ollama's `tests/test_conformance.py`. That set is the package's declared promise, and a missing promise is a `missing_expected` violation independent of the registry's requirement level.

Verified by reverting only the source fix while keeping the declaration:

```
[missing_expected] gen_ai.response.finish_reasons: this package promises to
emit it, but the span does not carry it
```

`ENFORCING` stays `False`, so this warns today and blocks when ollama flips to enforcing.

## Verification

Two commits — failing test alone, then the fix. RED proven in an isolated git worktree at the test commit (`assert None == ('stop',)`), green after.

Reuses the existing `test_chat/test_ollama_chat_legacy.yaml` cassette (contains `"done_reason":"stop"`). No cassettes recorded, no API keys.

- ollama suite: 43 passed (baseline 42 + 1)
- ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)