### PR TITLE
fix(crewai): stop the __dict__ walk leaking credentials onto spans

### DIFF
--- a/packages/opentelemetry-instrumentation-crewai/opentelemetry/instrumentation/crewai/crewai_span_attributes.py
+++ b/packages/opentelemetry-instrumentation-crewai/opentelemetry/instrumentation/crewai/crewai_span_attributes.py
@@ -102,6 +102,7 @@ class CrewAISpanAttributes:
                 self._set_attribute(SpanAttributes.GEN_AI_REQUEST_MAX_COMPLETION_TOKENS, value)
 
     def _populate_crew_attributes(self):
+        """Collect the allowlisted Crew fields, plus its tasks and agents."""
         for key in CREW_FIELDS:
             value = getattr(self.instance, key, None)
             if value is not None:
@@ -110,13 +111,16 @@ class CrewAISpanAttributes:
         self._parse_agents(self.instance.agents or [])
 
     def _populate_agent_attributes(self):
+        """Collect the allowlisted Agent fields for a standalone agent span."""
         return self._stringify(self._extract_agent_data(self.instance))
 
     def _populate_task_attributes(self):
+        """Collect the allowlisted Task fields for a standalone task span."""
         return self._stringify(self._extract_task_data(self.instance))
 
     @staticmethod
     def _stringify(data):
+        """Render a field dict as span-attribute values, dropping the unset ones."""
         return {key: str(value) for key, value in data.items() if value is not None}
 
     def _parse_agents(self, agents):
@@ -125,9 +129,11 @@ class CrewAISpanAttributes:
         ]
 
     def _parse_tasks(self, tasks):
+        """Attach the crew's tasks, each reduced to its allowlisted fields."""
         self.crew["tasks"] = [self._extract_task_data(task) for task in tasks if task is not None]
 
     def _extract_task_data(self, task):
+        """Return the allowlisted Task fields, with the agent named by its role."""
         return {
             "id": str(task.id),
             "agent": task.agent.role if task.agent else None,
@@ -140,6 +146,7 @@ class CrewAISpanAttributes:
         }
 
     def _extract_agent_data(self, agent):
+        """Return the allowlisted Agent fields, with the LLM named by its model."""
         model = (
             getattr(agent.llm, "model", None)
             or getattr(agent.llm, "model_name", None)

--- a/packages/opentelemetry-instrumentation-crewai/opentelemetry/instrumentation/crewai/crewai_span_attributes.py
+++ b/packages/opentelemetry-instrumentation-crewai/opentelemetry/instrumentation/crewai/crewai_span_attributes.py
@@ -12,6 +12,11 @@ from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
 from opentelemetry.semconv_ai import SpanAttributes
 import json
 
+# Crew fields that are safe to stringify. Anything else -- LLM clients, the
+# embedder config, memory handles -- can carry credentials in its repr.
+CREW_FIELDS = ("id", "name", "process", "verbose", "memory", "cache", "planning",
+               "max_rpm", "share_crew")
+
 
 def set_span_attribute(span: Span, name, value):
     if value is not None:
@@ -97,27 +102,22 @@ class CrewAISpanAttributes:
                 self._set_attribute(SpanAttributes.GEN_AI_REQUEST_MAX_COMPLETION_TOKENS, value)
 
     def _populate_crew_attributes(self):
-        for key, value in self.instance.__dict__.items():
-            if value is None:
-                continue
-            if key == "tasks":
-                self._parse_tasks(value)
-            elif key == "agents":
-                self._parse_agents(value)
-            else:
+        for key in CREW_FIELDS:
+            value = getattr(self.instance, key, None)
+            if value is not None:
                 self.crew[key] = str(value)
+        self._parse_tasks(self.instance.tasks or [])
+        self._parse_agents(self.instance.agents or [])
 
     def _populate_agent_attributes(self):
-        return self._extract_attributes(self.instance)
+        return self._stringify(self._extract_agent_data(self.instance))
 
     def _populate_task_attributes(self):
-        task_data = self._extract_attributes(self.instance)
-        if "agent" in task_data:
-            task_data["agent"] = self.instance.agent.role if self.instance.agent else None
-        return task_data
+        return self._stringify(self._extract_task_data(self.instance))
 
-    def _populate_llm_attributes(self):
-        return self._extract_attributes(self.instance)
+    @staticmethod
+    def _stringify(data):
+        return {key: str(value) for key, value in data.items() if value is not None}
 
     def _parse_agents(self, agents):
         self.crew["agents"] = [
@@ -125,18 +125,19 @@ class CrewAISpanAttributes:
         ]
 
     def _parse_tasks(self, tasks):
-        self.crew["tasks"] = [
-            {
-                "agent": task.agent.role if task.agent else None,
-                "description": task.description,
-                "async_execution": task.async_execution,
-                "expected_output": task.expected_output,
-                "human_input": task.human_input,
-                "tools": task.tools,
-                "output_file": task.output_file,
-            }
-            for task in tasks
-        ]
+        self.crew["tasks"] = [self._extract_task_data(task) for task in tasks if task is not None]
+
+    def _extract_task_data(self, task):
+        return {
+            "id": str(task.id),
+            "agent": task.agent.role if task.agent else None,
+            "description": task.description,
+            "async_execution": task.async_execution,
+            "expected_output": task.expected_output,
+            "human_input": task.human_input,
+            "tools": self._serialize_tools(task.tools or []),
+            "output_file": task.output_file,
+        }
 
     def _extract_agent_data(self, agent):
         model = (
@@ -151,23 +152,11 @@ class CrewAISpanAttributes:
             "goal": agent.goal,
             "backstory": agent.backstory,
             "cache": agent.cache,
-            "config": agent.config,
             "verbose": agent.verbose,
             "allow_delegation": agent.allow_delegation,
-            "tools": agent.tools,
+            "tools": self._serialize_tools(agent.tools or []),
             "max_iter": agent.max_iter,
             "llm": str(model), }
-
-    def _extract_attributes(self, obj):
-        attributes = {}
-        for key, value in obj.__dict__.items():
-            if value is None:
-                continue
-            if key == "tools":
-                attributes[key] = self._serialize_tools(value)
-            else:
-                attributes[key] = str(value)
-        return attributes
 
     def _serialize_tools(self, tools):
         return json.dumps(

--- a/packages/opentelemetry-instrumentation-crewai/tests/test_span_attribute_allowlist.py
+++ b/packages/opentelemetry-instrumentation-crewai/tests/test_span_attribute_allowlist.py
@@ -1,0 +1,80 @@
+"""
+Span attributes come from a fixed set of fields, never a __dict__ walk, so an
+object we don't control (an LLM client, an embedder config) can't leak its
+credentials through its repr.
+
+Objects are constructed only -- no kickoff, no network.
+"""
+
+import pytest
+from crewai import LLM, Agent, Crew, Task
+from crewai.tools import BaseTool
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from opentelemetry.instrumentation.crewai.crewai_span_attributes import CrewAISpanAttributes
+
+# Not a credential: an opaque marker with no provider shape, used only to prove
+# that whatever is configured on an LLM or embedder stays off the span.
+SENTINEL = "SENTINEL-NOT-A-KEY-9f3a"
+
+
+class EchoTool(BaseTool):
+    name: str = "echo"
+    description: str = "Echoes the input back."
+
+    def _run(self, text: str = "") -> str:
+        return text
+
+
+def build_agent():
+    return Agent(
+        role="researcher",
+        goal="find things",
+        backstory="a fixed backstory",
+        llm=LLM(model="test-model", api_key=SENTINEL),
+        embedder={"provider": "openai", "config": {"api_key": SENTINEL}},
+        tools=[EchoTool()],
+    )
+
+
+def build_task():
+    return Task(description="a fixed description", expected_output="a fixed output",
+                agent=build_agent(), tools=[EchoTool()])
+
+
+def build_crew():
+    agent = build_agent()
+    return Crew(
+        agents=[agent],
+        tasks=[Task(description="a fixed description", expected_output="a fixed output", agent=agent)],
+        name="fixed-crew",
+        manager_llm=LLM(model="test-model", api_key=SENTINEL),
+        embedder={"provider": "openai", "config": {"api_key": SENTINEL}},
+    )
+
+
+BUILDERS = {"Agent": build_agent, "Task": build_task, "Crew": build_crew}
+
+
+def span_attributes(instance):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    with provider.get_tracer(__name__).start_as_current_span("test") as span:
+        CrewAISpanAttributes(span=span, instance=instance)
+    return dict(exporter.get_finished_spans()[0].attributes)
+
+
+@pytest.mark.parametrize("kind", list(BUILDERS))
+def test_configured_credentials_never_reach_the_span(kind):
+    attrs = span_attributes(BUILDERS[kind]())
+
+    # Substring check: nested agents, tasks and tools are JSON-dumped into a
+    # single value, so a key-wise check would miss anything hidden inside them.
+    for key, value in attrs.items():
+        assert SENTINEL not in str(value), f"{key} carries configured LLM state"
+
+    # ...while the allowlisted fields are still emitted.
+    assert attrs[f"crewai.{kind.lower()}.id"]

--- a/packages/opentelemetry-instrumentation-crewai/tests/test_span_attribute_allowlist.py
+++ b/packages/opentelemetry-instrumentation-crewai/tests/test_span_attribute_allowlist.py
@@ -21,14 +21,18 @@ SENTINEL = "SENTINEL-NOT-A-KEY-9f3a"
 
 
 class EchoTool(BaseTool):
+    """A tool with nothing secret on it, so any leak in the span is the LLM's."""
+
     name: str = "echo"
     description: str = "Echoes the input back."
 
     def _run(self, text: str = "") -> str:
+        """Echo the input back; never called, the tool is only ever serialized."""
         return text
 
 
 def build_agent():
+    """An Agent holding a credential on both its LLM and its embedder config."""
     return Agent(
         role="researcher",
         goal="find things",
@@ -40,11 +44,13 @@ def build_agent():
 
 
 def build_task():
+    """A Task whose agent holds the credential."""
     return Task(description="a fixed description", expected_output="a fixed output",
                 agent=build_agent(), tools=[EchoTool()])
 
 
 def build_crew():
+    """A Crew holding a credential on its manager LLM and its embedder config."""
     agent = build_agent()
     return Crew(
         agents=[agent],
@@ -59,6 +65,7 @@ BUILDERS = {"Agent": build_agent, "Task": build_task, "Crew": build_crew}
 
 
 def span_attributes(instance):
+    """Return the attributes the instrumentation lands on a span for `instance`."""
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
@@ -69,6 +76,7 @@ def span_attributes(instance):
 
 @pytest.mark.parametrize("kind", list(BUILDERS))
 def test_configured_credentials_never_reach_the_span(kind):
+    """Nothing configured on an LLM or embedder is stringified onto the span."""
     attrs = span_attributes(BUILDERS[kind]())
 
     # Substring check: nested agents, tasks and tools are JSON-dumped into a


### PR DESCRIPTION
`CrewAISpanAttributes `stringified every attribute of the Crew, Agent and Task objects it was handed, so anything those objects held -- an LLM client, an embedder config -- reached the span through its repr, api keys included.

Read a fixed set of fields instead. `Agents `already had a hand-written allowlist in _extract_agent_data; the standalone-agent path just wasn't using it. Tasks reuse the dict _parse_tasks already built. Only Crew needed a new list. Tools go through the existing `_serialize_tools `on every path rather than being repr'd, and the dead `_populate_llm_attributes` is gone.


<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [x] I have added tests that cover my changes.

- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry safety by preventing credentials and other sensitive configuration values from appearing in span attributes.
  * Standardized captured task and agent details, including task identifiers and supported fields.
  * Represented tool information as structured JSON arrays instead of re-encoded strings or Python representations.
  * Continued emitting supported Crew, task, and agent identifiers while excluding unsupported configuration data.
  * Improved consistency of telemetry attributes across CrewAI components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->