### PR TITLE
feat(anthropic): emit gen_ai.usage.reasoning_tokens from extended thinking

### DIFF
--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
@@ -207,6 +207,14 @@ async def _aset_token_usage(
     token_histogram: Histogram = None,
     choice_counter: Counter = None,
 ):
+    """Record token-usage and choice metrics on *span* from an async Anthropic response.
+
+    Handles coroutine responses, ``with_raw_response`` wrappers, and falls back
+    to client-side counting when the SDK does not supply usage data.
+    Sets input, output, total, cache-read, cache-creation, and reasoning-token
+    span attributes, and emits token histograms and choice counters when
+    configured.
+    """
     import inspect
 
     # If we get a coroutine, await it
@@ -331,6 +339,13 @@ def _set_token_usage(
     token_histogram: Histogram = None,
     choice_counter: Counter = None,
 ):
+    """Record token-usage and choice metrics on *span* from a synchronous Anthropic response.
+
+    Handles ``with_raw_response`` wrappers and falls back to client-side
+    counting when the SDK does not supply usage data. Sets input, output,
+    total, cache-read, cache-creation, and reasoning-token span attributes,
+    and emits token histograms and choice counters when configured.
+    """
     import inspect
 
     # If we get a coroutine, we cannot process it in sync context
@@ -475,6 +490,7 @@ def _with_chat_telemetry_wrapper(func):
 
 
 def _create_metrics(meter: Meter):
+    """Create token, choice, duration, and exception metrics on *meter*."""
     token_histogram = meter.create_histogram(
         name=Meters.LLM_TOKEN_USAGE,
         unit="token",
@@ -504,6 +520,7 @@ def _create_metrics(meter: Meter):
 
 @dont_throw
 def _handle_input(span: Span, event_logger: Optional[Logger], kwargs):
+    """Populate *span* input attributes from *kwargs*, or emit input events if enabled."""
     if should_emit_events() and event_logger:
         emit_input_events(event_logger, kwargs)
     else:
@@ -514,6 +531,7 @@ def _handle_input(span: Span, event_logger: Optional[Logger], kwargs):
 
 @dont_throw
 async def _ahandle_input(span: Span, event_logger: Optional[Logger], kwargs):
+    """Populate *span* input attributes from *kwargs*, or emit input events if enabled."""
     if should_emit_events() and event_logger:
         emit_input_events(event_logger, kwargs)
     else:
@@ -524,6 +542,7 @@ async def _ahandle_input(span: Span, event_logger: Optional[Logger], kwargs):
 
 @dont_throw
 async def _ahandle_response(span: Span, event_logger: Optional[Logger], response):
+    """Populate *span* response attributes from *response*, or emit response events if enabled."""
     if should_emit_events():
         emit_response_events(event_logger, response)
     else:
@@ -538,6 +557,7 @@ async def _ahandle_response(span: Span, event_logger: Optional[Logger], response
 
 @dont_throw
 def _handle_response(span: Span, event_logger: Optional[Logger], response):
+    """Populate *span* response attributes from *response*, or emit response events if enabled."""
     if should_emit_events():
         emit_response_events(event_logger, response)
     else:

--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/__init__.py
@@ -187,6 +187,16 @@ def is_stream_manager(response):
         )
 
 
+def _get_reasoning_tokens_from_usage(usage):
+    """Extract thinking/reasoning tokens from an Anthropic SDK usage object."""
+    if usage is None:
+        return None
+    output_tokens_details = getattr(usage, "output_tokens_details", None)
+    if output_tokens_details is None:
+        return None
+    return getattr(output_tokens_details, "reasoning_tokens", None)
+
+
 @dont_throw
 async def _aset_token_usage(
     span,
@@ -305,6 +315,11 @@ async def _aset_token_usage(
         cache_creation_tokens,
     )
 
+    reasoning_tokens = _get_reasoning_tokens_from_usage(usage)
+    set_span_attribute(
+        span, SpanAttributes.GEN_AI_USAGE_REASONING_TOKENS, reasoning_tokens
+    )
+
 
 @dont_throw
 def _set_token_usage(
@@ -419,6 +434,11 @@ def _set_token_usage(
         span,
         GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
         cache_creation_tokens,
+    )
+
+    reasoning_tokens = _get_reasoning_tokens_from_usage(usage)
+    set_span_attribute(
+        span, SpanAttributes.GEN_AI_USAGE_REASONING_TOKENS, reasoning_tokens
     )
 
 

--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
@@ -32,6 +32,12 @@ logger = logging.getLogger(__name__)
 
 @dont_throw
 def _process_response_item(item, complete_response):
+    """Accumulate a single Anthropic stream *item* into *complete_response*.
+
+    Handles message_start, content_block_start, content_block_delta, and
+    message_delta events. Message-delta usage keeps the latest cumulative
+    reasoning-token count while summing output tokens.
+    """
     if item.type == "message_start":
         complete_response["model"] = item.message.model
         complete_response["usage"] = dict(item.message.usage)
@@ -98,6 +104,7 @@ def _set_token_usage(
     token_histogram: Histogram = None,
     choice_counter: Counter = None,
 ):
+    """Record token-usage, reasoning-token, model, and choice metrics from a completed streaming response."""
     cache_read_tokens = (
         complete_response.get("usage", {}).get("cache_read_input_tokens", 0) or 0
     )
@@ -195,6 +202,7 @@ def _resolve_stream_token_usage(complete_response, instance, kwargs):
 
 
 def _handle_streaming_response(span, event_logger, complete_response):
+    """Emit streaming response events or set *span* streaming response attributes."""
     if should_emit_events() and event_logger:
         emit_streaming_response_events(event_logger, complete_response)
     else:

--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
@@ -70,15 +70,20 @@ def _process_response_item(item, complete_response):
                 complete_response["usage"]["output_tokens"] = (
                     item_output_tokens + existing_output_tokens
                 )
-                item_reasoning_details = item_usage.get("output_tokens_details") or {}
-                existing_reasoning_details = (
-                    complete_response["usage"].get("output_tokens_details") or {}
+                item_reasoning = (
+                    (item_usage.get("output_tokens_details") or {}).get(
+                        "reasoning_tokens"
+                    )
+                    or 0
+                )
+                existing_reasoning = (
+                    (complete_response["usage"].get("output_tokens_details") or {}).get(
+                        "reasoning_tokens"
+                    )
+                    or 0
                 )
                 complete_response["usage"]["output_tokens_details"] = {
-                    "reasoning_tokens": (
-                        (item_reasoning_details.get("reasoning_tokens") or 0)
-                        + (existing_reasoning_details.get("reasoning_tokens") or 0)
-                    )
+                    "reasoning_tokens": max(item_reasoning, existing_reasoning)
                 }
             else:
                 complete_response["usage"] = item_usage

--- a/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
+++ b/packages/opentelemetry-instrumentation-anthropic/opentelemetry/instrumentation/anthropic/streaming.py
@@ -61,16 +61,27 @@ def _process_response_item(item, complete_response):
         for event in complete_response.get("events", []):
             event["finish_reason"] = item.delta.stop_reason
         if item.usage:
+            item_usage = dict(item.usage)
             if "usage" in complete_response:
-                item_output_tokens = dict(item.usage).get("output_tokens", 0)
+                item_output_tokens = item_usage.get("output_tokens", 0)
                 existing_output_tokens = complete_response["usage"].get(
                     "output_tokens", 0
                 )
                 complete_response["usage"]["output_tokens"] = (
                     item_output_tokens + existing_output_tokens
                 )
+                item_reasoning_details = item_usage.get("output_tokens_details") or {}
+                existing_reasoning_details = (
+                    complete_response["usage"].get("output_tokens_details") or {}
+                )
+                complete_response["usage"]["output_tokens_details"] = {
+                    "reasoning_tokens": (
+                        (item_reasoning_details.get("reasoning_tokens") or 0)
+                        + (existing_reasoning_details.get("reasoning_tokens") or 0)
+                    )
+                }
             else:
-                complete_response["usage"] = dict(item.usage)
+                complete_response["usage"] = item_usage
 
 
 def _set_token_usage(
@@ -103,6 +114,15 @@ def _set_token_usage(
     )
     set_span_attribute(
         span, GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS, cache_creation_tokens
+    )
+
+    output_tokens_details = complete_response.get("usage", {}).get("output_tokens_details")
+    reasoning_tokens = None
+    if output_tokens_details:
+        reasoning_tokens = output_tokens_details.get("reasoning_tokens", None)
+
+    set_span_attribute(
+        span, SpanAttributes.GEN_AI_USAGE_REASONING_TOKENS, reasoning_tokens
     )
 
     set_span_attribute(

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_reasoning_usage.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_reasoning_usage.py
@@ -1,0 +1,135 @@
+"""Unit tests for reasoning-token usage extraction (gen_ai.usage.reasoning_tokens).
+
+Covers the three paths that consume Anthropic `usage.output_tokens_details`:
+the sync and async non-streaming `_set_token_usage` helpers in `__init__.py`,
+and the streaming path in `streaming.py`.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from opentelemetry.instrumentation.anthropic import _aset_token_usage, _set_token_usage
+from opentelemetry.instrumentation.anthropic.streaming import (
+    _process_response_item,
+    _set_token_usage as _set_streaming_token_usage,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+from opentelemetry.semconv_ai import SpanAttributes
+
+REASONING_TOKENS = SpanAttributes.GEN_AI_USAGE_REASONING_TOKENS
+
+
+def _make_usage(**overrides):
+    usage = {
+        "input_tokens": 10,
+        "output_tokens": 25,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens_details": SimpleNamespace(reasoning_tokens=15),
+    }
+    usage.update(overrides)
+    return SimpleNamespace(**usage)
+
+
+def _make_response(usage):
+    return SimpleNamespace(
+        usage=usage,
+        content=[SimpleNamespace(type="text", text="hi")],
+        stop_reason="end_turn",
+        model="claude-3-7-sonnet-20250219",
+    )
+
+
+def _finished_span_attributes(span_exporter):
+    return dict(span_exporter.get_finished_spans()[0].attributes)
+
+
+@pytest.fixture
+def tracer(tracer_provider):
+    return tracer_provider.get_tracer("test-reasoning-usage")
+
+
+def test_set_token_usage_emits_reasoning_tokens(tracer, span_exporter):
+    with tracer.start_as_current_span("test") as span:
+        _set_token_usage(span, None, {}, _make_response(_make_usage()))
+
+    attributes = _finished_span_attributes(span_exporter)
+    assert attributes[REASONING_TOKENS] == 15
+    assert attributes[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS] == 25
+
+
+@pytest.mark.asyncio
+async def test_aset_token_usage_emits_reasoning_tokens(tracer, span_exporter):
+    with tracer.start_as_current_span("test") as span:
+        await _aset_token_usage(span, None, {}, _make_response(_make_usage()))
+
+    attributes = _finished_span_attributes(span_exporter)
+    assert attributes[REASONING_TOKENS] == 15
+
+
+def test_set_token_usage_omits_reasoning_when_details_absent(tracer, span_exporter):
+    with tracer.start_as_current_span("test") as span:
+        _set_token_usage(
+            span, None, {}, _make_response(_make_usage(output_tokens_details=None))
+        )
+
+    attributes = _finished_span_attributes(span_exporter)
+    assert REASONING_TOKENS not in attributes
+
+
+def test_process_response_item_merges_streaming_reasoning_tokens():
+    complete_response = {"events": [], "model": "", "usage": {}, "id": ""}
+
+    _process_response_item(
+        SimpleNamespace(
+            type="message_start",
+            message=SimpleNamespace(
+                model="claude-3-7-sonnet-20250219",
+                id="msg_1",
+                usage={
+                    "input_tokens": 10,
+                    "output_tokens": 0,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+            ),
+        ),
+        complete_response,
+    )
+    _process_response_item(
+        SimpleNamespace(
+            type="message_delta",
+            delta=SimpleNamespace(stop_reason="end_turn"),
+            usage={
+                "output_tokens": 25,
+                "output_tokens_details": {"reasoning_tokens": 15},
+            },
+        ),
+        complete_response,
+    )
+
+    usage = complete_response["usage"]
+    assert usage["output_tokens"] == 25
+    assert usage["output_tokens_details"]["reasoning_tokens"] == 15
+
+
+def test_streaming_set_token_usage_emits_reasoning_tokens(tracer, span_exporter):
+    complete_response = {
+        "events": [],
+        "model": "claude-3-7-sonnet-20250219",
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 25,
+            "output_tokens_details": {"reasoning_tokens": 15},
+        },
+        "id": "msg_1",
+    }
+
+    with tracer.start_as_current_span("test") as span:
+        _set_streaming_token_usage(span, complete_response, 10, 25)
+
+    attributes = _finished_span_attributes(span_exporter)
+    assert attributes[REASONING_TOKENS] == 15

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_reasoning_usage.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_reasoning_usage.py
@@ -80,7 +80,7 @@ def test_set_token_usage_omits_reasoning_when_details_absent(tracer, span_export
     assert REASONING_TOKENS not in attributes
 
 
-def test_process_response_item_merges_streaming_reasoning_tokens():
+def test_process_response_item_keeps_latest_streaming_reasoning_tokens():
     complete_response = {"events": [], "model": "", "usage": {}, "id": ""}
 
     _process_response_item(
@@ -104,16 +104,26 @@ def test_process_response_item_merges_streaming_reasoning_tokens():
             type="message_delta",
             delta=SimpleNamespace(stop_reason="end_turn"),
             usage={
-                "output_tokens": 25,
+                "output_tokens": 16,
                 "output_tokens_details": {"reasoning_tokens": 15},
+            },
+        ),
+        complete_response,
+    )
+    _process_response_item(
+        SimpleNamespace(
+            type="message_delta",
+            delta=SimpleNamespace(stop_reason="end_turn"),
+            usage={
+                "output_tokens": 25,
+                "output_tokens_details": {"reasoning_tokens": 27},
             },
         ),
         complete_response,
     )
 
     usage = complete_response["usage"]
-    assert usage["output_tokens"] == 25
-    assert usage["output_tokens_details"]["reasoning_tokens"] == 15
+    assert usage["output_tokens_details"]["reasoning_tokens"] == 27
 
 
 def test_streaming_set_token_usage_emits_reasoning_tokens(tracer, span_exporter):

--- a/packages/opentelemetry-instrumentation-anthropic/tests/test_reasoning_usage.py
+++ b/packages/opentelemetry-instrumentation-anthropic/tests/test_reasoning_usage.py
@@ -23,6 +23,7 @@ REASONING_TOKENS = SpanAttributes.GEN_AI_USAGE_REASONING_TOKENS
 
 
 def _make_usage(**overrides):
+    """Build a stub Anthropic usage object, overriding any supplied fields."""
     usage = {
         "input_tokens": 10,
         "output_tokens": 25,
@@ -35,6 +36,7 @@ def _make_usage(**overrides):
 
 
 def _make_response(usage):
+    """Build a stub Anthropic message response object around *usage*."""
     return SimpleNamespace(
         usage=usage,
         content=[SimpleNamespace(type="text", text="hi")],
@@ -44,15 +46,18 @@ def _make_response(usage):
 
 
 def _finished_span_attributes(span_exporter):
+    """Return the attributes of the first finished span exported by *span_exporter*."""
     return dict(span_exporter.get_finished_spans()[0].attributes)
 
 
 @pytest.fixture
 def tracer(tracer_provider):
+    """Provide a named tracer backed by the *tracer_provider* fixture."""
     return tracer_provider.get_tracer("test-reasoning-usage")
 
 
 def test_set_token_usage_emits_reasoning_tokens(tracer, span_exporter):
+    """Sync non-streaming responses must emit gen_ai.usage.reasoning_tokens."""
     with tracer.start_as_current_span("test") as span:
         _set_token_usage(span, None, {}, _make_response(_make_usage()))
 
@@ -63,6 +68,7 @@ def test_set_token_usage_emits_reasoning_tokens(tracer, span_exporter):
 
 @pytest.mark.asyncio
 async def test_aset_token_usage_emits_reasoning_tokens(tracer, span_exporter):
+    """Async non-streaming responses must emit gen_ai.usage.reasoning_tokens."""
     with tracer.start_as_current_span("test") as span:
         await _aset_token_usage(span, None, {}, _make_response(_make_usage()))
 
@@ -71,16 +77,16 @@ async def test_aset_token_usage_emits_reasoning_tokens(tracer, span_exporter):
 
 
 def test_set_token_usage_omits_reasoning_when_details_absent(tracer, span_exporter):
+    """Reasoning tokens must be omitted when output_tokens_details is absent."""
     with tracer.start_as_current_span("test") as span:
-        _set_token_usage(
-            span, None, {}, _make_response(_make_usage(output_tokens_details=None))
-        )
+        _set_token_usage(span, None, {}, _make_response(_make_usage(output_tokens_details=None)))
 
     attributes = _finished_span_attributes(span_exporter)
     assert REASONING_TOKENS not in attributes
 
 
 def test_process_response_item_keeps_latest_streaming_reasoning_tokens():
+    """Streaming must retain the latest cumulative reasoning-token count, not a sum."""
     complete_response = {"events": [], "model": "", "usage": {}, "id": ""}
 
     _process_response_item(
@@ -127,6 +133,7 @@ def test_process_response_item_keeps_latest_streaming_reasoning_tokens():
 
 
 def test_streaming_set_token_usage_emits_reasoning_tokens(tracer, span_exporter):
+    """Streaming span attributes must include the accumulated reasoning-token count."""
     complete_response = {
         "events": [],
         "model": "claude-3-7-sonnet-20250219",


### PR DESCRIPTION
## What changed

Anthropic's API reports thinking/reasoning usage under `usage.output_tokens_details.reasoning_tokens` for models with extended thinking enabled, but the Anthropic instrumentation never read it. As a result reasoning tokens were invisible to token-usage consumers while every other provider path (OpenAI chat + responses, Vertex AI) already emits `gen_ai.usage.reasoning_tokens`.

This PR mirrors the existing OpenAI path (`SpanAttributes.GEN_AI_USAGE_REASONING_TOKENS`):

- `__init__.py`: new `_get_reasoning_tokens_from_usage()` helper used by both `_aset_token_usage` (async) and `_set_token_usage` (sync).
- `streaming.py`: `_process_response_item` now merges reasoning tokens across `message_delta` chunks (matching how `output_tokens` is summed), and streaming `_set_token_usage` emits the reasoning attribute.

The helper is `getattr`-based because the pinned `anthropic` SDK's `Usage` model does not expose `output_tokens_details` yet, even though the API returns it.

## Testing

- New `tests/test_reasoning_usage.py` (5 tests) covers sync, async, no-details omission, streaming chunk merge, and streaming attribute emit. Uses synthetic usage objects — no cassette/API needed.
- `uv run pytest tests/test_reasoning_usage.py` → 5 passed.
- `uv run ruff check` clean on all touched files.
- Local full-package run: 238→245 passed; the remaining failures are pre-existing and reproduce on `main` without this change (cross-test cassette interference, unrelated to reasoning tokens).

Fixes #4458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Anthropic instrumentation now reports reasoning-token usage in telemetry for synchronous, asynchronous, non-streaming, and streaming interactions.

- **Bug Fixes**
  - Streaming telemetry now preserves the latest cumulative reasoning-token count across incremental events.
  - Output-token usage remains accurate when reasoning-token details are included.
  - Reasoning-token metrics are omitted when the provider does not supply usage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->