### PR TITLE
feat(ci): add TDD gate enforcing failing-test-first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,43 @@ jobs:
       - run: npx nx affected -t lint --parallel=3
       - run: npx nx affected -t type-check --parallel=3
 
+  tdd-gate:
+    name: TDD Gate
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'tdd-gate')
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - run: npm ci --cache ~/.npm --prefer-offline
+      - name: Clean npm cache
+        run: npm cache clean --force || true
+
+      # Opt-in only: forcing the test-first shape on every outside contributor
+      # would be hostile, but AI-authored PRs will carry the `tdd-gate` label.
+      # Runs against the PR base so the gate sees exactly the commits the PR adds.
+      - name: Enforce test-driven bug fixing
+        run: python3 tools/tdd_gate/tdd_gate.py --base "origin/${{ github.base_ref }}" --head "${{ github.event.pull_request.head.sha }}"
+
   build-packages:
     name: Build Packages
     runs-on: ubuntu-latest

--- a/tools/tdd_gate/project.json
+++ b/tools/tdd_gate/project.json
@@ -1,0 +1,29 @@
+{
+  "name": "tdd-gate",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "targets": {
+    "install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "uv sync --all-groups",
+        "cwd": "tools/tdd_gate"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "uv run ruff check .",
+        "cwd": "tools/tdd_gate"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "uv run pytest test_tdd_gate.py -v",
+        "cwd": "tools/tdd_gate"
+      }
+    }
+  },
+  "tags": ["tooling"]
+}

--- a/tools/tdd_gate/pyproject.toml
+++ b/tools/tdd_gate/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "tdd-gate"
+version = "0.1.0"
+description = "Mechanically enforces test-driven bug fixing on a commit range (repo tooling, not published)"
+requires-python = ">=3.10,<4"
+dependencies = []
+
+[dependency-groups]
+dev = [
+  "pytest>=8.2.2,<9",
+  "ruff>=0.4.0",
+]
+
+[tool.uv]
+package = false
+
+[tool.ruff]
+line-length = 120
+exclude = [".git", "__pycache__", "build", "dist", ".venv", ".pytest_cache"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W"]

--- a/tools/tdd_gate/tdd_gate.py
+++ b/tools/tdd_gate/tdd_gate.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Mechanically enforces test-driven bug fixing on a commit range.
+
+"Write a failing test first" is unverifiable as a prompt instruction — an
+agent can claim compliance and nothing checks. This gate makes it structural
+by re-deriving the fact that matters: the new test actually failed before the
+fix existed. Four checks, all required:
+
+  SHAPE   a `test:`/`test(scope):` commit is followed by a `fix:`/`feat:`
+          commit (optionally scoped).
+  PURITY  no `test:` commit touches instrumentation source
+          (packages/*/opentelemetry/**) — a fix smuggled into the test
+          commit would defeat the RED check below.
+  RED     each `test:` commit, checked out in isolation via `git worktree`,
+          must FAIL when its new/changed test files run there.
+  GREEN   at head, the same test files must pass.
+
+Pure logic (subject classification, test-file extraction, purity checking)
+is unit-tested directly in test_tdd_gate.py. Everything past the plumbing
+divider does real git/subprocess work and is instead exercised by running
+this script against real branches (see the task's VERIFY section).
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+SUBJECT_RE = re.compile(r"^(test|fix|feat)(\([^)]*\))?:\s*\S")
+IMPURE_GLOB = "packages/*/opentelemetry/*"
+PYTEST_STARTED_MARKER = "test session starts"
+
+
+# --------------------------------------------------------------------------
+# Pure logic — no subprocess, no filesystem. Unit-tested directly.
+# --------------------------------------------------------------------------
+
+
+def classify_subject(subject: str) -> str | None:
+    """Return 'test', 'fix', or 'feat' for a commit subject, else None.
+
+    Accepts an optional `(scope)` between the type and the colon, e.g.
+    `test(ollama): reproduce ...`.
+    """
+    match = SUBJECT_RE.match(subject.strip())
+    return match.group(1) if match else None
+
+
+def validate_shape(kinds: list[str | None]) -> str | None:
+    """Require a 'test' classification followed later by a 'fix'/'feat' one.
+
+    Returns an error message, or None if the shape is valid. Unrelated
+    commits may be interleaved; only relative order of test vs. fix/feat
+    matters.
+    """
+    test_idxs = [i for i, k in enumerate(kinds) if k == "test"]
+    if not test_idxs:
+        return (
+            "no commit subject starts with `test:` or `test(scope):` — the "
+            "required shape is a test commit followed by a fix/feat commit"
+        )
+    fix_idxs = [i for i, k in enumerate(kinds) if k in ("fix", "feat")]
+    if not fix_idxs:
+        return "a test: commit exists, but no fix:/feat: commit follows it"
+    if not any(f > t for t in test_idxs for f in fix_idxs):
+        return (
+            "a test: commit and a fix:/feat: commit both exist, but no "
+            "fix:/feat: commit comes after any test: commit"
+        )
+    return None
+
+
+def find_impure_paths(paths: list[str]) -> list[str]:
+    """Paths that touch instrumentation source (packages/*/opentelemetry/**);
+    a test: commit must have none."""
+    return [p for p in paths if fnmatch.fnmatch(p, IMPURE_GLOB)]
+
+
+def extract_test_files(paths: list[str]) -> list[str]:
+    """Paths that are `.py` files under a `tests/` directory."""
+    return [p for p in paths if p.endswith(".py") and "tests" in Path(p).parts[:-1]]
+
+
+def package_for_path(path: str) -> str | None:
+    """Extract `<pkg>` from `packages/<pkg>/...`, or None."""
+    parts = Path(path).parts
+    return parts[1] if len(parts) >= 2 and parts[0] == "packages" else None
+
+
+def group_by_package(paths: list[str]) -> dict[str, list[str]]:
+    """Group test-file paths by package, each made relative to its package
+    directory (e.g. packages/foo/tests/x.py -> {"foo": ["tests/x.py"]})."""
+    groups: dict[str, list[str]] = {}
+    for p in paths:
+        pkg = package_for_path(p)
+        if pkg is None:
+            continue
+        rel = str(Path(*Path(p).parts[2:]))
+        groups.setdefault(pkg, []).append(rel)
+    return groups
+
+
+def pytest_actually_ran(output: str) -> bool:
+    """False if `uv run pytest` errored before pytest itself started (e.g. an
+    unresolved environment) — such a run must NOT be treated as a pass."""
+    return PYTEST_STARTED_MARKER in output
+
+
+# --------------------------------------------------------------------------
+# Plumbing: git, subprocess, worktrees.
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Commit:
+    sha: str
+    subject: str
+    kind: str | None = None
+    changed_paths: list[str] = field(default_factory=list)
+
+
+@dataclass
+class PytestResult:
+    ran: bool
+    returncode: int
+    output: str
+
+
+def run_git(args: list[str], cwd: Path) -> str:
+    proc = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed:\n{proc.stderr}")
+    return proc.stdout
+
+
+def get_commits(base: str, head: str, cwd: Path) -> list[Commit]:
+    out = run_git(["log", "--reverse", "--format=%H%x1f%s", f"{base}..{head}"], cwd=cwd)
+    commits = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        sha, subject = line.split("\x1f", 1)
+        commits.append(Commit(sha=sha, subject=subject, kind=classify_subject(subject)))
+    return commits
+
+
+def get_changed_paths(sha: str, cwd: Path) -> list[str]:
+    out = run_git(["show", "--name-only", "--format=", sha], cwd=cwd)
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def run_pytest(paths: list[str], cwd: Path) -> PytestResult:
+    # --all-groups mirrors every package's `install` nx target (`uv sync
+    # --all-groups`) — the "test" dependency group (VCR, provider SDKs, etc.)
+    # is not part of uv's default group and would otherwise be missing.
+    proc = subprocess.run(
+        ["uv", "run", "--all-groups", "pytest", "-v", *paths],
+        cwd=cwd, capture_output=True, text=True,
+    )
+    output = proc.stdout + proc.stderr
+    return PytestResult(ran=pytest_actually_ran(output), returncode=proc.returncode, output=output)
+
+
+class Worktree:
+    """A temporary `git worktree` at a given sha, always cleaned up (even on
+    failure) — this is what makes the RED check isolated."""
+
+    def __init__(self, repo_root: Path, sha: str):
+        self.repo_root = repo_root
+        self.sha = sha
+        self.path: Path | None = None
+
+    def __enter__(self) -> Path:
+        self.path = Path(tempfile.mkdtemp(prefix="tdd-gate-wt-"))
+        shutil.rmtree(self.path)  # git worktree add needs to create it itself
+        run_git(["worktree", "add", "--detach", str(self.path), self.sha], cwd=self.repo_root)
+        return self.path
+
+    def __exit__(self, *exc_info) -> None:
+        if self.path is None:
+            return
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(self.path)],
+            cwd=self.repo_root, capture_output=True,
+        )
+        shutil.rmtree(self.path, ignore_errors=True)
+        subprocess.run(["git", "worktree", "prune"], cwd=self.repo_root, capture_output=True)
+
+
+# --------------------------------------------------------------------------
+# The gate itself.
+# --------------------------------------------------------------------------
+
+
+def indent(text: str, prefix: str = "    ") -> str:
+    return "\n".join(prefix + line for line in text.splitlines())
+
+
+def run_pytest_per_package(test_paths: list[str], cwd: Path) -> list[tuple[str, PytestResult]]:
+    return [
+        (pkg, run_pytest(rel_paths, cwd / "packages" / pkg))
+        for pkg, rel_paths in sorted(group_by_package(test_paths).items())
+    ]
+
+
+def check_results(results: list[tuple[str, PytestResult]], phase: str, expect_fail: bool) -> str | None:
+    """Print each package's captured pytest output and return an error
+    message (or None) per the RED/GREEN contract for that phase."""
+    for pkg, result in results:
+        print(f"  --- uv run pytest output ({pkg}) ---")
+        print(indent(result.output))
+        if not result.ran:
+            return (
+                f"{phase}: FAIL — pytest never started for {pkg} (uv could not "
+                "resolve the environment); an unrunnable check does not count as a pass"
+            )
+        if expect_fail and result.returncode == 0:
+            return (
+                f"{phase}: FAIL — the test PASSED before the fix exists ({pkg}); "
+                "it never failed, so it proves nothing"
+            )
+        if not expect_fail and result.returncode != 0:
+            return f"{phase}: FAIL — the test still fails at head ({pkg})"
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--head", default="HEAD")
+    args = parser.parse_args()
+
+    repo_root = Path(run_git(["rev-parse", "--show-toplevel"], cwd=Path.cwd()).strip())
+    print(f"TDD gate: {args.base}..{args.head}\n")
+
+    commits = get_commits(args.base, args.head, repo_root)
+    if not commits:
+        print(f"No commits found in range {args.base}..{args.head}.")
+        return 1
+
+    print("Commits in range:")
+    for c in commits:
+        print(f"  {c.sha[:10]}  [{c.kind or '?'}]  {c.subject}")
+    print()
+
+    shape_error = validate_shape([c.kind for c in commits])
+    if shape_error:
+        print(f"SHAPE: FAIL — {shape_error}")
+        return 1
+    print("SHAPE: ok — a test: commit is followed by a fix:/feat: commit")
+
+    test_commits = [c for c in commits if c.kind == "test"]
+    for c in test_commits:
+        c.changed_paths = get_changed_paths(c.sha, repo_root)
+
+    impure = [(c, find_impure_paths(c.changed_paths)) for c in test_commits]
+    impure = [(c, offenders) for c, offenders in impure if offenders]
+    if impure:
+        print("PURITY: FAIL")
+        for c, offenders in impure:
+            print(f"  {c.sha[:10]} ({c.subject}) touches instrumentation source:")
+            for path in offenders:
+                print(f"    {path}")
+        return 1
+    print("PURITY: ok — no test: commit touches packages/*/opentelemetry/**")
+
+    all_test_files: list[str] = []
+    for c in test_commits:
+        files = extract_test_files(c.changed_paths)
+        if not files:
+            print(
+                f"RED: FAIL — {c.sha[:10]} ({c.subject}) adds/modifies no *.py "
+                "file under a tests/ directory, so there is nothing to prove failed"
+            )
+            return 1
+        all_test_files.extend(files)
+
+        print(f"\nRED check for {c.sha[:10]} ({c.subject}):")
+        print(f"  test files: {files}")
+        with Worktree(repo_root, c.sha) as wt_path:
+            error = check_results(run_pytest_per_package(files, wt_path), "RED", expect_fail=True)
+            if error:
+                print(error)
+                return 1
+    print("RED: ok — every new test failed in isolation before its fix")
+
+    print(f"\nGREEN check at {args.head}:")
+    with Worktree(repo_root, args.head) as wt_path:
+        error = check_results(run_pytest_per_package(all_test_files, wt_path), "GREEN", expect_fail=False)
+        if error:
+            print(error)
+            return 1
+    print("GREEN: ok — the tests pass at head")
+
+    print("\nTDD gate: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tdd_gate/test_tdd_gate.py
+++ b/tools/tdd_gate/test_tdd_gate.py
@@ -1,0 +1,113 @@
+"""Unit tests for the TDD gate's pure logic.
+
+These test plain data in, plain data out — no real git repo, no subprocess,
+no filesystem. The git/subprocess plumbing in tdd_gate.py is exercised
+instead by running the script against real branches (see the task's VERIFY
+section), because faking git history well enough to unit-test it would be
+less trustworthy than the real thing.
+"""
+from tdd_gate import (
+    classify_subject,
+    extract_test_files,
+    find_impure_paths,
+    validate_shape,
+)
+
+
+class TestClassifySubject:
+    def test_recognises_plain_test(self):
+        assert classify_subject("test: reproduce missing finish reasons") == "test"
+
+    def test_recognises_scoped_test(self):
+        assert classify_subject("test(ollama): reproduce missing finish reasons") == "test"
+
+    def test_recognises_plain_fix(self):
+        assert classify_subject("fix: emit gen_ai.response.finish_reasons") == "fix"
+
+    def test_recognises_scoped_fix(self):
+        assert classify_subject("fix(ollama): emit gen_ai.response.finish_reasons") == "fix"
+
+    def test_recognises_plain_feat(self):
+        assert classify_subject("feat: add litellm instrumentation") == "feat"
+
+    def test_recognises_scoped_feat(self):
+        assert classify_subject("feat(litellm): add package instrumentation") == "feat"
+
+    def test_rejects_non_conforming_subject(self):
+        assert classify_subject("docs: update the README") is None
+
+    def test_rejects_bare_type_with_no_colon(self):
+        assert classify_subject("test something without a colon") is None
+
+    def test_rejects_empty_subject(self):
+        assert classify_subject("") is None
+
+
+class TestValidateShape:
+    def test_valid_test_then_fix(self):
+        assert validate_shape(["test", "fix"]) is None
+
+    def test_valid_test_then_feat(self):
+        assert validate_shape(["test", "feat"]) is None
+
+    def test_valid_with_unrelated_commits_interleaved(self):
+        assert validate_shape([None, "test", None, "fix", None]) is None
+
+    def test_rejects_no_test_commit(self):
+        error = validate_shape(["fix", "feat"])
+        assert error is not None
+        assert "test:" in error
+
+    def test_rejects_test_with_no_following_fix(self):
+        error = validate_shape(["test", None])
+        assert error is not None
+        assert "fix" in error
+
+    def test_rejects_fix_before_test(self):
+        """A fix: commit that precedes the test: commit does not satisfy the
+        shape — the fix must come after, proving the test drove it."""
+        error = validate_shape(["fix", "test"])
+        assert error is not None
+
+    def test_rejects_empty_range(self):
+        assert validate_shape([]) is not None
+
+
+class TestFindImpurePaths:
+    def test_flags_instrumentation_source(self):
+        paths = ["packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/span_utils.py"]
+        assert find_impure_paths(paths) == paths
+
+    def test_does_not_flag_tests_paths(self):
+        paths = ["packages/opentelemetry-instrumentation-ollama/tests/test_chat.py"]
+        assert find_impure_paths(paths) == []
+
+    def test_mixed_list_flags_only_the_instrumentation_path(self):
+        impure = "packages/foo/opentelemetry/instrumentation/foo/bar.py"
+        pure = "packages/foo/tests/test_bar.py"
+        assert find_impure_paths([impure, pure]) == [impure]
+
+    def test_empty_list_is_pure(self):
+        assert find_impure_paths([]) == []
+
+
+class TestExtractTestFiles:
+    def test_extracts_py_file_under_tests_dir(self):
+        paths = ["packages/opentelemetry-instrumentation-ollama/tests/test_chat.py"]
+        assert extract_test_files(paths) == paths
+
+    def test_ignores_non_test_directory_py_files(self):
+        paths = ["packages/opentelemetry-instrumentation-ollama/opentelemetry/instrumentation/ollama/span_utils.py"]
+        assert extract_test_files(paths) == []
+
+    def test_ignores_non_py_files_under_tests(self):
+        paths = ["packages/opentelemetry-instrumentation-ollama/tests/cassettes/test_chat.yaml"]
+        assert extract_test_files(paths) == []
+
+    def test_mixed_list_extracts_only_the_test_file(self):
+        test_file = "packages/foo/tests/test_bar.py"
+        source_file = "packages/foo/opentelemetry/instrumentation/foo/bar.py"
+        assert extract_test_files([test_file, source_file]) == [test_file]
+
+    def test_empty_list_yields_no_test_files(self):
+        assert extract_test_files([]) == []

--- a/tools/tdd_gate/uv.lock
+++ b/tools/tdd_gate/uv.lock
@@ -1,0 +1,185 @@
+version = 1
+revision = 3
+requires-python = ">=3.10, <4"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/25/7113f6d5498888c5fb7db34081cba7d5971c4cb1bfb26819966eee68f003/ruff-0.16.1.tar.gz", hash = "sha256:fedad7c801dabd3fb9741d76aca39246e6ddd9ca446a015875207bf19f1e6bc7", size = 4877500, upload-time = "2026-07-30T19:37:01.379Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/bd/694da69368e0973de65df2ddc73ab18d43c469d5963d9b150911de6bc513/ruff-0.16.1-py3-none-linux_armv6l.whl", hash = "sha256:58edb313b88f0c5460a26adf5f39a37a3be789494a15e3e411e35fa78b89f9a0", size = 10839126, upload-time = "2026-07-30T19:36:13.697Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f0/b626e5d5bd0dd9576263658ef12885e2288afd1029a48e26ffed65ec1ac1/ruff-0.16.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fde5a99e2f97479af66edd6622c6d5a2a7592c77cf4153d9e4428f5eeb55b60c", size = 11070253, upload-time = "2026-07-30T19:36:17.14Z" },
+    { url = "https://files.pythonhosted.org/packages/83/63/f40acfb6b35b88623e71684942b552c3edd96035f5d98f313815f7b277de/ruff-0.16.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e0d4c20532fca4f7fa609369161d968dd28f65d83dabbd61d8e9c7edbf7001f6", size = 10561425, upload-time = "2026-07-30T19:36:20.04Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/14ec0e9c2b4d315547dd38765004b4863e354e1b52cb308272215d9f6f6d/ruff-0.16.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30affbcedf59ad5703d9c91f82266e02b47739f797e1a7b6e158e5526a6dae38", size = 10948879, upload-time = "2026-07-30T19:36:22.476Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e9/9d870cbae575030fdef595f04b4b97573c525b5497cce4f4498cf2f85446/ruff-0.16.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24e9c631573cbca9d20f1283f8f479b2afa4a8503504822bd71a293889f16743", size = 10643691, upload-time = "2026-07-30T19:36:24.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/09/12743d544e2173f53ecd27217c65f90d2bc0f8424a66a60339e56bbc0457/ruff-0.16.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b41bdd48fb420987a9b5212e4957c26ad4abce401fa9ea9d4d85843727945f4f", size = 11435354, upload-time = "2026-07-30T19:36:28.447Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/89/a1652b2daee52083c9554a6333b678a8b01d0400f976827bb87857f9449a/ruff-0.16.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b0d1e1393b7648079e13669de1c1f4fde06d4583e84d8fd5c1551e0a77a2aa75", size = 12259033, upload-time = "2026-07-30T19:36:31.326Z" },
+    { url = "https://files.pythonhosted.org/packages/16/96/ecdcb8c54ee7b123b487f807eb014e6e019155a0b81dfb669acd52f28ce3/ruff-0.16.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:07bf434b1c95f4e093be4532068ef4fcf00924eb2ade8796075980902d6fd54a", size = 11667981, upload-time = "2026-07-30T19:36:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/90/c52e12e0d862e9572f2a33aa227409143520abe53111e9a6babbac7b4af8/ruff-0.16.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39897739f112253ee4fdd2e8aa9a4f9ded99fb2be367d5f31dfa4ded6025584c", size = 11468183, upload-time = "2026-07-30T19:36:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6b/4ffb7ad1d83eb16cf8cbb3c8815d3f11c88460fd162d4b372a2059be1c2a/ruff-0.16.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82ae3c0c0d74daf17b968a10b7b3bb3ef297ab7de0c1f749646b25e690ccb150", size = 11470071, upload-time = "2026-07-30T19:36:39.91Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/32ae7db4c0b5e32ab611787caa19d1546800676d79f7483b7100a3561bf4/ruff-0.16.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4d5f2ed10f8242d83fc08d521301089364e3375375705356f20c0e31606ef3ef", size = 10919503, upload-time = "2026-07-30T19:36:42.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/3d901ba6ad6fc38da39c3448fc6c59ac945679293a17c3ceb6d6c1cba13e/ruff-0.16.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a4665b309891f83f3e3c25447935f1213e9abbd4b5640af7a1f2def9f8d413c1", size = 10649861, upload-time = "2026-07-30T19:36:45.18Z" },
+    { url = "https://files.pythonhosted.org/packages/92/79/894ef1ced26552d5f8c9cf6d85b0687840e1128c55aeab7b9c2d54a0d880/ruff-0.16.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26e9ca5c9bc3971f20d3cf18a957f52ffd6a5f6564ff15c4912a144dcac22494", size = 11148137, upload-time = "2026-07-30T19:36:47.936Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/69/3609a09fa1cb46cc28b762363e440a354204e5dff01bd0c8d7437874d6b9/ruff-0.16.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:67e1e1e3fa4f0c82f0e36d4cd61e661f6e7a6196cb1aa92fe0828fa7b8f257cd", size = 11559211, upload-time = "2026-07-30T19:36:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8a/fb22af2fd78a736e241fabf67e30ce1799a64244026377a49e133af90762/ruff-0.16.1-py3-none-win32.whl", hash = "sha256:d31765e131295b8445caf301e3e8a85b34d1b9b211b4109b7ba457888b051806", size = 10838258, upload-time = "2026-07-30T19:36:53.298Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/35/e57fd9fb5d423961df087a00b12d42c0a830288dc2f3b45ecca299158b4f/ruff-0.16.1-py3-none-win_amd64.whl", hash = "sha256:09b05e8b90c2cb06ad63464350e7a45e8e44a2dfe52072ebfba6666ca8d3f596", size = 11961111, upload-time = "2026-07-30T19:36:56.107Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/240ea004bf6dc4feb40e9832f2205a476a47dd5b8a3f8211a5fc5f95e20e/ruff-0.16.1-py3-none-win_arm64.whl", hash = "sha256:dbaadaac38c70239f056d306b7476f246b0bf000fa6b3876402acbf5b227eaf8", size = 11309414, upload-time = "2026-07-30T19:36:58.79Z" },
+]
+
+[[package]]
+name = "tdd-gate"
+version = "0.1.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.2.2,<9" },
+    { name = "ruff", specifier = ">=0.4.0" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]


### PR DESCRIPTION
Adds a CI gate that mechanically enforces test-driven bug fixing. Opt-in via the `tdd-gate` label.

Foundation for the autonomous fix loop: "write a failing test first" as a prompt instruction is unverifiable — an agent claims compliance and nothing can tell. This makes it structural.

## What it checks

Given a PR's commit range:

| Check | Requirement |
|---|---|
| **Shape** | A `test:` commit must precede a `fix:`/`feat:` commit |
| **Purity** | `test:` commits must touch no `packages/*/opentelemetry/**` — a fix smuggled into the test commit defeats the gate |
| **RED** | The test commit is checked out in an isolated `git worktree` and its tests must **FAIL** there |
| **GREEN** | The same tests must pass at head |

**RED is the check that carries the weight.** A test that never failed proves nothing, and this catches the three ways completion gets faked: a test that asserts nothing, a test that passes trivially, and a "fix" for a bug that was never real.

It also **fails closed**: if pytest cannot start (unresolvable environment), that is a failure, not a pass. An unrunnable check must never be mistaken for a green one.

## Verification

Four fixture cases, all confirmed in throwaway clones:

1. **Passes** on the real `gk/ollama-finish-reasons` branch — exit 0, RED captured as `assert None == ('stop',)`, GREEN 17/17
2. **Fails** when there is no `test:` commit
3. **Fails**, naming the path, when a `test:` commit also edits instrumentation source
4. **Fails** on a vacuous `assert True` test — the critical case; a gate that passes this is decorative

The gate's own logic is unit-tested (25 tests), linted, and wired into nx via `uv` so it runs correctly under `nx affected -t test`.

## Opt-in on purpose

It runs only on PRs labelled `tdd-gate`. Imposing this shape on every outside contributor would be hostile; AI-authored PRs will carry the label.

## Derived from practice, not theory

Both checks were hand-validated on real fixes first (#4398, #4399) before being mechanized here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in pull request check that enforces test-driven development practices.
  * Validates commit structure and test changes, ensuring new tests fail before implementation and pass afterward.
  * Provides clear failure reporting for commits or tests that do not meet the gate’s requirements.

* **Tests**
  * Added automated coverage for commit validation, test detection, and change classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->