### PR TITLE
fix(anthropic): skip NotGiven/Omit sentinel in set_span_attribute

### DIFF
--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/utils.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/utils.py
@@ -23,7 +23,8 @@ TRACELOOP_TRACE_CONTENT = "TRACELOOP_TRACE_CONTENT"
 def set_span_attribute(span, name, value):
     if value is not None:
         if value != "":
-            span.set_attribute(name, value)
+            if type(value).__name__ not in ("Omit", "NotGiven"):
+                span.set_attribute(name, value)
     return
 
 

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_set_span_attribute.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_set_span_attribute.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock
+
+import anthropic
+import pytest
+
+from opentelemetry.instrumentation.anthropic.utils import set_span_attribute
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(anthropic.NOT_GIVEN, id="not-given"),
+        pytest.param(anthropic.Omit(), id="omit"),
+    ],
+)
+def test_set_span_attribute_skips_anthropic_sentinels(value):
+    span = MagicMock()
+
+    set_span_attribute(span, "gen_ai.request.temperature", value)
+
+    span.set_attribute.assert_not_called()


### PR DESCRIPTION
<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [x] I have added tests that cover my changes.
- [x] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [x] (If applicable) I have updated the documentation accordingly.(Not applicable)

## Summary

Skip Anthropic SDK `Omit` and `NotGiven` sentinel values in `set_span_attribute`.

This prevents unset optional parameters such as `temperature` and `top_p` from being passed to OpenTelemetry as invalid span attribute types.

## Testing

Added regression coverage for both `anthropic.NOT_GIVEN` and `anthropic.Omit()`.

Fixes #4431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Anthropic instrumentation to ignore unspecified option values when recording telemetry.
  * Prevented internal sentinel values from appearing as span attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->